### PR TITLE
Add max query depth validation for graphql queries

### DIFF
--- a/graphql-ballerina/engine.bal
+++ b/graphql-ballerina/engine.bal
@@ -26,15 +26,16 @@ class Engine {
         self.'listener = 'listener;
         self.schema = ();
         self.graphqlService = ();
-        var maxQueryDepth = trap configs?.maxQueryDepth;
-        if (maxQueryDepth is int) {
-            if (maxQueryDepth < 1) {
-                string message = "Maximum query depth should be an integer greater than 0";
-                return error ListenerError(message);
+        self.maxQueryDepth = 0;
+        if (configs is ListenerConfiguration) {
+            var maxQueryDepth = configs?.maxQueryDepth;
+            if (maxQueryDepth is int) {
+                if (maxQueryDepth < 1) {
+                    string message = "Maximum query depth should be an integer greater than 0";
+                    return error ListenerError(message);
+                }
+                self.maxQueryDepth = maxQueryDepth;
             }
-            self.maxQueryDepth = maxQueryDepth;
-        } else {
-            self.maxQueryDepth = 0;
         }
     }
 

--- a/graphql-ballerina/listener.bal
+++ b/graphql-ballerina/listener.bal
@@ -30,7 +30,7 @@ public class Listener {
     public isolated function init(int|http:Listener listenTo, ListenerConfiguration? configuration = ())
     returns ListenerError? {
         if (listenTo is int) {
-            http:Listener|error httpListener = new(listenTo, configuration);
+            http:Listener|error httpListener = new(listenTo, configuration?.httpConfiguration);
             if (httpListener is error) {
                 return error ListenerError("Listener initialization failed", httpListener);
             } else {
@@ -38,13 +38,15 @@ public class Listener {
             }
         } else {
             if (configuration is ListenerConfiguration) {
-                string message =
-                    "Provided listener configurations will be overridden by the http listener configurations";
-                return error ListenerError(message);
+                if (configuration?.httpConfiguration is HttpConfiguration) {
+                    string message =
+                        "Provided `HttpConfiguration` will be overridden by the given http listener configurations";
+                    return error ListenerError(message);
+                }
             }
             self.httpListener = listenTo;
         }
-        self.engine = new(self);
+        self.engine = check new(self, configuration);
         self.httpService = new(self.engine);
     }
 

--- a/graphql-ballerina/modules/parser/operation_node.bal
+++ b/graphql-ballerina/modules/parser/operation_node.bal
@@ -19,12 +19,22 @@ public class OperationNode {
     private RootOperationType kind;
     private Location location;
     private FieldNode[] selections;
+    private int depth;
 
     public isolated function init(string name, RootOperationType kind, Location location) {
         self.name = name;
         self.kind = kind;
         self.location = location;
         self.selections = [];
+        self.depth = 0;
+    }
+
+    public isolated function getDepth() returns int {
+        return self.depth;
+    }
+
+    public isolated function setDepth(int depth) {
+        self.depth = depth;
     }
 
     public isolated function getName() returns string {

--- a/graphql-ballerina/modules/parser/operation_node.bal
+++ b/graphql-ballerina/modules/parser/operation_node.bal
@@ -19,22 +19,22 @@ public class OperationNode {
     private RootOperationType kind;
     private Location location;
     private FieldNode[] selections;
-    private int depth;
+    private int maxDepth;
 
     public isolated function init(string name, RootOperationType kind, Location location) {
         self.name = name;
         self.kind = kind;
         self.location = location;
         self.selections = [];
-        self.depth = 0;
+        self.maxDepth = 0;
     }
 
-    public isolated function getDepth() returns int {
-        return self.depth;
+    public isolated function getMaxDepth() returns int {
+        return self.maxDepth;
     }
 
-    public isolated function setDepth(int depth) {
-        self.depth = depth;
+    public isolated function setMaxDepth(int depth) {
+        self.maxDepth = depth;
     }
 
     public isolated function getName() returns string {

--- a/graphql-ballerina/modules/parser/parser.bal
+++ b/graphql-ballerina/modules/parser/parser.bal
@@ -17,6 +17,8 @@
 public class Parser {
     private Lexer lexer;
     private DocumentNode document;
+    private int depth = 0;
+    private int highestDepth = 0;
 
     public isolated function init(string text) {
         self.lexer = new(text);
@@ -51,7 +53,7 @@ public class Parser {
 
     isolated function parseAnonymousOperation() returns Error? {
         Token token = check self.peekNextNonSeparatorToken();
-        OperationNode operation = check self.createOperationRecord(ANONYMOUS_OPERATION, QUERY, token.location);
+        OperationNode operation = check self.createOperationNode(ANONYMOUS_OPERATION, QUERY, token.location);
         self.addOperationToDocument(operation);
     }
 
@@ -64,25 +66,29 @@ public class Parser {
         token = check self.peekNextNonSeparatorToken();
         TokenType tokenType = token.kind;
         if (tokenType == T_OPEN_BRACE) {
-            OperationNode operation = check self.createOperationRecord(operationName, operationType, location);
+            OperationNode operation = check self.createOperationNode(operationName, operationType, location);
             self.addOperationToDocument(operation);
         } else {
             return getExpectedCharError(token, OPEN_BRACE);
         }
     }
 
-    isolated function createOperationRecord(string name, RootOperationType kind, Location location)
+    isolated function createOperationNode(string name, RootOperationType kind, Location location)
     returns OperationNode|Error {
+        self.depth = 0;
+        self.highestDepth = 0;
         OperationNode operation = new(name, kind, location);
         check self.addSelections(operation);
+        operation.setDepth(self.highestDepth);
         return operation;
     }
 
     isolated function addSelections(ParentType parentNode) returns Error? {
         Token token = check self.readNextNonSeparatorToken(); // Read the open brace here
+        self.depth += 1;
         while (token.kind != T_CLOSE_BRACE) {
             token = check self.readNextNonSeparatorToken();
-            string name = check getStringTokenvalue(token);
+            string name = check getIdentifierTokenvalue(token);
             FieldNode fieldNode = new(name, token.location);
             token = check self.peekNextNonSeparatorToken();
             if (token.kind == T_OPEN_PARENTHESES) {
@@ -96,6 +102,10 @@ public class Parser {
             parentNode.addSelection(fieldNode);
             token = check self.peekNextNonSeparatorToken();
         }
+        if (self.highestDepth < self.depth) {
+            self.highestDepth = self.depth;
+        }
+        self.depth -= 1;
         // If it comes to this, token.kind == T_CLOSE_BRACE. We consume it
         token = check self.readNextNonSeparatorToken();
     }
@@ -191,7 +201,7 @@ isolated function getOperationNameFromToken(Parser parser) returns string|Error 
     return getUnexpectedTokenError(token);
 }
 
-isolated function getStringTokenvalue(Token token) returns string|Error {
+isolated function getIdentifierTokenvalue(Token token) returns string|Error {
     if (token.kind == T_TEXT) {
         return <string>token.value;
     } else {

--- a/graphql-ballerina/modules/parser/parser.bal
+++ b/graphql-ballerina/modules/parser/parser.bal
@@ -18,7 +18,7 @@ public class Parser {
     private Lexer lexer;
     private DocumentNode document;
     private int depth = 0;
-    private int highestDepth = 0;
+    private int operationMaxDepth = 0;
 
     public isolated function init(string text) {
         self.lexer = new(text);
@@ -76,10 +76,10 @@ public class Parser {
     isolated function createOperationNode(string name, RootOperationType kind, Location location)
     returns OperationNode|Error {
         self.depth = 0;
-        self.highestDepth = 0;
+        self.operationMaxDepth = 0;
         OperationNode operation = new(name, kind, location);
         check self.addSelections(operation);
-        operation.setDepth(self.highestDepth);
+        operation.setMaxDepth(self.operationMaxDepth);
         return operation;
     }
 
@@ -102,8 +102,8 @@ public class Parser {
             parentNode.addSelection(fieldNode);
             token = check self.peekNextNonSeparatorToken();
         }
-        if (self.highestDepth < self.depth) {
-            self.highestDepth = self.depth;
+        if (self.operationMaxDepth < self.depth) {
+            self.operationMaxDepth = self.depth;
         }
         self.depth -= 1;
         // If it comes to this, token.kind == T_CLOSE_BRACE. We consume it

--- a/graphql-ballerina/records.bal
+++ b/graphql-ballerina/records.bal
@@ -18,7 +18,16 @@ import ballerina/http;
 import graphql.parser;
 
 # Provides a set of configurations for the GraphQL listener endpoint.
+#
+# + httpConfiguration - Configurations related to underlying HTTP service
+# + maxQueryDepth - The maximum depth allowed for a query
 public type ListenerConfiguration record {|
+    HttpConfiguration httpConfiguration?;
+    int maxQueryDepth?;
+|};
+
+# Provides a set of configurations related to the underlying HTTP service.
+public type HttpConfiguration record {|
     *http:ListenerConfiguration;
 |};
 

--- a/graphql-ballerina/tests/12_listener_configurations_test.bal
+++ b/graphql-ballerina/tests/12_listener_configurations_test.bal
@@ -21,12 +21,19 @@ import ballerina/test;
 ListenerConfiguration configs = {
     httpConfiguration: {
         timeoutInMillis: 1000
-    },
-    maxQueryDepth: 2
+    }
 };
 listener Listener timeoutListener = new(9102, configs);
+listener Listener depthLimitListener = new(9103, { maxQueryDepth: 2 });
 
-service /timeoutServer on timeoutListener {
+service /timeoutService on timeoutListener {
+    isolated resource function get greet() returns string {
+        runtime:sleep(3);
+        return "Hello";
+    }
+}
+
+service /depthLimitService on depthLimitListener {
     isolated resource function get greet() returns string {
         runtime:sleep(3);
         return "Hello";
@@ -41,7 +48,7 @@ function testTimeoutResponse() returns error? {
     json payload = {
         query: document
     };
-    http:Client httpClient = check new("http://localhost:9102/timeoutServer");
+    http:Client httpClient = check new("http://localhost:9102/timeoutService");
     http:Request request = new;
     request.setPayload(payload);
 
@@ -94,7 +101,7 @@ function testQueryExceedingMaxDepth() returns error? {
     json payload = {
         query: document
     };
-    http:Client httpClient = check new("http://localhost:9102/timeoutServer");
+    http:Client httpClient = check new("http://localhost:9103/depthLimitService");
     http:Request request = new;
     request.setPayload(payload);
 

--- a/graphql-ballerina/validator_visitor.bal
+++ b/graphql-ballerina/validator_visitor.bal
@@ -21,10 +21,12 @@ class ValidatorVisitor {
 
     private ErrorDetail[] errors;
     private __Schema schema;
+    private int maxQueryDepth;
 
-    public isolated function init(__Schema schema) {
+    public isolated function init(__Schema schema, int maxQueryDepth) {
         self.errors = [];
         self.schema = schema;
+        self.maxQueryDepth = maxQueryDepth;
     }
 
     public isolated function validate(parser:DocumentNode documentNode) {
@@ -47,6 +49,13 @@ class ValidatorVisitor {
     }
 
     public isolated function visitOperation(parser:OperationNode operationNode) {
+        if (self.maxQueryDepth > 0 && operationNode.getDepth() > self.maxQueryDepth) {
+            string depthString = operationNode.getDepth().toString();
+            string message = "Query has depth of " + depthString + ", which exceeds max depth of " +
+                            self.maxQueryDepth.toString();
+            self.errors.push(getErrorDetailRecord(message, operationNode.getLocation()));
+            return;
+        }
         parser:FieldNode[] selections = operationNode.getSelections();
         foreach parser:FieldNode selection in selections {
             if (selection.getName() == SCHEMA_FIELD) {

--- a/graphql-ballerina/validator_visitor.bal
+++ b/graphql-ballerina/validator_visitor.bal
@@ -49,8 +49,8 @@ class ValidatorVisitor {
     }
 
     public isolated function visitOperation(parser:OperationNode operationNode) {
-        if (self.maxQueryDepth > 0 && operationNode.getDepth() > self.maxQueryDepth) {
-            string depthString = operationNode.getDepth().toString();
+        if (self.maxQueryDepth > 0 && operationNode.getMaxDepth() > self.maxQueryDepth) {
+            string depthString = operationNode.getMaxDepth().toString();
             string message = "Query has depth of " + depthString + ", which exceeds max depth of " +
                             self.maxQueryDepth.toString();
             self.errors.push(getErrorDetailRecord(message, operationNode.getLocation()));


### PR DESCRIPTION
## Purpose
GraphQL endpoints can be secured in many ways. One of the popular method is to limit the depth of an accepted query before executing it. This way, we can avoid queries which may be too deep.

With this PR, a new configuration `maxQueryDepth` is introduced to meet this requirement. The `graphql:ListenerConfiguration` now have a `maxQueryDepth` field. We can provide any integer value greater than zero to this field. Then when a document is received, at the validation phase, the query will be validated for its depth and if the depth of the query exceeds the provided maximum depth, the execution will not occur.

#### Example

Consider the following example, where there is a cyclic reference between the Book and the Author records.

```ballerina
import ballerina/graphql;

graphql:ListenerConfiguration configs = { maxQueryDepth: 3 }
listener graphql:Listener graphqlListener = new(9090, configs);

service /graphql on graphqlListener {
    isolated resource function get book(int id) returns Book {
        // Get Book record from somewhere and return
    }
}

type Book record {|
    string title;
    Author author;
|};

type Author record {|
    string name;
    Book[] books;
|};
```

Someone can exploit this cyclic reference to send a too deep query in order to break the service. But notice the `maxQueryDepth` field in the `graphql:ListenerConfiguration` record. This limits the maximum depth of a query to 5.

Consider the following query:

```
{
    book(id: 1) {
        author {
            books {
                author {
                    books {
                        author {
                            books {
                                author {
                                    // This can go on like this forever
                                    name
                                }
                            }
                        }
                    }
                }
            }
        }
    }
}
```

If we do not provide a maximum depth for a query, the GraphQL service will validate this query as a valid query, hence it will execute this (which may probably requires a heavy load of DB queries). But with the maximum depth limit, the validation of this query fails and the following response will be returned to the client:

```json
{
    "errors": [
        {
            "message": "Query has depth of 9, which exceeds max depth of 3",
            "locations": [
                {
                    "line": 1,
                    "column": 1
                }
            ]
        }
    ]
}
```

Fixes: [#938](https://github.com/ballerina-platform/ballerina-standard-library/issues/938)