### PR TITLE
Remove Jacoco XML Report Generation Gradle Tasks

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -31,7 +31,6 @@ jobs:
                     packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
                 run: |
                     ./gradlew publish --no-daemon --scan
-                    ./gradlew codeCoverageReport --no-daemon
 
             -   name: Archive Error Log
                 uses: actions/upload-artifact@v2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,7 +21,6 @@ jobs:
                     packagePAT: ${{ secrets.GITHUB_TOKEN }}
                 run: |
                     ./gradlew build --no-daemon --scan
-                    ./gradlew codeCoverageReport --no-daemon
 
             -   name: Archive Error Log
                 uses: actions/upload-artifact@v2

--- a/build.gradle
+++ b/build.gradle
@@ -233,26 +233,3 @@ subprojects {
     }
 }
 
-task codeCoverageReport(type: JacocoReport) {
-    dependsOn('graphql-native:copyJavaClassFiles')
-    dependsOn('graphql-ballerina:extractBallerinaClassFiles')
-    
-    executionData fileTree(project.rootDir.absolutePath).include("**/target/cache/tests_cache/coverage/ballerina.exec")
-    additionalClassDirs files("${buildDir}/classes")
-    
-    subprojects.each {
-        sourceSets it.sourceSets.main
-    }
-    
-    reports {
-        xml.enabled = true
-        html.enabled = true
-        xml.destination = new File("${buildDir}/reports/jacoco/report.xml")
-        html.destination = new File("${buildDir}/reports/jacoco/report.html")
-    }
-
-    onlyIf = {
-        true
-    }
-}
-

--- a/graphql-ballerina/build.gradle
+++ b/graphql-ballerina/build.gradle
@@ -273,20 +273,6 @@ publishing {
     }
 }
 
-task extractBallerinaClassFiles(type: Copy) {
-    def jars = fileTree(artifactTestableJar).findAll {
-        it.name.endsWith("-testable.jar")
-    }
-
-    jars.forEach { file ->
-        from zipTree(file).matching {
-            exclude '**/tests/*'
-            include '**/*.class'
-        }
-        into "${project.rootDir.absolutePath}/build/classes"
-    }
-}
-
 unpackStdLibs.dependsOn unpackJballerinaTools
 copyStdlibs.dependsOn unpackStdLibs
 updateTomlFile.dependsOn copyStdlibs

--- a/graphql-native/build.gradle
+++ b/graphql-native/build.gradle
@@ -71,11 +71,3 @@ compileJava {
     }
 }
 
-task copyJavaClassFiles(type: Copy) {
-    from("${project.buildDir}/classes") {
-        exclude '**/module-info.class'
-        include '**/*.class'
-    }
-    into "${project.rootDir.absolutePath}/build/classes"
-}
-


### PR DESCRIPTION
- With this change only testerina generated XML will be used for the codecov coverage report