### PR TITLE
Add Support to Return Optional type from Resource Functions

### DIFF
--- a/graphql-ballerina/engine_utils.bal
+++ b/graphql-ballerina/engine_utils.bal
@@ -44,7 +44,7 @@ isolated function createSchema(Service s) returns __Schema|Error = @java:Method 
 } external;
 
 isolated function executeResource(Service s, ExecutorVisitor visitor, parser:FieldNode fieldNode)
-returns anydata = @java:Method {
+returns anydata|error = @java:Method {
     'class: "io.ballerina.stdlib.graphql.engine.Engine"
 } external;
 

--- a/graphql-ballerina/executor_visitor.bal
+++ b/graphql-ballerina/executor_visitor.bal
@@ -68,14 +68,14 @@ class ExecutorVisitor {
                 }
             } else {
                 var fieldResult = self.visitField(fieldNode, self.data);
-                if (fieldResult != ()) {
+                if (fieldResult is anydata) {
                     self.data[fieldNode.getName()] = fieldResult;
                 }
             }
         }
     }
 
-    public isolated function visitField(parser:FieldNode fieldNode, anydata data = ()) returns anydata {
+    public isolated function visitField(parser:FieldNode fieldNode, anydata data = ()) returns anydata|error {
         return executeResource(self.serviceType, self, fieldNode);
     }
 

--- a/graphql-ballerina/tests/08_resources_returning_union_types.bal
+++ b/graphql-ballerina/tests/08_resources_returning_union_types.bal
@@ -38,9 +38,11 @@ Service serviceWithInvalidUnionTypes = service object {
 };
 
 service /graphql on new Listener(9098) {
-    resource function get profile(int id) returns Person|error {
+    resource function get profile(int id) returns Person|error? {
         if (id < people.length()) {
             return people[id];
+        } else if (id < 5) {
+            return;
         } else {
             return error("Invalid ID provided");
         }
@@ -67,6 +69,22 @@ public function testResourceReturningUnionTypes() returns @tainted error? {
                 ]
             }
         ]
+    };
+    test:assertEquals(result, expectedPayload);
+}
+
+@test:Config {
+    groups: ["test", "service", "unit"]
+}
+public function testResourceReturningUnionWithNull() returns @tainted error? {
+    string graphqlUrl = "http://localhost:9098/graphql";
+    string document = "{ profile (id: 4) { name } }";
+    json result = check getJsonPayloadFromService(graphqlUrl, document);
+
+    json expectedPayload = {
+        data: {
+            profile: null
+        }
     };
     test:assertEquals(result, expectedPayload);
 }

--- a/graphql-ballerina/tests/12_hierarchical_resource_paths.bal
+++ b/graphql-ballerina/tests/12_hierarchical_resource_paths.bal
@@ -94,7 +94,7 @@ function testHierarchicalResourcePathsComplete() returns error? {
 }
 
 @test:Config {
-    groups: ["test", "negative", "hierarchicalPaths", "unit"]
+    groups: ["negative", "hierarchicalPaths", "unit"]
 }
 function testInvalidHierarchicalResourcePaths() returns error? {
     string document = "{ profile { name { first middle } } }";

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/engine/Engine.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/engine/Engine.java
@@ -102,6 +102,7 @@ public class Engine {
         if (result instanceof BError) {
             BArray errors = visitor.getArrayValue(ERRORS_FIELD);
             errors.append(getErrorDetailRecord((BError) result, fieldNode));
+            return result;
         } else if (result instanceof BMap) {
             BMap<BString, Object> resultRecord = (BMap<BString, Object>) result;
             return getDataFromRecord(fieldNode, resultRecord);
@@ -112,7 +113,6 @@ public class Engine {
         } else {
             return result;
         }
-        return null;
     }
 
     public static Object getDataFromBalType(BObject fieldNode, Object data) {
@@ -141,7 +141,7 @@ public class Engine {
 
     private static BMap<BString, Object> getDataFromRecord(BObject fieldNode, BMap<BString, Object> record) {
         BArray selections = fieldNode.getArrayValue(SELECTIONS_FIELD);
-        BMap<BString, Object> data = ValueCreator.createRecordValue(getModule(), DATA_RECORD);
+        BMap<BString, Object> data = createDataRecord();
         for (int i = 0; i < selections.size(); i++) {
             BObject subfieldNode = (BObject) selections.get(i);
             BString fieldName = subfieldNode.getStringValue(NAME_FIELD);
@@ -160,7 +160,7 @@ public class Engine {
     private static BMap<BString, Object> getDataFromService(Environment environment, BObject service, BObject visitor,
                                                             BObject fieldNode) {
         BArray selections = fieldNode.getArrayValue(SELECTIONS_FIELD);
-        BMap<BString, Object> data = ValueCreator.createRecordValue(getModule(), DATA_RECORD);
+        BMap<BString, Object> data = createDataRecord();
         for (int i = 0; i < selections.size(); i++) {
             BObject subField = (BObject) selections.get(i);
             Object subFieldValue = executeResource(environment, service, visitor, subField);
@@ -194,7 +194,11 @@ public class Engine {
     }
 
     private static ArrayType getDataRecordArrayType() {
-        BMap<BString, Object> data = ValueCreator.createRecordValue(getModule(), DATA_RECORD);
+        BMap<BString, Object> data = createDataRecord();
         return TypeCreator.createArrayType(data.getType());
+    }
+
+    private static BMap<BString, Object> createDataRecord() {
+        return ValueCreator.createRecordValue(getModule(), DATA_RECORD);
     }
 }


### PR DESCRIPTION
## Purpose
$Subject

With this PR, resource functions with optional return values are supported. 

### Examples

```ballerina
import ballerina/graphql;

service /graphql on new graphql:Listener(9090) {
    resource function get profile(int id) returns Person|error? {
        // ...
    }
}
```

Fixes: [#912](https://github.com/ballerina-platform/ballerina-standard-library/issues/912)