### PR TITLE
Add HTTP Listener Configs to the GraphQL Listener

### DIFF
--- a/graphql-ballerina/listener.bal
+++ b/graphql-ballerina/listener.bal
@@ -26,18 +26,24 @@ public class Listener {
     # provided to initialize the listener.
     #
     # + listenTo - An `http:Listener` or a port number to listen for the GraphQL service
-    public isolated function init(int|http:Listener listenTo) returns ListenerError? {
+    # + configuration - Configurations for the GraphQL service listener
+    public isolated function init(int|http:Listener listenTo, ListenerConfiguration? configuration = ())
+    returns ListenerError? {
         if (listenTo is int) {
-            http:Listener|error httpListener = new(listenTo);
+            http:Listener|error httpListener = new(listenTo, configuration);
             if (httpListener is error) {
                 return error ListenerError("Listener initialization failed", httpListener);
             } else {
                 self.httpListener = httpListener;
             }
         } else {
+            if (configuration is ListenerConfiguration) {
+                string message =
+                    "Provided listener configurations will be overridden by the http listener configurations";
+                return error ListenerError(message);
+            }
             self.httpListener = listenTo;
         }
-        // TODO: Decouple engine and the listener
         self.engine = new(self);
         self.httpService = new(self.engine);
     }

--- a/graphql-ballerina/records.bal
+++ b/graphql-ballerina/records.bal
@@ -14,7 +14,45 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/http;
 import graphql.parser;
+
+# Provides a set of configurations for the GraphQL listener endpoint.
+public type ListenerConfiguration record {|
+    *http:ListenerConfiguration;
+|};
+
+# Provides settings related to HTTP/1.x protocol, when using HTTP 1.x as the underlying protocol for the GraphQL
+# service.
+public type ListenerHttp1Settings record {|
+    *http:ListenerHttp1Settings;
+    // TODO: KeepAlive settings?
+|};
+
+# Configures the SSL/TLS options to be used for the underlying HTTP service used in GraphQL service.
+public type ListenerSecureSocket record {|
+    *http:ListenerSecureSocket;
+|};
+
+# Provides inbound request URI, total header and entity body size threshold configurations.
+public type RequestLimitConfigs record {|
+    *http:RequestLimitConfigs;
+|};
+
+# A record for configuring SSL/TLS protocol and version to be used for the undelying HTTP service.
+public type Protocols record {|
+    *http:Protocols;
+|};
+
+# A record for providing configurations for certificate revocation status checks.
+public type ValidateCert record {|
+    *http:ValidateCert;
+|};
+
+# A record for providing configurations for validate the certificate chain from the root CA.
+public type ListenerOcspStapling record {|
+    *http:ListenerOcspStapling;
+|};
 
 # Represents the data in an output object for a GraphQL query.
 public type Data record {

--- a/graphql-ballerina/tests/12_listener_configurations_test.bal
+++ b/graphql-ballerina/tests/12_listener_configurations_test.bal
@@ -1,0 +1,58 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/lang.runtime;
+import ballerina/test;
+
+ListenerConfiguration configs = {
+    timeoutInMillis: 1000,
+    server: "TIMEOUT_SERVER"
+};
+listener Listener timeoutListener = new(9102, configs);
+
+service /timeoutServer on timeoutListener {
+    isolated resource function get greet() returns string {
+        runtime:sleep(3);
+        return "Hello";
+    }
+}
+
+@test:Config {
+    groups: ["listenerConfigs", "unit"]
+}
+function testTimeoutResponse() returns error? {
+    string document = "{ greet }";
+    json payload = {
+        query: document
+    };
+    http:Client httpClient = check new("http://localhost:9102/timeoutServer");
+    http:Request request = new;
+    request.setPayload(payload);
+
+    var response = check httpClient->post("/", request);
+    if (response is http:Response) {
+        int statusCode = response.statusCode;
+        test:assertEquals(statusCode, 408, msg = "Unexpected status code received: " + statusCode.toString());
+
+        var textPayload = response.getTextPayload();
+        string expectedMessage = "Idle timeout triggered before initiating outbound response";
+        string actualPaylaod = textPayload is error? textPayload.toString() : textPayload.toString();
+        test:assertEquals(actualPaylaod, expectedMessage);
+    }
+}
+
+

--- a/graphql-ballerina/tests/12_listener_configurations_test.bal
+++ b/graphql-ballerina/tests/12_listener_configurations_test.bal
@@ -52,6 +52,22 @@ function testTimeoutResponse() returns error? {
         string expectedMessage = "Idle timeout triggered before initiating outbound response";
         string actualPaylaod = textPayload is error? textPayload.toString() : textPayload.toString();
         test:assertEquals(actualPaylaod, expectedMessage);
+    } else {
+        test:assertFail("HTTP response expected");
+    }
+}
+
+@test:Config {
+    groups: ["negative", "listenerConfigs", "unit"]
+}
+function testConfigurationsWithHttpListener() returns error? {
+    http:Listener httpListener = check new(91021);
+    var graphqlListener = new Listener(httpListener, configs);
+    if (graphqlListener is ListenerError) {
+        string message = "Provided listener configurations will be overridden by the http listener configurations";
+        test:assertEquals(message, graphqlListener.message());
+    } else {
+        test:assertFail("This must throw an error");
     }
 }
 


### PR DESCRIPTION
## Purpose
With this PR, developers can pass the configurations related to http listener, when creating a graphql listener without using the http listener configs.

#### Example

```ballerina
import ballerina/graphql;

graphql:ListenerConfiguration configs = {
    timeoutInMillis: 5000
    // We can add any configuration related to the http listener here
};

service /graphql on new graphql:Listener(9090, configs) {
    // resources
}
```

Added a simple test to check whether the configs are passed properly, since all the other configs acts same.

Fixes: [#934](https://github.com/ballerina-platform/ballerina-standard-library/issues/934)