### PR TITLE
Add Introspection Support for GraphQL Schema

### DIFF
--- a/graphql-ballerina/Ballerina.toml
+++ b/graphql-ballerina/Ballerina.toml
@@ -1,31 +1,31 @@
 [package]
 org = "ballerina"
 name = "graphql"
-version = "0.1.1"
+version = "@toml.version@"
 
 [[dependency]]
 org = "ballerina"
 name = "encoding"
-version = "1.0.7"
+version = "@stdlib.encoding.version@"
 
 [[dependency]]
 org = "ballerina"
 name = "file"
-version = "0.6.3"
+version = "@stdlib.file.version@"
 
 [[dependency]]
 org = "ballerina"
 name = "http"
-version = "1.0.5"
+version = "@stdlib.http.version@"
 
 [[dependency]]
 org = "ballerina"
 name = "io"
-version = "0.5.5"
+version = "@stdlib.io.version@"
 
 [[platform.java11.dependency]]
-path = "../graphql-native/build/libs/graphql-native-0.1.1-SNAPSHOT.jar"
+path = "../graphql-native/build/libs/graphql-native-@project.version@.jar"
 groupId = "io.ballerina.stdlib.graphql"
 artifactId = "graphql"
-version = "0.1.1-SNAPSHOT"
+version = "@project.version@"
 modules = ["graphql"]

--- a/graphql-ballerina/Ballerina.toml
+++ b/graphql-ballerina/Ballerina.toml
@@ -1,31 +1,31 @@
 [package]
 org = "ballerina"
 name = "graphql"
-version = "@toml.version@"
+version = "0.1.1"
 
 [[dependency]]
 org = "ballerina"
 name = "encoding"
-version = "@stdlib.encoding.version@"
+version = "1.0.7"
 
 [[dependency]]
 org = "ballerina"
 name = "file"
-version = "@stdlib.file.version@"
+version = "0.6.3"
 
 [[dependency]]
 org = "ballerina"
 name = "http"
-version = "@stdlib.http.version@"
+version = "1.0.5"
 
 [[dependency]]
 org = "ballerina"
 name = "io"
-version = "@stdlib.io.version@"
+version = "0.5.5"
 
 [[platform.java11.dependency]]
-path = "../graphql-native/build/libs/graphql-native-@project.version@.jar"
+path = "../graphql-native/build/libs/graphql-native-0.1.1-SNAPSHOT.jar"
 groupId = "io.ballerina.stdlib.graphql"
 artifactId = "graphql"
-version = "@project.version@"
+version = "0.1.1-SNAPSHOT"
 modules = ["graphql"]

--- a/graphql-ballerina/build.gradle
+++ b/graphql-ballerina/build.gradle
@@ -92,7 +92,6 @@ task updateTomlFile {
         def stdlibDependentFileVersion = project.stdlibFileVersion.split("-")[0]
         def stdlibDependentHttpVersion = project.stdlibHttpVersion.split("-")[0]
         def stdlibDependentIoVersion = project.stdlibIoVersion.split("-")[0]
-        def stdlibDependentStringUtilsVersion = project.stdlibStringutilsVersion.split("-")[0]
 
         def newConfig = ballerinaConfigFile.text.replace("@project.version@", project.version)
         newConfig = newConfig.replace("@toml.version@", tomlVersion)
@@ -100,7 +99,6 @@ task updateTomlFile {
         newConfig = newConfig.replace("@stdlib.file.version@", stdlibDependentFileVersion)
         newConfig = newConfig.replace("@stdlib.http.version@", stdlibDependentHttpVersion)
         newConfig = newConfig.replace("@stdlib.io.version@", stdlibDependentIoVersion)
-        newConfig = newConfig.replace("@stdlib.stringutils.version@", stdlibDependentStringUtilsVersion)
         ballerinaConfigFile.text = newConfig
     }
 }

--- a/graphql-ballerina/constants.bal
+++ b/graphql-ballerina/constants.bal
@@ -31,11 +31,13 @@ const FIELD_ERROR_RECORD = "errorRecord";
 const FIELD_LOCATIONS = "locations";
 const FIELD_MESSAGE = "message";
 
-const OPERATION_QUERY = "Query";
-
 const SCALAR = "SCALAR";
 const OBJECT = "OBJECT";
 const LIST = "LIST";
 const NON_NULL = "NON_NULL";
 
 const SCHEMA_FIELD = "__schema";
+const TYPES_FIELD = "types";
+const SCHEMA_TYPE_NAME = "__Schema";
+const TYPE_TYPE_NAME = "__Type";
+const QUERY_TYPE_NAME = "Query";

--- a/graphql-ballerina/constants.bal
+++ b/graphql-ballerina/constants.bal
@@ -36,3 +36,6 @@ const OPERATION_QUERY = "Query";
 const SCALAR = "SCALAR";
 const OBJECT = "OBJECT";
 const LIST = "LIST";
+const NON_NULL = "NON_NULL";
+
+const SCHEMA_FIELD = "__schema";

--- a/graphql-ballerina/engine.bal
+++ b/graphql-ballerina/engine.bal
@@ -15,7 +15,6 @@
 // under the License.
 
 import graphql.parser;
-//import ballerina/io;
 
 # Represents the Ballerina GraphQL engine.
 public class Engine {

--- a/graphql-ballerina/engine_utils.bal
+++ b/graphql-ballerina/engine_utils.bal
@@ -47,3 +47,8 @@ isolated function executeSingleResource(Service s, ExecutorVisitor visitor, pars
 map<Scalar> arguments) returns anydata = @java:Method {
     'class: "io.ballerina.stdlib.graphql.engine.Engine"
 } external;
+
+isolated function getDataFromBalType(parser:FieldNode fieldNode, anydata fieldRecord) returns anydata =
+@java:Method {
+	'class: "io.ballerina.stdlib.graphql.engine.Engine"
+} external;

--- a/graphql-ballerina/records.bal
+++ b/graphql-ballerina/records.bal
@@ -98,8 +98,6 @@ public type __InputValue record {|
 	string defaultValue?;
 |};
 
-
-
 # Represents the type kind of a GraphQL type.
 public type __TypeKind "SCALAR"|"OBJECT"|"ENUM"|"NON_NULL"|"LIST";
 

--- a/graphql-ballerina/tests/10_resources_returning_arrays.bal
+++ b/graphql-ballerina/tests/10_resources_returning_arrays.bal
@@ -27,7 +27,7 @@ service /graphql on new Listener(9100) {
 }
 
 @test:Config {
-    groups: ["test", "service", "unit"]
+    groups: ["array", "service", "unit"]
 }
 function testResourcesReturningScalarArrays() returns @tainted error? {
     Client graphqlClient = new("http://localhost:9100/graphql");
@@ -42,7 +42,7 @@ function testResourcesReturningScalarArrays() returns @tainted error? {
 }
 
 @test:Config {
-    groups: ["test", "service", "unit"]
+    groups: ["array", "service", "unit"]
 }
 function testResourcesReturningArrays() returns @tainted error? {
     Client graphqlClient = new("http://localhost:9100/graphql");
@@ -76,7 +76,7 @@ function testResourcesReturningArrays() returns @tainted error? {
 }
 
 @test:Config {
-    groups: ["service", "unit"]
+    groups: ["array", "service", "unit"]
 }
 function testResourcesReturningArraysMissingFields() returns @tainted error? {
     Client graphqlClient = new("http://localhost:9100/graphql");

--- a/graphql-ballerina/tests/10_resources_returning_arrays.bal
+++ b/graphql-ballerina/tests/10_resources_returning_arrays.bal
@@ -24,6 +24,10 @@ service /graphql on new Listener(9100) {
     isolated resource function get ids() returns int[] {
         return [0, 1, 2];
     }
+
+    resource function get students() returns Student[] {
+        return students;
+    }
 }
 
 @test:Config {
@@ -96,6 +100,114 @@ function testResourcesReturningArraysMissingFields() returns @tainted error? {
                 ]
             }
         ]
+    };
+    test:assertEquals(actualResult, expectedResult);
+}
+
+@test:Config {
+    groups: ["array", "service", "unit"]
+}
+function testComplexArraySample() returns @tainted error? {
+    Client graphqlClient = new("http://localhost:9100/graphql");
+    string document = "{ students { name courses { name books { name } } } }";
+    json actualResult = check graphqlClient->query(document);
+    json expectedResult = {
+        data: {
+            students: [
+                {
+                    name: "John Doe",
+                    courses: [
+                        {
+                            name: "Electronics",
+                            books: [
+                                {
+                                    name: "The Art of Electronics"
+                                },
+                                {
+                                    name: "Practical Electronics"
+                                }
+                            ]
+                        },
+                        {
+                            name: "Computer Science",
+                            books: [
+                                {
+                                    name: "Algorithms to Live By"
+                                },
+                                {
+                                    name: "Code: The Hidden Language"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    name: "Jane Doe",
+                    courses: [
+                        {
+                            name: "Computer Science",
+                            books: [
+                                {
+                                    name: "Algorithms to Live By"
+                                },
+                                {
+                                    name: "Code: The Hidden Language"
+                                }
+                            ]
+                        },
+                        {
+                            name: "Mathematics",
+                            books: [
+                                {
+                                    name: "Calculus Made Easy"
+                                },
+                                {
+                                    name: "Calculus"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    name: "Jonny Doe",
+                    courses: [
+                        {
+                            name: "Electronics",
+                            books: [
+                                {
+                                    name: "The Art of Electronics"
+                                },
+                                {
+                                    name: "Practical Electronics"
+                                }
+                            ]
+                        },
+                        {
+                            name: "Computer Science",
+                            books: [
+                                {
+                                    name: "Algorithms to Live By"
+                                },
+                                {
+                                    name: "Code: The Hidden Language"
+                                }
+                            ]
+                        },
+                        {
+                            name: "Mathematics",
+                            books: [
+                                {
+                                    name: "Calculus Made Easy"
+                                },
+                                {
+                                    name: "Calculus"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
     };
     test:assertEquals(actualResult, expectedResult);
 }

--- a/graphql-ballerina/tests/11_introspection_queries.bal
+++ b/graphql-ballerina/tests/11_introspection_queries.bal
@@ -1,0 +1,201 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+@test:Config {
+    groups: ["introspection", "unit"]
+}
+function testSimpleIntrospectionQuery() returns @tainted error? {
+    Client graphqlClient = new("http://localhost:9101/graphql");
+    string document = "{ __schema { types { name kind } } }";
+    json actualResult = check graphqlClient->query(document);
+    json expectedResult = {
+        data: {
+            __schema: {
+                types: [
+                    {
+                        name: "__TypeKind",
+                        kind: "ENUM"
+                    },
+                    {
+                        name: "__Field",
+                        kind: "OBJECT"
+                    },
+                    {
+                        name: "Query",
+                        kind: "OBJECT"
+                    },
+                    {
+                        name: "__Type",
+                        kind: "OBJECT"
+                    },
+                    {
+                        name: "__InputValue",
+                        kind: "OBJECT"
+                    },
+                    {
+                        name: "String",
+                        kind: "SCALAR"
+                    },
+                    {
+                        name: "__Schema",
+                        kind: "OBJECT"
+                    }
+                ]
+            }
+        }
+    };
+    test:assertEquals(actualResult, expectedResult);
+}
+
+@test:Config {
+    groups: ["introspection", "unit"]
+}
+function testComplexIntrospectionQuery() returns @tainted error? {
+    // Using 9100 endpoint since it has more complex schema
+    Client graphqlClient = new("http://localhost:9100/graphql");
+    string document = "{ __schema { types { name kind } } }";
+    json actualResult = check graphqlClient->query(document);
+    json expectedResult = {
+        data: {
+            __schema: {
+                types: [
+                    {
+                        name: "__TypeKind",
+                        kind: "ENUM"
+                    },
+                    {
+                        name: "__Field",
+                        kind: "OBJECT"
+                    },
+                    {
+                        name: "Address",
+                        kind: "OBJECT"
+                    },
+                    {
+                        name: "Query",
+                        kind: "OBJECT"
+                    },
+                    {
+                        name: "__Type",
+                        kind: "OBJECT"
+                    },
+                    {
+                        name: "__InputValue",
+                        kind: "OBJECT"
+                    },
+                    {
+                        name: "String",
+                        kind: "SCALAR"
+                    },
+                    {
+                        name: "Person",
+                        kind: "OBJECT"
+                    },
+                    {
+                        name: "Int",
+                        kind: "SCALAR"
+                    },
+                    {
+                        name: "__Schema",
+                        kind: "OBJECT"
+                    }
+                ]
+            }
+        }
+    };
+    test:assertEquals(actualResult, expectedResult);
+}
+
+@test:Config {
+    groups: ["introspection", "unit"]
+}
+function testInvalidIntrospectionQuery() returns @tainted error? {
+    Client graphqlClient = new("http://localhost:9101/graphql");
+    string document = "{ __schema { greet } }";
+    json actualResult = check graphqlClient->query(document);
+    string expectedMessage = "Cannot query field \"greet\" on type \"__Schema\".";
+    json expectedResult = {
+        errors: [
+            {
+                message: expectedMessage,
+                locations: [
+                    {
+                        line: 1,
+                        column: 14
+                    }
+                ]
+            }
+        ]
+    };
+    test:assertEquals(actualResult, expectedResult);
+}
+
+@test:Config {
+    groups: ["introspection", "unit"]
+}
+function testIntrospectionQueryWithMissingSelection() returns @tainted error? {
+    Client graphqlClient = new("http://localhost:9101/graphql");
+    string document = "{ __schema }";
+    json actualResult = check graphqlClient->query(document);
+    string expectedMessage = "Field \"__schema\" of type \"__Schema\" must have a selection of subfields." +
+                             " Did you mean \"__schema { ... }\"?";
+    json expectedResult = {
+        errors: [
+            {
+                message: expectedMessage,
+                locations: [
+                    {
+                        line: 1,
+                        column: 3
+                    }
+                ]
+            }
+        ]
+    };
+    test:assertEquals(actualResult, expectedResult);
+}
+
+@test:Config {
+    groups: ["introspection", "unit"],
+    enable: false
+}
+function testQueryTypeIntrospection() returns @tainted error? {
+    Client graphqlClient = new("http://localhost:9101/graphql");
+    string document = "{ __schema { queryType { fields { name } } } }";
+    json actualResult = check graphqlClient->query(document);
+    json expectedResult = {
+        data: {
+            __schema: {
+                queryType: {
+                    fields: [
+                        {
+                            name: "greet"
+                        }
+                    ]
+                }
+            }
+        }
+    };
+    test:assertEquals(actualResult, expectedResult);
+}
+
+service /graphql on new Listener(9101) {
+    isolated resource function get greet() returns string {
+        return "Hello";
+    }
+}

--- a/graphql-ballerina/tests/11_introspection_queries.bal
+++ b/graphql-ballerina/tests/11_introspection_queries.bal
@@ -182,9 +182,10 @@ function testIntrospectionQueryWithMissingSelection() returns @tainted error? {
     test:assertEquals(actualResult, expectedResult);
 }
 
+// Enable after fixing https://github.com/ballerina-platform/ballerina-standard-library/issues/832
 @test:Config {
     groups: ["introspection", "unit"],
-    enable: false // Enable after fixing https://github.com/ballerina-platform/ballerina-standard-library/issues/832
+    enable: false
 }
 function testQueryTypeIntrospection() returns @tainted error? {
     Client graphqlClient = new("http://localhost:9101/graphql");

--- a/graphql-ballerina/tests/11_introspection_queries.bal
+++ b/graphql-ballerina/tests/11_introspection_queries.bal
@@ -95,12 +95,24 @@ function testComplexIntrospectionQuery() returns @tainted error? {
                         kind: "OBJECT"
                     },
                     {
+                        name: "Book",
+                        kind: "OBJECT"
+                    },
+                    {
                         name: "__InputValue",
                         kind: "OBJECT"
                     },
                     {
                         name: "String",
                         kind: "SCALAR"
+                    },
+                    {
+                        name: "Course",
+                        kind: "OBJECT"
+                    },
+                    {
+                        name: "Student",
+                        kind: "OBJECT"
                     },
                     {
                         name: "Person",

--- a/graphql-ballerina/tests/11_introspection_queries.bal
+++ b/graphql-ballerina/tests/11_introspection_queries.bal
@@ -184,7 +184,7 @@ function testIntrospectionQueryWithMissingSelection() returns @tainted error? {
 
 @test:Config {
     groups: ["introspection", "unit"],
-    enable: false
+    enable: false // Enable after fixing https://github.com/ballerina-platform/ballerina-standard-library/issues/832
 }
 function testQueryTypeIntrospection() returns @tainted error? {
     Client graphqlClient = new("http://localhost:9101/graphql");

--- a/graphql-ballerina/tests/records.bal
+++ b/graphql-ballerina/tests/records.bal
@@ -14,14 +14,30 @@
 // specific language governing permissions and limitations
 // under the License.
 
-public type Address record {
+type Address record {
     string number;
     string street;
     string city;
 };
 
-public type Person record {
+type Person record {
     string name;
     int age;
     Address address;
+};
+
+type Book record {
+    string name;
+    string author;
+};
+
+type Course record {
+    string name;
+    int code;
+    Book[] books;
+};
+
+type Student record {
+    string name;
+    Course[] courses;
 };

--- a/graphql-ballerina/tests/values.bal
+++ b/graphql-ballerina/tests/values.bal
@@ -14,34 +14,105 @@
 // specific language governing permissions and limitations
 // under the License.
 
+Address a1 = {
+    number: "221/B",
+    street: "Baker Street",
+    city: "London"
+};
+
+Address a2 = {
+    number: "308",
+    street: "Negra Arroyo Lane",
+    city: "Albuquerque"
+};
+
+Address a3 = {
+    number: "Uknown",
+    street: "Unknown",
+    city: "Hogwarts"
+};
+
 Person p1 = {
     name: "Sherlock Holmes",
     age: 40,
-    address: {
-        number: "221/B",
-        street: "Baker Street",
-        city: "London"
-    }
+    address: a1
 };
 
 Person p2 = {
     name: "Walter White",
     age: 50,
-    address: {
-        number: "308",
-        street: "Negra Arroyo Lane",
-        city: "Albuquerque"
-    }
+    address: a2
 };
 
 Person p3 = {
     name: "Tom Marvolo Riddle",
     age: 100,
-    address: {
-        number: "Uknown",
-        street: "Unknown",
-        city: "Hogwarts"
-    }
+    address: a3
 };
 
 Person[] people = [p1, p2, p3];
+
+Book b1 = {
+    name: "The Art of Electronics",
+    author: "Paul Horowitz"
+};
+
+Book b2 = {
+    name: "Practical Electronics",
+    author: "Paul Scherz"
+};
+
+Book b3 = {
+    name: "Algorithms to Live By",
+    author: "Brian Christian"
+};
+
+Book b4 = {
+    name: "Code: The Hidden Language",
+    author: "Charles Petzold"
+};
+
+Book b5 = {
+    name: "Calculus Made Easy",
+    author: "Silvanus P. Thompson"
+};
+
+Book b6 = {
+    name: "Calculus",
+    author: "Michael Spivak"
+};
+
+Course c1 = {
+    name: "Electronics",
+    code: 106,
+    books: [b1, b2]
+};
+
+Course c2 = {
+    name: "Computer Science",
+    code: 107,
+    books: [b3, b4]
+};
+
+Course c3 = {
+    name: "Mathematics",
+    code: 105,
+    books: [b5, b6]
+};
+
+Student s1 = {
+    name: "John Doe",
+    courses: [c1, c2]
+};
+
+Student s2 = {
+    name: "Jane Doe",
+    courses: [c2, c3]
+};
+
+Student s3 = {
+    name: "Jonny Doe",
+    courses: [c1, c2, c3]
+};
+
+Student[] students = [s1, s2, s3];

--- a/graphql-ballerina/validator_visitor.bal
+++ b/graphql-ballerina/validator_visitor.bal
@@ -94,7 +94,7 @@ public class ValidatorVisitor {
         }
 
         foreach parser:FieldNode subFieldNode in selections {
-            if (fieldType.kind == LIST) {
+            if (fieldType.kind == LIST || fieldType.kind == NON_NULL) {
                 Parent subParent = {
                     parentType: <__Type>fieldType?.ofType,
                     name: fieldNode.getName()
@@ -171,7 +171,7 @@ isolated function hasFields(__Type fieldType) returns boolean {
     if (fieldType.kind == OBJECT) {
         return true;
     }
-    if (fieldType.kind == LIST) {
+    if (fieldType.kind == NON_NULL || fieldType.kind == LIST) {
         __Type ofType = <__Type>fieldType?.ofType;
         return ofType.kind == OBJECT;
     }

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/engine/Engine.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/engine/Engine.java
@@ -154,6 +154,8 @@ public class Engine {
             Object fieldValue = record.get(fieldName);
             if (fieldValue instanceof BMap) {
                 data.put(fieldName, getDataFromRecord(subfieldNode, (BMap<BString, Object>) fieldValue));
+            } else if (fieldValue instanceof BArray) {
+                data.put(fieldName, getDataFromArray(subfieldNode, (BArray) fieldValue));
             } else {
                 data.put(fieldName, fieldValue);
             }

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/engine/Engine.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/engine/Engine.java
@@ -20,7 +20,6 @@ package io.ballerina.stdlib.graphql.engine;
 
 import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.Module;
-import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.async.StrandMetadata;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
@@ -99,20 +98,9 @@ public class Engine {
                     errors.append(getErrorDetailRecord((BError) result, fieldNode));
                 } else if (result instanceof BMap) {
                     BMap<BString, Object> resultRecord = (BMap<BString, Object>) result;
-                    return getSelectionsFromRecord(fieldNode, resultRecord);
+                    return getDataFromRecord(fieldNode, resultRecord);
                 } else if (result instanceof BArray) {
-                    BArray dataArray = (BArray) result;
-                    if (isScalarType(dataArray.getElementType())) {
-                        return result;
-                    } else if (dataArray.getElementType().getTag() == TypeTags.RECORD_TYPE_TAG) {
-                        BArray resultArray = ValueCreator.createArrayValue(getDataRecordArrayType());
-                        for (int i = 0; i < dataArray.size(); i++) {
-                            BMap<BString, Object> resultRecord = (BMap<BString, Object>) dataArray.get(i);
-                            BMap<BString, Object> arrayField = getSelectionsFromRecord(fieldNode, resultRecord);
-                            resultArray.append(arrayField);
-                        }
-                        return resultArray;
-                    }
+                    return getDataFromArray(fieldNode, (BArray) result);
                 } else if (result instanceof BObject) {
                     BObject subService = (BObject) result;
                     BArray selections = fieldNode.getArrayValue(SELECTIONS_FIELD);
@@ -133,7 +121,47 @@ public class Engine {
         return null;
     }
 
-    public static BMap<BString, Object> getArgumentsFromField(BObject fieldNode) {
+    public static Object getDataFromBalType(BObject fieldNode, Object data) {
+        if (data instanceof BArray) {
+            return getDataFromArray(fieldNode, (BArray) data);
+        } else if (data instanceof BMap) {
+            return getDataFromRecord(fieldNode, (BMap<BString, Object>) data);
+        } else {
+            return data;
+        }
+    }
+
+    private static BArray getDataFromArray(BObject fieldNode, BArray result) {
+        if (isScalarType(result.getElementType())) {
+            return result;
+        } else {
+            BArray resultArray = ValueCreator.createArrayValue(getDataRecordArrayType());
+            for (int i = 0; i < result.size(); i++) {
+                BMap<BString, Object> resultRecord = (BMap<BString, Object>) result.get(i);
+                BMap<BString, Object> arrayField = getDataFromRecord(fieldNode, resultRecord);
+                resultArray.append(arrayField);
+            }
+            return resultArray;
+        }
+    }
+
+    private static BMap<BString, Object> getDataFromRecord(BObject fieldNode, BMap<BString, Object> record) {
+        BArray selections = fieldNode.getArrayValue(SELECTIONS_FIELD);
+        BMap<BString, Object> data = ValueCreator.createRecordValue(getModule(), DATA_RECORD);
+        for (int i = 0; i < selections.size(); i++) {
+            BObject subfieldNode = (BObject) selections.get(i);
+            BString fieldName = subfieldNode.getStringValue(NAME_FIELD);
+            Object fieldValue = record.get(fieldName);
+            if (fieldValue instanceof BMap) {
+                data.put(fieldName, getDataFromRecord(subfieldNode, (BMap<BString, Object>) fieldValue));
+            } else {
+                data.put(fieldName, fieldValue);
+            }
+        }
+        return data;
+    }
+
+    private static BMap<BString, Object> getArgumentsFromField(BObject fieldNode) {
         BArray argumentArray = fieldNode.getArrayValue(ARGUMENTS_FIELD);
         BMap<BString, Object> argumentsMap = ValueCreator.createMapValue();
         for (int i = 0; i < argumentArray.size(); i++) {
@@ -147,7 +175,7 @@ public class Engine {
         return argumentsMap;
     }
 
-    public static Object[] getArgsForResource(ResourceMethodType resourceMethod, BMap<BString, Object> arguments) {
+    private static Object[] getArgsForResource(ResourceMethodType resourceMethod, BMap<BString, Object> arguments) {
         String[] paramNames = resourceMethod.getParamNames();
         Object[] result = new Object[paramNames.length * 2];
         for (int i = 0, j = 0; i < paramNames.length; i += 1, j += 2) {
@@ -155,22 +183,6 @@ public class Engine {
             result[j + 1] = true;
         }
         return result;
-    }
-
-    private static BMap<BString, Object> getSelectionsFromRecord(BObject fieldNode, BMap<BString, Object> record) {
-        BArray selections = fieldNode.getArrayValue(SELECTIONS_FIELD);
-        BMap<BString, Object> data = ValueCreator.createRecordValue(getModule(), DATA_RECORD);
-        for (int i = 0; i < selections.size(); i++) {
-            BObject subfieldNode = (BObject) selections.get(i);
-            BString fieldName = subfieldNode.getStringValue(NAME_FIELD);
-            Object fieldValue = record.get(fieldName);
-            if (fieldValue instanceof BMap) {
-                data.put(fieldName, getSelectionsFromRecord(subfieldNode, (BMap<BString, Object>) fieldValue));
-            } else {
-                data.put(fieldName, fieldValue);
-            }
-        }
-        return data;
     }
 
     private static ArrayType getDataRecordArrayType() {

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/engine/EngineUtils.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/engine/EngineUtils.java
@@ -194,7 +194,7 @@ public class EngineUtils {
             ArrayType arrayType = (ArrayType) type;
             SchemaType ofType = getSchemaTypeForBalType(arrayType.getElementType(), schema);
             String typeName = "[" + ofType.getName() + "]";
-            SchemaType schemaType = new SchemaType(typeName, TypeKind.LIST);
+            SchemaType schemaType = new SchemaType(typeName, TypeKind.NON_NULL);
             schemaType.setOfType(ofType);
             return schemaType;
         } else {

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/engine/EngineUtils.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/engine/EngineUtils.java
@@ -101,7 +101,6 @@ public class EngineUtils {
     static final String EXECUTE_SINGLE_RESOURCE_FUNCTION = "executeSingleResource";
 
     // Record Types
-    static final String LOCATION_RECORD = "Location";
     static final String ERROR_DETAIL_RECORD = "ErrorDetail";
     static final String DATA_RECORD = "Data";
 


### PR DESCRIPTION
## Purpose
With this PR, the GraphQL engine is able to respond introspection queries on the schema types.
Although it still does not support any other introspection query. This is tracked by [#832](https://github.com/ballerina-platform/ballerina-standard-library/issues/832)

Fixes: [#831](https://github.com/ballerina-platform/ballerina-standard-library/issues/831)
Fixes: [#697](https://github.com/ballerina-platform/ballerina-standard-library/issues/697)