### PR TITLE
Mandate query accessor

### DIFF
--- a/graphql-ballerina/engine.bal
+++ b/graphql-ballerina/engine.bal
@@ -56,9 +56,9 @@ public class Engine {
         }
     }
 
-    isolated function registerService(Service s) {
+    isolated function registerService(Service s) returns error? {
         self.graphqlService = s;
-        self.schema = createSchema(s);
+        self.schema = check createSchema(s);
     }
 
     isolated function parse(string documentString) returns parser:DocumentNode|OutputObject {

--- a/graphql-ballerina/engine_utils.bal
+++ b/graphql-ballerina/engine_utils.bal
@@ -52,7 +52,7 @@ isolated function getFieldMapForSelection(parser:FieldNode fieldNode, map<anydat
     return result;
 }
 
-isolated function createSchema(Service s) returns __Schema = @java:Method {
+isolated function createSchema(Service s) returns __Schema|error = @java:Method {
     'class: "io.ballerina.stdlib.graphql.engine.Engine"
 } external;
 

--- a/graphql-ballerina/listener.bal
+++ b/graphql-ballerina/listener.bal
@@ -44,7 +44,7 @@ public class Listener {
     # + return - An `error`, if an error occurred during the service attaching process
     public isolated function attach(Service s, string[]|string? name = ()) returns error? {
         checkpanic self.httpListener.attach(self.httpService, name);
-        self.engine.registerService(s);
+        return self.engine.registerService(s);
     }
 
     # Detaches the provided service from the Listener.

--- a/graphql-ballerina/tests/01_schema_generation.bal
+++ b/graphql-ballerina/tests/01_schema_generation.bal
@@ -19,35 +19,35 @@ import ballerina/test;
 @test:Config {
     groups: ["schema_generation", "engine", "unit"]
 }
-function testSchemaGenerationForMultipleResources() {
-    __Schema actualSchema = createSchema(serviceWithMultipleResources);
+function testSchemaGenerationForMultipleResources() returns error? {
+    __Schema actualSchema = check createSchema(serviceWithMultipleResources);
     test:assertEquals(actualSchema, expectedSchemaForMultipleResources);
 }
 
 @test:Config {
     groups: ["schema_generation", "engine", "unit"]
 }
-function testSchemaGenerationForResourcesReturningRecords() {
-    __Schema actualSchema = createSchema(serviceWithResourcesReturningRecords);
+function testSchemaGenerationForResourcesReturningRecords() returns error? {
+    __Schema actualSchema = check createSchema(serviceWithResourcesReturningRecords);
     test:assertEquals(actualSchema, expectedSchemaForResourcesReturningRecords);
 }
 
 Service serviceWithMultipleResources = service object {
-    isolated resource function get name() returns string {
+    isolated resource function query name() returns string {
         return "John Doe";
     }
 
-    isolated resource function get id() returns int {
+    isolated resource function query id() returns int {
         return 1;
     }
 
-    isolated resource function get birthdate(string format) returns string {
+    isolated resource function query birthdate(string format) returns string {
         return "01-01-1980";
     }
 };
 
 service object {} serviceWithResourcesReturningRecords = service object {
-    isolated resource function get person() returns Person {
+    isolated resource function query person() returns Person {
         return {
             name: "Sherlock Holmes",
             age: 20,

--- a/graphql-ballerina/tests/03_listener_test.bal
+++ b/graphql-ballerina/tests/03_listener_test.bal
@@ -66,11 +66,11 @@ function testGetRequestResult() returns @tainted error? {
 }
 
 service /graphql on simpleResourceListener {
-    isolated resource function get name() returns string {
+    isolated resource function query name() returns string {
         return "James Moriarty";
     }
 
-    isolated resource function get birthdate() returns string {
+    isolated resource function query birthdate() returns string {
         return "15-05-1848";
     }
 }

--- a/graphql-ballerina/tests/04_resource_functions_with_input_parameters.bal
+++ b/graphql-ballerina/tests/04_resource_functions_with_input_parameters.bal
@@ -20,7 +20,7 @@ import ballerina/test;
 listener Listener functionWithArgumentsListener = new(9093);
 
 service /graphql on functionWithArgumentsListener {
-    isolated resource function get greet(string name) returns string {
+    isolated resource function query greet(string name) returns string {
         return "Hello, " + name;
     }
 }

--- a/graphql-ballerina/tests/05_resource_functions_returning_records.bal
+++ b/graphql-ballerina/tests/05_resource_functions_returning_records.bal
@@ -44,7 +44,7 @@ function testGetFieldFromRecordResource() returns @tainted error? {
 }
 
 service /graphql on new Listener(9094) {
-    isolated resource function get profile() returns Person {
+    isolated resource function query profile() returns Person {
         return {
             name: "Sherlock Holmes",
             age: 40,

--- a/graphql-ballerina/tests/06_client_test.bal
+++ b/graphql-ballerina/tests/06_client_test.bal
@@ -17,7 +17,7 @@
 import ballerina/test;
 
 service /graphql on new Listener(9095) {
-    resource function get profile(int id) returns Person {
+    resource function query profile(int id) returns Person {
         return people[id];
     }
 }

--- a/graphql-ballerina/tests/07_errors_test.bal
+++ b/graphql-ballerina/tests/07_errors_test.bal
@@ -17,7 +17,7 @@
 import ballerina/test;
 
 service /graphql on new Listener(9096) {
-    resource function get profile(int id) returns Person {
+    resource function query profile(int id) returns Person {
         return people[id];
     }
 }

--- a/graphql-ballerina/tests/08_resource_functions_returning_services.bal
+++ b/graphql-ballerina/tests/08_resource_functions_returning_services.bal
@@ -17,22 +17,22 @@
 import ballerina/test;
 
 service /graphql on new Listener(9097) {
-    isolated resource function get greet() returns service object {} {
+    isolated resource function query greet() returns service object {} {
         return service object {
-            isolated resource function get generalGreeting() returns string {
+            isolated resource function query generalGreeting() returns string {
                 return "Hello, world";
             }
         };
     }
 
-    isolated resource function get profile() returns service object {} {
+    isolated resource function query profile() returns service object {} {
         return service object {
-            isolated resource function get name() returns service object {} {
+            isolated resource function query name() returns service object {} {
                 return service object {
-                    isolated resource function get first() returns string {
+                    isolated resource function query first() returns string {
                         return "Sherlock";
                     }
-                    isolated resource function get last() returns string {
+                    isolated resource function query last() returns string {
                         return "Holmes";
                     }
                 };


### PR DESCRIPTION
## Purpose
As per the [discussion](https://github.com/ballerina-platform/ballerina-standard-library/discussions/757#discussion-73027), we now mandate the `query` accessor for GraphQL resources. This is now checked at the runtime, eventually, this should be done using a compiler plugin. Created [#759](https://github.com/ballerina-platform/ballerina-standard-library/issues/759) to track this.