### PR TITLE
Make suitable types non-public

### DIFF
--- a/graphql-ballerina/engine.bal
+++ b/graphql-ballerina/engine.bal
@@ -16,8 +16,7 @@
 
 import graphql.parser;
 
-# Represents the Ballerina GraphQL engine.
-public class Engine {
+class Engine {
     private Listener 'listener;
     private __Schema? schema;
     private Service? graphqlService;

--- a/graphql-ballerina/executor_visitor.bal
+++ b/graphql-ballerina/executor_visitor.bal
@@ -16,7 +16,7 @@
 
 import graphql.parser;
 
-public class ExecutorVisitor {
+class ExecutorVisitor {
     *parser:Visitor;
 
     private Service serviceType;
@@ -25,7 +25,7 @@ public class ExecutorVisitor {
     private ErrorDetail[] errors;
     private __Schema schema;
 
-    public isolated function init(Service serviceType, __Schema schema) {
+    isolated function init(Service serviceType, __Schema schema) {
         self.serviceType = serviceType;
         self.outputObject = {
             data: {},

--- a/graphql-ballerina/http_service.bal
+++ b/graphql-ballerina/http_service.bal
@@ -19,7 +19,7 @@ import ballerina/http;
 service class HttpService {
     private Engine engine;
 
-    public isolated function init(Engine engine) {
+    isolated function init(Engine engine) {
         self.engine = engine;
     }
 

--- a/graphql-ballerina/modules/parser/tests/to_record_visitor.bal
+++ b/graphql-ballerina/modules/parser/tests/to_record_visitor.bal
@@ -48,7 +48,7 @@ public type Document record {
     Operation[] operations;
 };
 
-public class RecordCreatorVisitor {
+class RecordCreatorVisitor {
     *Visitor;
 
     public isolated function visitDocument(DocumentNode documentNode) returns Document {

--- a/graphql-ballerina/records.bal
+++ b/graphql-ballerina/records.bal
@@ -16,6 +16,7 @@
 
 import graphql.parser;
 
+# Represents the data in an output object for a GraphQL query.
 public type Data record {
     // Intentionally kept empty
 };

--- a/graphql-ballerina/validator_visitor.bal
+++ b/graphql-ballerina/validator_visitor.bal
@@ -16,7 +16,7 @@
 
 import graphql.parser;
 
-public class ValidatorVisitor {
+class ValidatorVisitor {
     *parser:Visitor;
 
     private ErrorDetail[] errors;


### PR DESCRIPTION
## Purpose
Some of the types defined in GraphQL module shouldn't be public, even though some of them are marked as public in the initial implementation. With this PR, those types are marked as non-public.

Fixes: [#871](https://github.com/ballerina-platform/ballerina-standard-library/issues/871)