### PR TITLE
Move the maxQueryDepth Configuration to Service Level

### DIFF
--- a/graphql-ballerina/annotation_processor.bal
+++ b/graphql-ballerina/annotation_processor.bal
@@ -1,0 +1,36 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+isolated function getMaxQueryDepth(Service serviceObject) returns int|InvalidConfigurationError {
+    GraphqlServiceConfiguration? serviceConfig = getServiceConfiguration(serviceObject);
+    if (serviceConfig is GraphqlServiceConfiguration) {
+        if (serviceConfig?.maxQueryDepth is int) {
+            int maxQueryDepth = <int>serviceConfig?.maxQueryDepth;
+            if (maxQueryDepth < 1) {
+                string message = "Maximum query depth should be an integer greater than 0";
+                return error InvalidConfigurationError(message);
+            }
+            return maxQueryDepth;
+        }
+    }
+    return 0;
+}
+
+isolated function getServiceConfiguration(Service serviceObject) returns GraphqlServiceConfiguration? {
+    typedesc<any> serviceType = typeof serviceObject;
+    var serviceConfiguration = serviceType.@ServiceConfiguration;
+    return serviceConfiguration;
+}

--- a/graphql-ballerina/annotations.bal
+++ b/graphql-ballerina/annotations.bal
@@ -1,0 +1,26 @@
+// Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+# Provides a set of configurations for the GraphQL service.
+#
+# + maxQueryDepth - The maximum depth allowed for a query
+public type GraphqlServiceConfiguration record {|
+    int maxQueryDepth?;
+|};
+
+# The annotation to configure a GraphQL service.
+public annotation GraphqlServiceConfiguration ServiceConfiguration on service;

--- a/graphql-ballerina/engine.bal
+++ b/graphql-ballerina/engine.bal
@@ -22,21 +22,11 @@ class Engine {
     private Service? graphqlService;
     private int maxQueryDepth;
 
-    public isolated function init(Listener 'listener, ListenerConfiguration? configs = ()) returns ListenerError? {
+    public isolated function init(Listener 'listener) returns ListenerError? {
         self.'listener = 'listener;
         self.schema = ();
         self.graphqlService = ();
         self.maxQueryDepth = 0;
-        if (configs is ListenerConfiguration) {
-            var maxQueryDepth = configs?.maxQueryDepth;
-            if (maxQueryDepth is int) {
-                if (maxQueryDepth < 1) {
-                    string message = "Maximum query depth should be an integer greater than 0";
-                    return error ListenerError(message);
-                }
-                self.maxQueryDepth = maxQueryDepth;
-            }
-        }
     }
 
     isolated function getOutputObjectForQuery(string documentString, string operationName) returns OutputObject {

--- a/graphql-ballerina/engine.bal
+++ b/graphql-ballerina/engine.bal
@@ -57,9 +57,11 @@ class Engine {
         }
     }
 
-    isolated function registerService(Service s) {
+    isolated function registerService(Service s) returns ListenerError? {
         self.graphqlService = s;
         self.schema = createSchema(s);
+        GraphqlServiceConfiguration? serviceConfig = getServiceConfiguration(s);
+        self.maxQueryDepth = check getMaxQueryDepth(s);
         self.populateSchemaType();
     }
 

--- a/graphql-ballerina/errors.bal
+++ b/graphql-ballerina/errors.bal
@@ -17,14 +17,20 @@
 import graphql.parser;
 
 // General errors
-# Represents an error occurred while a listener operation
-public type ListenerError distinct error;
-
 # Represents a non-implemented feature error
 public type NotImplementedError distinct error;
 
 # Represents an unsupported functionality error
 public type NotSupportedError distinct error;
+
+# Represents an error due to invalid configurations
+public type InvalidConfigurationError distinct error;
+
+# Represents an error occurred in the listener while handling a service
+public type ServiceHandlingError distinct error;
+
+# Represents an error occurred while a listener operation
+public type ListenerError InvalidConfigurationError|ServiceHandlingError;
 
 // Validation errors
 # Represents an error where multiple operations with the same name exists

--- a/graphql-ballerina/listener.bal
+++ b/graphql-ballerina/listener.bal
@@ -32,7 +32,7 @@ public class Listener {
         if (listenTo is int) {
             http:Listener|error httpListener = new(listenTo, configuration);
             if (httpListener is error) {
-                return error ListenerError("Listener initialization failed", httpListener);
+                return error ServiceHandlingError("Listener initialization failed", httpListener);
             } else {
                 self.httpListener = httpListener;
             }
@@ -40,7 +40,7 @@ public class Listener {
             if (configuration is ListenerConfiguration) {
                 string message =
                     "Provided `HttpConfiguration` will be overridden by the given http listener configurations";
-                return error ListenerError(message);
+                return error InvalidConfigurationError(message);
             }
             self.httpListener = listenTo;
         }
@@ -56,9 +56,9 @@ public class Listener {
     public isolated function attach(Service s, string[]|string? name = ()) returns ListenerError? {
         error? result = self.httpListener.attach(self.httpService, name);
         if (result is error) {
-            return error ListenerError("Error occurred while attaching the service", result);
+            return error ServiceHandlingError("Error occurred while attaching the service", result);
         }
-        self.engine.registerService(s);
+        check self.engine.registerService(s);
     }
 
     # Detaches the provided service from the Listener.
@@ -68,7 +68,7 @@ public class Listener {
     public isolated function detach(Service s) returns ListenerError? {
         error? result = self.httpListener.detach(self.httpService);
         if (result is error) {
-            return error ListenerError("Error occurred while detaching the service", result);
+            return error ServiceHandlingError("Error occurred while detaching the service", result);
         }
     }
 
@@ -78,7 +78,7 @@ public class Listener {
     public isolated function 'start() returns ListenerError? {
         error? result = self.httpListener.'start();
         if (result is error) {
-            return error ListenerError("Error occurred while starting the service", result);
+            return error ServiceHandlingError("Error occurred while starting the service", result);
         }
     }
 
@@ -88,7 +88,7 @@ public class Listener {
     public isolated function gracefulStop() returns ListenerError? {
         error? result = self.httpListener.gracefulStop();
         if (result is error) {
-            return error ListenerError("Error occurred while stopping the service", result);
+            return error ServiceHandlingError("Error occurred while stopping the service", result);
         }
     }
 
@@ -98,7 +98,7 @@ public class Listener {
     public isolated function immediateStop() returns ListenerError? {
         error? result = self.httpListener.immediateStop();
         if (result is error) {
-            return error ListenerError("Error occurred while stopping the service", result);
+            return error ServiceHandlingError("Error occurred while stopping the service", result);
         }
     }
 }

--- a/graphql-ballerina/listener.bal
+++ b/graphql-ballerina/listener.bal
@@ -30,7 +30,7 @@ public class Listener {
     public isolated function init(int|http:Listener listenTo, ListenerConfiguration? configuration = ())
     returns ListenerError? {
         if (listenTo is int) {
-            http:Listener|error httpListener = new(listenTo, configuration?.httpConfiguration);
+            http:Listener|error httpListener = new(listenTo, configuration);
             if (httpListener is error) {
                 return error ListenerError("Listener initialization failed", httpListener);
             } else {
@@ -38,15 +38,13 @@ public class Listener {
             }
         } else {
             if (configuration is ListenerConfiguration) {
-                if (configuration?.httpConfiguration is HttpConfiguration) {
-                    string message =
-                        "Provided `HttpConfiguration` will be overridden by the given http listener configurations";
-                    return error ListenerError(message);
-                }
+                string message =
+                    "Provided `HttpConfiguration` will be overridden by the given http listener configurations";
+                return error ListenerError(message);
             }
             self.httpListener = listenTo;
         }
-        self.engine = check new(self, configuration);
+        self.engine = check new(self);
         self.httpService = new(self.engine);
     }
 

--- a/graphql-ballerina/records.bal
+++ b/graphql-ballerina/records.bal
@@ -17,14 +17,7 @@
 import ballerina/http;
 import graphql.parser;
 
-# Provides a set of configurations for the GraphQL listener endpoint.
-#
-# + maxQueryDepth - The maximum depth allowed for a query
-public type ServiceConfiguration record {|
-    int maxQueryDepth?;
-|};
-
-# Provides a set of configurations for the GraphQL listener endpoint.
+# Provides a set of configurations for configure the underlying HTTP listener of the GraphQL listener.
 public type ListenerConfiguration record {|
     *http:ListenerConfiguration;
 |};

--- a/graphql-ballerina/records.bal
+++ b/graphql-ballerina/records.bal
@@ -19,15 +19,13 @@ import graphql.parser;
 
 # Provides a set of configurations for the GraphQL listener endpoint.
 #
-# + httpConfiguration - Configurations related to underlying HTTP service
 # + maxQueryDepth - The maximum depth allowed for a query
-public type ListenerConfiguration record {|
-    HttpConfiguration httpConfiguration?;
+public type ServiceConfiguration record {|
     int maxQueryDepth?;
 |};
 
-# Provides a set of configurations related to the underlying HTTP service.
-public type HttpConfiguration record {|
+# Provides a set of configurations for the GraphQL listener endpoint.
+public type ListenerConfiguration record {|
     *http:ListenerConfiguration;
 |};
 

--- a/graphql-ballerina/tests/12_listener_configurations_test.bal
+++ b/graphql-ballerina/tests/12_listener_configurations_test.bal
@@ -19,12 +19,10 @@ import ballerina/lang.runtime;
 import ballerina/test;
 
 ListenerConfiguration configs = {
-    httpConfiguration: {
-        timeoutInMillis: 1000
-    }
+    timeoutInMillis: 1000
 };
 listener Listener timeoutListener = new(9102, configs);
-listener Listener depthLimitListener = new(9103, { maxQueryDepth: 2 });
+listener Listener depthLimitListener = new(9103);
 
 service /timeoutService on timeoutListener {
     isolated resource function get greet() returns string {
@@ -81,10 +79,12 @@ function testConfigurationsWithHttpListener() returns error? {
 }
 
 @test:Config {
-    groups: ["negative", "configs", "unit"]
+    groups: ["negative", "configs", "unit"],
+    enable: false
 }
 isolated function testInvalidMaxDepth() returns error? {
-    var graphqlListener = new Listener(91022, { maxQueryDepth: 0 });
+    //var graphqlListener = new Listener(91022, { maxQueryDepth: 0 });
+    var graphqlListener = new Listener(91022);
     if (graphqlListener is ListenerError) {
         string message = "Maximum query depth should be an integer greater than 0";
         test:assertEquals(message, graphqlListener.message());
@@ -94,7 +94,8 @@ isolated function testInvalidMaxDepth() returns error? {
 }
 
 @test:Config {
-    groups: ["configs", "unit"]
+    groups: ["configs", "unit"],
+    enable: false
 }
 function testQueryExceedingMaxDepth() returns error? {
     string document = "{ book { author { books { author { books } } } } }";


### PR DESCRIPTION
## Purpose
With this PR, the `maxQueryDepth` config will be moved to the service annotation, instead of the `ListenerConfiguration`. 

Now when creating a service, the max query depth can be provided as follows:

```ballerina
import ballerina/graphql;

listener graphql:Listener graphqlListener = new(9090);

@graphql:ServiceConfiguration {
    maxQueryDepth: 2
}
service /graphql on depthLimitListener {
    isolated resource function get greet() returns string {
        return "Hello";
    }
}
```

The `maxQueryDepth` should be an integer greater than `1`. If the provided value is lesser than `1`, a `ListenerError` will be thrown at the runtime.

Related PR(s): #66 
Fixes: [#938](https://github.com/ballerina-platform/ballerina-standard-library/issues/938)