### PR TITLE
Support Resource Functions Returning Union with Error Type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ build
 # Ballerina
 velocity.log*
 *Ballerina.lock
+graphql-ballerina/modules/graphql/

--- a/graphql-ballerina/common_utils.bal
+++ b/graphql-ballerina/common_utils.bal
@@ -36,7 +36,7 @@ isolated function getMissingSubfieldsError(string fieldName, string typeName) re
 }
 
 isolated function getMissingRequiredArgError(parser:FieldNode node, __InputValue input) returns string {
-    return "Field \"" + node.getName() + "\" argument \"" + input.name + "\" of type \"" + input.'type.name
+    return "Field \"" + node.getName() + "\" argument \"" + input.name + "\" of type \"" + input.'type.name.toString()
             + "\" is required, but it was not provided.";
 
 }

--- a/graphql-ballerina/constants.bal
+++ b/graphql-ballerina/constants.bal
@@ -32,7 +32,3 @@ const FIELD_LOCATIONS = "locations";
 const FIELD_MESSAGE = "message";
 
 const OPERATION_QUERY = "Query";
-
-const string SCALAR = "SCALAR";
-const string OBJECT = "OBJECT";
-const string ENUM = "ENUM";

--- a/graphql-ballerina/constants.bal
+++ b/graphql-ballerina/constants.bal
@@ -32,3 +32,7 @@ const FIELD_LOCATIONS = "locations";
 const FIELD_MESSAGE = "message";
 
 const OPERATION_QUERY = "Query";
+
+const string SCALAR = "SCALAR";
+const string OBJECT = "OBJECT";
+const string ENUM = "ENUM";

--- a/graphql-ballerina/constants.bal
+++ b/graphql-ballerina/constants.bal
@@ -32,3 +32,5 @@ const FIELD_LOCATIONS = "locations";
 const FIELD_MESSAGE = "message";
 
 const OPERATION_QUERY = "Query";
+
+const SCALAR = "SCALAR";

--- a/graphql-ballerina/modules/graphql/resources/Client_functions.json
+++ b/graphql-ballerina/modules/graphql/resources/Client_functions.json
@@ -1,1 +1,0 @@
-{"ballerina/graphql:0.1.0" : [{"function":{"name":"query","requiredParams":[{"document":"string"},{"operationName":"string?"}],"returnType":"json"}}]}

--- a/graphql-ballerina/modules/graphql/resources/Client_functions.json
+++ b/graphql-ballerina/modules/graphql/resources/Client_functions.json
@@ -1,0 +1,1 @@
+{"ballerina/graphql:0.1.0" : [{"function":{"name":"query","requiredParams":[{"document":"string"},{"operationName":"string?"}],"returnType":"json"}}]}

--- a/graphql-ballerina/records.bal
+++ b/graphql-ballerina/records.bal
@@ -63,13 +63,22 @@ public type __Schema record {|
 #
 # + kind - The `graphql:__TypeKind` type of the type
 # + name - The name of the type
-# + fields - The fields of the given type
+# + fields - The fields of the given type, if the type qaulifies to have fields
+# + enumValues - The possible set of values, if the type is an enum
 public type __Type record {
     __TypeKind kind;
-    string name;
+    string? name;
     map<__Field> fields?;
+    map<anydata> enumValues?;
 
-    // TODO: Add following: description, inputFields, interfaces, possibleTypes, enumValues, ofType
+    // TODO: Add following: description, inputFields, interfaces, possibleTypes, ofType
+};
+
+# Represents a GraphQL enum.
+#
+# + name - The name of the enum
+public type __EnumValue record {
+    string name;
 };
 
 # Represents a GraphQL field.
@@ -101,17 +110,10 @@ public type __InputValue record {|
 	//string description?;
 |};
 
-public enum __TypeKind {
-    SCALAR,
-    OBJECT,
-    ENUM
-    // TODO: Support the following
-    //INTERFACE,
-    //UNION,
-    //INPUT_OBJECT,
-    //LIST,
-    //NON_NULL
-}
+
+
+# Represents the type kind of a GraphQL type.
+public type __TypeKind "SCALAR"|"OBJECT"|"ENUM"|"NON_NULL";
 
 type __Directive record {|
     string name;

--- a/graphql-ballerina/tests/09_resources_returning_union_types.bal
+++ b/graphql-ballerina/tests/09_resources_returning_union_types.bal
@@ -1,0 +1,52 @@
+// Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+service /graphql on new Listener(9098) {
+    resource function get profile(int id) returns Person|error {
+        if (id < people.length()) {
+            return people[id];
+        } else {
+            return error("Invalid ID provided");
+        }
+    }
+}
+
+@test:Config {
+    groups: ["service", "unit"]
+}
+public function testResourceReturningUnionTypes() returns @tainted error? {
+    Client graphqlClient = new("http://localhost:9098/graphql");
+    string document = "{ profile (id: 5) { name } }";
+
+    json expectedPayload = {
+        errors: [
+            {
+                message: "Invalid ID provided",
+                locations: [
+                    {
+                        line: 1,
+                        column: 3
+                    }
+                ]
+            }
+        ]
+    };
+    json result = check graphqlClient->query(document);
+    test:assertEquals(result, expectedPayload);
+}
+

--- a/graphql-ballerina/tests/09_resources_returning_union_types.bal
+++ b/graphql-ballerina/tests/09_resources_returning_union_types.bal
@@ -16,6 +16,24 @@
 
 import ballerina/test;
 
+@test:Config {
+    groups: ["service", "unit"]
+}
+public function testResourcesReturningInvalidUnionType() {
+    Listener graphqlListener = new (9099);
+    var result = trap graphqlListener.attach(serviceWithInvalidUnionTypes);
+    test:assertTrue(result is error);
+    error err = <error> result;
+    string expectedErrorMessage = "Unsupported union: Ballerina GraphQL does not allow unions other that <T>|error";
+    test:assertEquals(err.message(), expectedErrorMessage);
+}
+
+Service serviceWithInvalidUnionTypes = service object {
+    isolated resource function get name() returns int|string {
+        return "John Doe";
+    }
+};
+
 service /graphql on new Listener(9098) {
     resource function get profile(int id) returns Person|error {
         if (id < people.length()) {

--- a/graphql-ballerina/tests/expected_values.bal
+++ b/graphql-ballerina/tests/expected_values.bal
@@ -15,11 +15,15 @@
 // under the License.
 
 __Schema expectedSchemaForMultipleResources = {
-    types: {
-        "int": {
-            kind: "SCALAR",
-            name: "int",
-            fields: {}
+    "types": {
+        "__TypeKind": {
+            kind: "ENUM",
+            name: "__TypeKind",
+            "enumValues": {
+                "SCALAR": "SCALAR",
+                "OBJECT": "OBJECT",
+                "ENUM": "ENUM"
+            }
         },
         "__Field": {
             kind: "OBJECT",
@@ -28,111 +32,29 @@ __Schema expectedSchemaForMultipleResources = {
                 "name": {
                     name: "name",
                     'type: {
-                        kind: "SCALAR",
-                        name: "string",
-                        fields: {}
-                    },
-                    args: {}
+                        kind: "NON_NULL",
+                        name: ()
+                    }
                 },
                 "type": {
                     name: "type",
                     'type: {
-                        kind: "OBJECT",
-                        name: "__Type",
-                        fields: {
-                            "kind": {
-                                name: "kind",
-                                'type: {
-                                    kind: "SCALAR",
-                                    name: "id",
-                                    fields: {}
-                                },
-                                args: {}
-                            },
-                            "name": {
-                                name: "name",
-                                'type: {
-                                    kind: "SCALAR",
-                                    name: "string",
-                                    fields: {}
-                                },
-                                args: {}
-                            },
-                            fields: {
-                                name: "fields",
-                                'type: {
-                                    kind: "SCALAR",
-                                    name: "id",
-                                    fields: {}
-                                },
-                                args: {}
-                            }
-                        }
-                    },
-                    args: {}
+                        kind: "NON_NULL",
+                        name: ()
+                    }
                 },
                 "args": {
                     name: "args",
                     'type: {
-                        kind: "SCALAR",
-                        name: "id",
-                        fields: {}
-                    },
-                    args: {}
+                        kind: "NON_NULL",
+                        name: ()
+                    }
                 }
             }
         },
-        "__Schema": {
-            kind: "OBJECT",
-            name: "__Schema",
-            fields: {
-                "types": {
-                    name: "types",
-                    'type: {
-                        kind: "SCALAR",
-                        name: "id",
-                        fields: {}
-                    },
-                    args: {}
-                },
-                "queryType": {
-                    name: "queryType",
-                    'type: {
-                        kind: "OBJECT",
-                        name: "__Type",
-                        fields: {
-                            "kind": {
-                                name: "kind",
-                                'type: {
-                                    kind: "SCALAR",
-                                    name: "id",
-                                    fields: {}
-                                },
-                                args: {}
-                            },
-                            "name": {
-                                name: "name",
-                                'type: {
-                                    kind: "SCALAR",
-                                    name: "string",
-                                    fields: {}
-                                },
-                                args: {}
-                            },
-                            fields: {
-                                name: "fields",
-                                'type: {
-                                    kind: "SCALAR",
-                                    name: "id",
-                                    fields: {}
-                                },
-                                args: {}
-                            }
-                        }
-                    },
-                    args: {}
-                }
-            }
+        "string": {
+            kind: "SCALAR",
+            name: "string"
         },
         "Query": {
             kind: "OBJECT",
@@ -142,34 +64,28 @@ __Schema expectedSchemaForMultipleResources = {
                     name: "name",
                     'type: {
                         kind: "SCALAR",
-                        name: "string",
-                        fields: {}
-                    },
-                    args: {}
+                        name: "string"
+                    }
                 },
                 "id": {
                     name: "id",
                     'type: {
                         kind: "SCALAR",
-                        name: "int",
-                        fields: {}
-                    },
-                    args: {}
+                        name: "int"
+                    }
                 },
                 "birthdate": {
                     name: "birthdate",
                     'type: {
                         kind: "SCALAR",
-                        name: "string",
-                        fields: {}
+                        name: "string"
                     },
-                    args: {
+                    "args": {
                         "format": {
                             name: "format",
                             'type: {
                                 kind: "SCALAR",
-                                name: "string",
-                                fields: {}
+                                name: "string"
                             }
                         }
                     }
@@ -180,39 +96,35 @@ __Schema expectedSchemaForMultipleResources = {
             kind: "OBJECT",
             name: "__Type",
             fields: {
-                "kind": {
-                    name: "kind",
-                    'type: {
-                        kind: "SCALAR",
-                        name: "id",
-                        fields: {}
-                    },
-                    args: {}
-                },
                 "name": {
                     name: "name",
                     'type: {
-                        kind: "SCALAR",
-                        name: "string",
-                        fields: {}
-                    },
-                    args: {}
+                        kind: "NON_NULL",
+                        name: ()
+                    }
+                },
+                kind: {
+                    name: "kind",
+                    'type: {
+                        kind: "NON_NULL",
+                        name: ()
+                    }
                 },
                 fields: {
                     name: "fields",
                     'type: {
-                        kind: "SCALAR",
-                        name: "id",
-                        fields: {}
-                    },
-                    args: {}
+                        kind: "NON_NULL",
+                        name: ()
+                    }
+                },
+                "enumValues": {
+                    name: "enumValues",
+                    'type: {
+                        kind: "NON_NULL",
+                        name: ()
+                    }
                 }
             }
-        },
-        "string": {
-            kind: "SCALAR",
-            name: "string",
-            fields: {}
         },
         "__InputValue": {
             kind: "OBJECT",
@@ -221,62 +133,32 @@ __Schema expectedSchemaForMultipleResources = {
                 "name": {
                     name: "name",
                     'type: {
-                        kind: "SCALAR",
-                        name: "string",
-                        fields: {}
-                    },
-                    args: {}
+                        kind: "NON_NULL",
+                        name: ()
+                    }
                 },
                 "type": {
                     name: "type",
                     'type: {
-                        kind: "OBJECT",
-                        name: "__Type",
-                        fields: {
-                            "kind": {
-                                name: "kind",
-                                'type: {
-                                    kind: "SCALAR",
-                                    name: "id",
-                                    fields: {}
-                                },
-                                args: {}
-                            },
-                            "name": {
-                                name: "name",
-                                'type: {
-                                    kind: "SCALAR",
-                                    name: "string",
-                                    fields: {}
-                                },
-                                args: {}
-                            },
-                            fields: {
-                                name: "fields",
-                                'type: {
-                                    kind: "SCALAR",
-                                    name: "id",
-                                    fields: {}
-                                },
-                                args: {}
-                            }
-                        }
-                    },
-                    args: {}
+                        kind: "NON_NULL",
+                        name: ()
+                    }
                 },
                 "defaultValue": {
                     name: "defaultValue",
                     'type: {
-                        kind: "SCALAR",
-                        name: "string",
-                        fields: {}
-                    },
-                    args: {}
+                        kind: "NON_NULL",
+                        name: ()
+                    }
                 }
             }
+        },
+        "int": {
+            kind: "SCALAR",
+            name: "int"
         }
     },
-    "queryType": {
+    queryType: {
         kind: "OBJECT",
         name: "Query",
         fields: {
@@ -284,34 +166,28 @@ __Schema expectedSchemaForMultipleResources = {
                 name: "name",
                 'type: {
                     kind: "SCALAR",
-                    name: "string",
-                    fields: {}
-                },
-                args: {}
+                    name: "string"
+                }
             },
             "id": {
                 name: "id",
                 'type: {
                     kind: "SCALAR",
-                    name: "int",
-                    fields: {}
-                },
-                args: {}
+                    name: "int"
+                }
             },
             "birthdate": {
                 name: "birthdate",
                 'type: {
                     kind: "SCALAR",
-                    name: "string",
-                    fields: {}
+                    name: "string"
                 },
-                args: {
+                "args": {
                     "format": {
                         name: "format",
                         'type: {
                             kind: "SCALAR",
-                            name: "string",
-                            fields: {}
+                            name: "string"
                         }
                     }
                 }
@@ -321,11 +197,15 @@ __Schema expectedSchemaForMultipleResources = {
 };
 
 __Schema expectedSchemaForResourcesReturningRecords = {
-    types: {
-        "int": {
-            kind: "SCALAR",
-            name: "int",
-            fields: {}
+    "types": {
+        "__TypeKind": {
+            kind: "ENUM",
+            name: "__TypeKind",
+            "enumValues": {
+                "SCALAR": "SCALAR",
+                "OBJECT": "OBJECT",
+                "ENUM": "ENUM"
+            }
         },
         "__Field": {
             kind: "OBJECT",
@@ -334,111 +214,29 @@ __Schema expectedSchemaForResourcesReturningRecords = {
                 "name": {
                     name: "name",
                     'type: {
-                        kind: "SCALAR",
-                        name: "string",
-                        fields: {}
-                    },
-                    args: {}
+                        kind: "NON_NULL",
+                        name: ()
+                    }
                 },
                 "type": {
                     name: "type",
                     'type: {
-                        kind: "OBJECT",
-                        name: "__Type",
-                        fields: {
-                            "kind": {
-                                name: "kind",
-                                'type: {
-                                    kind: "SCALAR",
-                                    name: "id",
-                                    fields: {}
-                                },
-                                args: {}
-                            },
-                            "name": {
-                                name: "name",
-                                'type: {
-                                    kind: "SCALAR",
-                                    name: "string",
-                                    fields: {}
-                                },
-                                args: {}
-                            },
-                            fields: {
-                                name: "fields",
-                                'type: {
-                                    kind: "SCALAR",
-                                    name: "id",
-                                    fields: {}
-                                },
-                                args: {}
-                            }
-                        }
-                    },
-                    args: {}
+                        kind: "NON_NULL",
+                        name: ()
+                    }
                 },
                 "args": {
                     name: "args",
                     'type: {
-                        kind: "SCALAR",
-                        name: "id",
-                        fields: {}
-                    },
-                    args: {}
+                        kind: "NON_NULL",
+                        name: ()
+                    }
                 }
             }
         },
-        "__Schema": {
-            kind: "OBJECT",
-            name: "__Schema",
-            fields: {
-                "types": {
-                    name: "types",
-                    'type: {
-                        kind: "SCALAR",
-                        name: "id",
-                        fields: {}
-                    },
-                    args: {}
-                },
-                "queryType": {
-                    name: "queryType",
-                    'type: {
-                        kind: "OBJECT",
-                        name: "__Type",
-                        fields: {
-                            "kind": {
-                                name: "kind",
-                                'type: {
-                                    kind: "SCALAR",
-                                    name: "id",
-                                    fields: {}
-                                },
-                                args: {}
-                            },
-                            "name": {
-                                name: "name",
-                                'type: {
-                                    kind: "SCALAR",
-                                    name: "string",
-                                    fields: {}
-                                },
-                                args: {}
-                            },
-                            fields: {
-                                name: "fields",
-                                'type: {
-                                    kind: "SCALAR",
-                                    name: "id",
-                                    fields: {}
-                                },
-                                args: {}
-                            }
-                        }
-                    },
-                    args: {}
-                }
-            }
+        "string": {
+            kind: "SCALAR",
+            name: "string"
         },
         "Address": {
             kind: "OBJECT",
@@ -448,28 +246,22 @@ __Schema expectedSchemaForResourcesReturningRecords = {
                     name: "number",
                     'type: {
                         kind: "SCALAR",
-                        name: "string",
-                        fields: {}
-                    },
-                    args: {}
+                        name: "string"
+                    }
                 },
                 "street": {
                     name: "street",
                     'type: {
                         kind: "SCALAR",
-                        name: "string",
-                        fields: {}
-                    },
-                    args: {}
+                        name: "string"
+                    }
                 },
                 "city": {
                     name: "city",
                     'type: {
                         kind: "SCALAR",
-                        name: "string",
-                        fields: {}
-                    },
-                    args: {}
+                        name: "string"
+                    }
                 }
             }
         },
@@ -487,19 +279,15 @@ __Schema expectedSchemaForResourcesReturningRecords = {
                                 name: "name",
                                 'type: {
                                     kind: "SCALAR",
-                                    name: "string",
-                                    fields: {}
-                                },
-                                args: {}
+                                    name: "string"
+                                }
                             },
                             "age": {
                                 name: "age",
                                 'type: {
                                     kind: "SCALAR",
-                                    name: "int",
-                                    fields: {}
-                                },
-                                args: {}
+                                    name: "int"
+                                }
                             },
                             "address": {
                                 name: "address",
@@ -511,36 +299,28 @@ __Schema expectedSchemaForResourcesReturningRecords = {
                                             name: "number",
                                             'type: {
                                                 kind: "SCALAR",
-                                                name: "string",
-                                                fields: {}
-                                            },
-                                            args: {}
+                                                name: "string"
+                                            }
                                         },
                                         "street": {
                                             name: "street",
                                             'type: {
                                                 kind: "SCALAR",
-                                                name: "string",
-                                                fields: {}
-                                            },
-                                            args: {}
+                                                name: "string"
+                                            }
                                         },
                                         "city": {
                                             name: "city",
                                             'type: {
                                                 kind: "SCALAR",
-                                                name: "string",
-                                                fields: {}
-                                            },
-                                            args: {}
+                                                name: "string"
+                                            }
                                         }
                                     }
-                                },
-                                args: {}
+                                }
                             }
                         }
-                    },
-                    args: {}
+                    }
                 }
             }
         },
@@ -548,39 +328,35 @@ __Schema expectedSchemaForResourcesReturningRecords = {
             kind: "OBJECT",
             name: "__Type",
             fields: {
-                "kind": {
-                    name: "kind",
-                    'type: {
-                        kind: "SCALAR",
-                        name: "id",
-                        fields: {}
-                    },
-                    args: {}
-                },
                 "name": {
                     name: "name",
                     'type: {
-                        kind: "SCALAR",
-                        name: "string",
-                        fields: {}
-                    },
-                    args: {}
+                        kind: "NON_NULL",
+                        name: ()
+                    }
+                },
+                kind: {
+                    name: "kind",
+                    'type: {
+                        kind: "NON_NULL",
+                        name: ()
+                    }
                 },
                 fields: {
                     name: "fields",
                     'type: {
-                        kind: "SCALAR",
-                        name: "id",
-                        fields: {}
-                    },
-                    args: {}
+                        kind: "NON_NULL",
+                        name: ()
+                    }
+                },
+                enumValues: {
+                    name: "enumValues",
+                    'type: {
+                        kind: "NON_NULL",
+                        name: ()
+                    }
                 }
             }
-        },
-        "string": {
-            kind: "SCALAR",
-            name: "string",
-            fields: {}
         },
         "__InputValue": {
             kind: "OBJECT",
@@ -589,57 +365,23 @@ __Schema expectedSchemaForResourcesReturningRecords = {
                 "name": {
                     name: "name",
                     'type: {
-                        kind: "SCALAR",
-                        name: "string",
-                        fields: {}
-                    },
-                    args: {}
+                        kind: "NON_NULL",
+                        name: ()
+                    }
                 },
                 "type": {
                     name: "type",
                     'type: {
-                        kind: "OBJECT",
-                        name: "__Type",
-                        fields: {
-                            "kind": {
-                                name: "kind",
-                                'type: {
-                                    kind: "SCALAR",
-                                    name: "id",
-                                    fields: {}
-                                },
-                                args: {}
-                            },
-                            "name": {
-                                name: "name",
-                                'type: {
-                                    kind: "SCALAR",
-                                    name: "string",
-                                    fields: {}
-                                },
-                                args: {}
-                            },
-                            fields: {
-                                name: "fields",
-                                'type: {
-                                    kind: "SCALAR",
-                                    name: "id",
-                                    fields: {}
-                                },
-                                args: {}
-                            }
-                        }
-                    },
-                    args: {}
+                        kind: "NON_NULL",
+                        name: ()
+                    }
                 },
                 "defaultValue": {
                     name: "defaultValue",
                     'type: {
-                        kind: "SCALAR",
-                        name: "string",
-                        fields: {}
-                    },
-                    args: {}
+                        kind: "NON_NULL",
+                        name: ()
+                    }
                 }
             }
         },
@@ -651,19 +393,15 @@ __Schema expectedSchemaForResourcesReturningRecords = {
                     name: "name",
                     'type: {
                         kind: "SCALAR",
-                        name: "string",
-                        fields: {}
-                    },
-                    args: {}
+                        name: "string"
+                    }
                 },
                 "age": {
                     name: "age",
                     'type: {
                         kind: "SCALAR",
-                        name: "int",
-                        fields: {}
-                    },
-                    args: {}
+                        name: "int"
+                    }
                 },
                 "address": {
                     name: "address",
@@ -675,37 +413,34 @@ __Schema expectedSchemaForResourcesReturningRecords = {
                                 name: "number",
                                 'type: {
                                     kind: "SCALAR",
-                                    name: "string",
-                                    fields: {}
-                                },
-                                args: {}
+                                    name: "string"
+                                }
                             },
                             "street": {
                                 name: "street",
                                 'type: {
                                     kind: "SCALAR",
-                                    name: "string",
-                                    fields: {}
-                                },
-                                args: {}
+                                    name: "string"
+                                }
                             },
                             "city": {
                                 name: "city",
                                 'type: {
                                     kind: "SCALAR",
-                                    name: "string",
-                                    fields: {}
-                                },
-                                args: {}
+                                    name: "string"
+                                }
                             }
                         }
-                    },
-                    args: {}
+                    }
                 }
             }
+        },
+        "int": {
+            kind: "SCALAR",
+            name: "int"
         }
     },
-    "queryType": {
+    queryType: {
         kind: "OBJECT",
         name: "Query",
         fields: {
@@ -719,19 +454,15 @@ __Schema expectedSchemaForResourcesReturningRecords = {
                             name: "name",
                             'type: {
                                 kind: "SCALAR",
-                                name: "string",
-                                fields: {}
-                            },
-                            args: {}
+                                name: "string"
+                            }
                         },
                         "age": {
                             name: "age",
                             'type: {
                                 kind: "SCALAR",
-                                name: "int",
-                                fields: {}
-                            },
-                            args: {}
+                                name: "int"
+                            }
                         },
                         "address": {
                             name: "address",
@@ -743,36 +474,28 @@ __Schema expectedSchemaForResourcesReturningRecords = {
                                         name: "number",
                                         'type: {
                                             kind: "SCALAR",
-                                            name: "string",
-                                            fields: {}
-                                        },
-                                        args: {}
+                                            name: "string"
+                                        }
                                     },
                                     "street": {
                                         name: "street",
                                         'type: {
                                             kind: "SCALAR",
-                                            name: "string",
-                                            fields: {}
-                                        },
-                                        args: {}
+                                            name: "string"
+                                        }
                                     },
                                     "city": {
                                         name: "city",
                                         'type: {
                                             kind: "SCALAR",
-                                            name: "string",
-                                            fields: {}
-                                        },
-                                        args: {}
+                                            name: "string"
+                                        }
                                     }
                                 }
-                            },
-                            args: {}
+                            }
                         }
                     }
-                },
-                args: {}
+                }
             }
         }
     }

--- a/graphql-ballerina/validator_visitor.bal
+++ b/graphql-ballerina/validator_visitor.bal
@@ -64,13 +64,13 @@ public class ValidatorVisitor {
         __Type parentType = parent.parentType;
 
         // Skip service types validation
-        if (parentType.name.startsWith("$")) {
+        if (parentType.name.toString().startsWith("$")) {
             return;
         }
 
         map<__Field> fields = parentType?.fields == () ? {} : <map<__Field>>parentType?.fields;
         if (fields.length() == 0) {
-            string message = getNoSubfieldsErrorMessage(parent.name, parentType.name);
+            string message = getNoSubfieldsErrorMessage(parent.name, parentType.name.toString());
             self.errors.push(getErrorDetailRecord(message, fieldNode.getLocation()));
             return;
         }
@@ -78,7 +78,7 @@ public class ValidatorVisitor {
         string requiredFieldName = fieldNode.getName();
         var schemaFieldValue = fields[requiredFieldName];
         if (schemaFieldValue is ()) {
-            string message = getFieldNotFoundErrorMessage(requiredFieldName, parentType.name);
+            string message = getFieldNotFoundErrorMessage(requiredFieldName, parentType.name.toString());
             self.errors.push(getErrorDetailRecord(message, fieldNode.getLocation()));
             return;
         }
@@ -90,7 +90,7 @@ public class ValidatorVisitor {
         parser:FieldNode[] selections = fieldNode.getSelections();
 
         if (fieldType.kind != SCALAR && selections.length() == 0) {
-            string message = getMissingSubfieldsError(requiredFieldName, fieldType.name);
+            string message = getMissingSubfieldsError(requiredFieldName, fieldType.name.toString());
             self.errors.push(getErrorDetailRecord(message, fieldNode.getLocation()));
         }
 
@@ -105,7 +105,7 @@ public class ValidatorVisitor {
 
     public isolated function visitArgument(parser:ArgumentNode argumentNode, anydata data = ()) {
         __InputValue schemaArg = <__InputValue>data;
-        string typeName = schemaArg.'type.name;
+        string typeName = schemaArg.'type.name.toString();
         parser:ArgumentValue value = argumentNode.getValue();
         string expectedTypeName = getTypeName(value);
         if (typeName != expectedTypeName) {

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/engine/Engine.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/engine/Engine.java
@@ -24,7 +24,6 @@ import io.ballerina.runtime.api.async.StrandMetadata;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.ResourceFunctionType;
 import io.ballerina.runtime.api.types.ServiceType;
-import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BError;
@@ -38,23 +37,19 @@ import io.ballerina.stdlib.graphql.utils.CallableUnitCallback;
 
 import java.util.concurrent.CountDownLatch;
 
+import static io.ballerina.stdlib.graphql.engine.IntrospectionUtils.initializeIntrospectionTypes;
 import static io.ballerina.stdlib.graphql.engine.Utils.ARGUMENTS_FIELD;
 import static io.ballerina.stdlib.graphql.engine.Utils.DATA_RECORD;
 import static io.ballerina.stdlib.graphql.engine.Utils.ERRORS_FIELD;
 import static io.ballerina.stdlib.graphql.engine.Utils.EXECUTE_SINGLE_RESOURCE_FUNCTION;
-import static io.ballerina.stdlib.graphql.engine.Utils.FIELD_RECORD;
-import static io.ballerina.stdlib.graphql.engine.Utils.INPUT_VALUE_RECORD;
 import static io.ballerina.stdlib.graphql.engine.Utils.NAME_FIELD;
 import static io.ballerina.stdlib.graphql.engine.Utils.QUERY;
-import static io.ballerina.stdlib.graphql.engine.Utils.SCHEMA_RECORD;
 import static io.ballerina.stdlib.graphql.engine.Utils.SELECTIONS_FIELD;
-import static io.ballerina.stdlib.graphql.engine.Utils.TYPE_RECORD;
 import static io.ballerina.stdlib.graphql.engine.Utils.VALUE_FIELD;
 import static io.ballerina.stdlib.graphql.engine.Utils.addQueryFieldsForServiceType;
 import static io.ballerina.stdlib.graphql.engine.Utils.getErrorDetailRecord;
 import static io.ballerina.stdlib.graphql.engine.Utils.getResourceName;
 import static io.ballerina.stdlib.graphql.engine.Utils.getSchemaRecordFromSchema;
-import static io.ballerina.stdlib.graphql.engine.Utils.getSchemaTypeForBalType;
 
 /**
  * This handles Ballerina GraphQL Engine.
@@ -63,7 +58,7 @@ public class Engine {
 
     public static BMap<BString, Object> createSchema(Environment environment, BObject service) {
         Schema schema = new Schema();
-        initializeIntrospectionTypes(environment, schema);
+        initializeIntrospectionTypes(schema);
         ServiceType serviceType = (ServiceType) service.getType();
         SchemaType queryType = new SchemaType(QUERY, TypeKind.OBJECT);
         addQueryFieldsForServiceType(serviceType, queryType, schema);
@@ -142,21 +137,6 @@ public class Engine {
             result[j + 1] = true;
         }
         return result;
-    }
-
-    private static void initializeIntrospectionTypes(Environment environment, Schema schema) {
-        Type schemaBalType = ValueCreator.createRecordValue(environment.getCurrentModule(), SCHEMA_RECORD).getType();
-        schema.addType(getSchemaTypeForBalType(schemaBalType, schema));
-
-        Type typeBalType = ValueCreator.createRecordValue(environment.getCurrentModule(), TYPE_RECORD).getType();
-        schema.addType(getSchemaTypeForBalType(typeBalType, schema));
-
-        Type fieldBalType = ValueCreator.createRecordValue(environment.getCurrentModule(), FIELD_RECORD).getType();
-        schema.addType(getSchemaTypeForBalType(fieldBalType, schema));
-
-        Type inputValueBalType = ValueCreator.createRecordValue(environment.getCurrentModule(), INPUT_VALUE_RECORD)
-                .getType();
-        schema.addType(getSchemaTypeForBalType(inputValueBalType, schema));
     }
 
     private static BMap<BString, Object> getSelectionsFromRecord(BObject fieldNode, BMap<BString, Object> record,

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/engine/IntrospectionUtils.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/engine/IntrospectionUtils.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.graphql.engine;
+
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.stdlib.graphql.schema.Schema;
+import io.ballerina.stdlib.graphql.schema.SchemaField;
+import io.ballerina.stdlib.graphql.schema.SchemaType;
+import io.ballerina.stdlib.graphql.schema.TypeKind;
+
+import static io.ballerina.stdlib.graphql.engine.Utils.FIELD_RECORD;
+import static io.ballerina.stdlib.graphql.engine.Utils.INPUT_VALUE_RECORD;
+import static io.ballerina.stdlib.graphql.engine.Utils.TYPE_KIND_ENUM;
+import static io.ballerina.stdlib.graphql.engine.Utils.TYPE_RECORD;
+
+/**
+ * This class creates the introspection types for the Schema.
+ */
+public class IntrospectionUtils {
+    private static final String NAME = "name";
+    private static final String KIND = "kind";
+    private static final String FIELDS = "fields";
+    private static final String ENUM_VALUES = "enumValues";
+    private static final String TYPE = "type";
+    private static final String ARGS = "args";
+    private static final String DEFAULT_VALUE = "defaultValue";
+
+    static void initializeIntrospectionTypes(Schema schema) {
+        schema.addType(createTypeKindSchemaType());
+        schema.addType(createTypeSchemaType());
+        schema.addType(createFieldSchemaType());
+        schema.addType(createInputValueSchemaType());
+    }
+
+    private static SchemaType createTypeKindSchemaType() {
+        SchemaType typeKindSchemaType = new SchemaType(TYPE_KIND_ENUM, TypeKind.ENUM);
+        typeKindSchemaType.addEnumValue(StringUtils.fromString(TypeKind.SCALAR.toString()));
+        typeKindSchemaType.addEnumValue(StringUtils.fromString(TypeKind.OBJECT.toString()));
+        typeKindSchemaType.addEnumValue(StringUtils.fromString(TypeKind.ENUM.toString()));
+        return typeKindSchemaType;
+    }
+
+    private static SchemaType createTypeSchemaType() {
+        SchemaType typeSchemaType = new SchemaType(TYPE_RECORD, TypeKind.OBJECT);
+        typeSchemaType.addField(new SchemaField(NAME));
+        typeSchemaType.addField(new SchemaField(KIND));
+        typeSchemaType.addField(new SchemaField(FIELDS));
+        typeSchemaType.addField(new SchemaField(ENUM_VALUES));
+        return typeSchemaType;
+    }
+
+    private static SchemaType createFieldSchemaType() {
+        SchemaType fieldSchemaType = new SchemaType(FIELD_RECORD, TypeKind.OBJECT);
+        fieldSchemaType.addField(new SchemaField(NAME));
+        fieldSchemaType.addField(new SchemaField(TYPE));
+        fieldSchemaType.addField(new SchemaField(ARGS));
+        return fieldSchemaType;
+    }
+
+    private static SchemaType createInputValueSchemaType() {
+        SchemaType inputValueSchemaType = new SchemaType(INPUT_VALUE_RECORD, TypeKind.OBJECT);
+        inputValueSchemaType.addField(new SchemaField(NAME));
+        inputValueSchemaType.addField(new SchemaField(TYPE));
+        inputValueSchemaType.addField(new SchemaField(DEFAULT_VALUE));
+        return inputValueSchemaType;
+    }
+}

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/schema/SchemaField.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/schema/SchemaField.java
@@ -28,20 +28,14 @@ public class SchemaField {
     private String name;
     private List<InputValue> args;
     private SchemaType type;
-    private int typeTag;
 
-    public SchemaField(String name, int typeTag) {
+    public SchemaField(String name) {
         this.name = name;
-        this.typeTag = typeTag;
         this.args = new ArrayList<>();
     }
 
     public void setType(SchemaType type) {
         this.type = type;
-    }
-
-    public int getTypeTag() {
-        return this.typeTag;
     }
 
     public void addArg(InputValue arg) {

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/schema/SchemaType.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/schema/SchemaType.java
@@ -29,11 +29,13 @@ public class SchemaType {
     private TypeKind kind;
     private String name;
     private List<SchemaField> fields;
+    private List<Object> enumValues;
 
     public SchemaType(String name, TypeKind kind) {
         this.name = name;
         this.kind = kind;
         this.fields = new ArrayList<>();
+        this.enumValues = new ArrayList<>();
     }
 
     public String getName() {
@@ -48,8 +50,16 @@ public class SchemaType {
         return this.fields;
     }
 
+    public List<Object> getEnumValues() {
+        return this.enumValues;
+    }
+
     public void addField(SchemaField field) {
         this.fields.add(field);
+    }
+
+    public void addEnumValue(Object o) {
+        this.enumValues.add(o);
     }
 
     @Override

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/schema/TypeKind.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/schema/TypeKind.java
@@ -24,5 +24,6 @@ package io.ballerina.stdlib.graphql.schema;
 public enum TypeKind {
     SCALAR,
     OBJECT,
-    ENUM
+    ENUM,
+    NON_NULL
 }


### PR DESCRIPTION
## Purpose
With this PR, the Ballerina GraphQL resources can return union types (with `error` type). 

This means the following resource function is allowed:

```ballerina
resource function get profile() returns string|error {

}
```

But the following is not allowed, since the union is only allowed with the error type.

```ballerina
resource function get id() returns int|string{

}
```

Fixes: [#762](https://github.com/ballerina-platform/ballerina-standard-library/issues/762)