### PR TITLE
Add Support for Ballerina Table Types

### DIFF
--- a/graphql-ballerina/tests/13_resources_returninng_tables.bal
+++ b/graphql-ballerina/tests/13_resources_returninng_tables.bal
@@ -1,0 +1,75 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+service /graphql on new Listener(9105) {
+    resource function get employees() returns EmployeeTable? {
+        return employees;
+    }
+}
+
+@test:Config {
+    groups: ["tables", "unit"]
+}
+isolated function testResourceReturningTables() returns error? {
+    string document = "{ employees { name } }";
+    string url = "http://localhost:9105/graphql";
+    json actualPayload = check getJsonPayloadFromService(url, document);
+
+    json expectedPayload = {
+        data: {
+            employees: [
+                {
+                    name: "John Doe"
+                },
+                {
+                    name: "Jane Doe"
+                },
+                {
+                    name: "Johnny Roe"
+                }
+            ]
+        }
+    };
+    test:assertEquals(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["negative", "tables", "unit"]
+}
+isolated function testQueryingTableWithoutSelections() returns error? {
+    string document = "{ employees }";
+    string url = "http://localhost:9105/graphql";
+    json actualPayload = check getJsonPayloadFromService(url, document);
+
+    string message = "Field \"employees\" of type \"[Employee!]\" must have a selection of subfields. Did you mean "
+        + "\"employees { ... }\"?";
+    json expectedPayload = {
+        errors: [
+            {
+                message: message,
+                locations: [
+                    {
+                        line: 1,
+                        column: 3
+                    }
+                ]
+            }
+        ]
+    };
+    test:assertEquals(actualPayload, expectedPayload);
+}

--- a/graphql-ballerina/tests/records.bal
+++ b/graphql-ballerina/tests/records.bal
@@ -41,3 +41,11 @@ type Student record {
     string name;
     Course[] courses;
 };
+
+type Employee record {|
+    readonly int id;
+    string name;
+    decimal salary;
+|};
+
+type EmployeeTable table<Employee> key(id);

--- a/graphql-ballerina/tests/values.bal
+++ b/graphql-ballerina/tests/values.bal
@@ -116,3 +116,9 @@ Student s3 = {
 };
 
 Student[] students = [s1, s2, s3];
+
+EmployeeTable employees = table[
+    { id: 1, name: "John Doe", salary: 1000.00 },
+    { id: 2, name: "Jane Doe", salary: 2000.00 },
+    { id: 3, name: "Johnny Roe", salary: 500.00 }
+];

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/schema/tree/SchemaGenerator.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/schema/tree/SchemaGenerator.java
@@ -21,9 +21,9 @@ package io.ballerina.stdlib.graphql.schema.tree;
 import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.types.ArrayType;
 import io.ballerina.runtime.api.types.Field;
-import io.ballerina.runtime.api.types.MapType;
 import io.ballerina.runtime.api.types.RecordType;
 import io.ballerina.runtime.api.types.ServiceType;
+import io.ballerina.runtime.api.types.TableType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.types.UnionType;
 import io.ballerina.stdlib.graphql.schema.Schema;
@@ -130,13 +130,12 @@ public class SchemaGenerator {
                     schemaType.addField(getSchemaFieldFromRecordField(field));
                 }
             }
-        } else if (tag == TypeTags.MAP_TAG) {
-            MapType mapType = (MapType) type;
-            Type constrainedType = mapType.getConstrainedType();
-            return getSchemaTypeFromType(constrainedType);
         } else if (tag == TypeTags.ARRAY_TAG) {
             ArrayType arrayType = (ArrayType) type;
             return getSchemaTypeFromType(arrayType.getElementType());
+        } else if (tag == TypeTags.TABLE_TAG) {
+            TableType tableType = (TableType) type;
+            return getSchemaTypeFromType(tableType.getConstrainedType());
         } else if (tag == TypeTags.UNION_TAG) {
             UnionType unionType = (UnionType) type;
             Type mainType = getNonNullNonErrorTypeFromUnion(unionType.getMemberTypes());

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/schema/tree/SchemaTreeGenerator.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/schema/tree/SchemaTreeGenerator.java
@@ -22,10 +22,10 @@ import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.flags.SymbolFlags;
 import io.ballerina.runtime.api.types.ArrayType;
 import io.ballerina.runtime.api.types.Field;
-import io.ballerina.runtime.api.types.MapType;
 import io.ballerina.runtime.api.types.RecordType;
 import io.ballerina.runtime.api.types.ResourceMethodType;
 import io.ballerina.runtime.api.types.ServiceType;
+import io.ballerina.runtime.api.types.TableType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.types.UnionType;
 import io.ballerina.stdlib.graphql.schema.InputValue;
@@ -102,14 +102,14 @@ public class SchemaTreeGenerator {
             SchemaType ofType = createSchemaTypeForRecordType((RecordType) type);
             schemaType.setOfType(ofType);
             return schemaType;
-        } else if (tag == TypeTags.MAP_TAG) {
-            SchemaType schemaType = getNonNullType();
-            SchemaType ofType = createSchemaTypeForMapType((MapType) type);
-            schemaType.setOfType(ofType);
-            return schemaType;
         } else if (tag == TypeTags.SERVICE_TAG) {
             SchemaType schemaType = getNonNullType();
             addFieldsForServiceType((ServiceType) type, schemaType);
+            return schemaType;
+        } else if (tag == TypeTags.TABLE_TAG) {
+            SchemaType schemaType = getNonNullType();
+            SchemaType ofType = createSchemaTypeForTableType((TableType) type);
+            schemaType.setOfType(ofType);
             return schemaType;
         } else {
             String typeName = getScalarTypeName(tag);
@@ -162,9 +162,15 @@ public class SchemaTreeGenerator {
         return schemaType;
     }
 
-    private SchemaType createSchemaTypeForMapType(MapType mapType) {
-        Type constrainedType = mapType.getConstrainedType();
-        return getSchemaTypeForField(constrainedType);
+    private SchemaType createSchemaTypeForTableType(TableType tableType) {
+        Type constrainedType = tableType.getConstrainedType();
+        SchemaType internalType = getSchemaTypeForField(constrainedType);
+
+        SchemaType returnType = getNonNullType();
+        SchemaType ofType = new SchemaType(null, TypeKind.LIST);
+        ofType.setOfType(internalType);
+        returnType.setOfType(ofType);
+        return returnType;
     }
 
     private void addArgumentsForSchemaField(ResourceMethodType resourceMethod, SchemaField field) {

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/schema/tree/TypeTreeGenerator.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/schema/tree/TypeTreeGenerator.java
@@ -21,10 +21,10 @@ package io.ballerina.stdlib.graphql.schema.tree;
 import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.types.ArrayType;
 import io.ballerina.runtime.api.types.Field;
-import io.ballerina.runtime.api.types.MapType;
 import io.ballerina.runtime.api.types.RecordType;
 import io.ballerina.runtime.api.types.ResourceMethodType;
 import io.ballerina.runtime.api.types.ServiceType;
+import io.ballerina.runtime.api.types.TableType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.types.UnionType;
 
@@ -104,15 +104,15 @@ public class TypeTreeGenerator {
                 throw createError(message, NOT_SUPPORTED_ERROR);
             }
             return createNodeForService(name, serviceType);
-        } else if (tag == TypeTags.MAP_TAG) {
-            MapType mapType = (MapType) type;
-            return createNodeForMapType(name, mapType);
         } else if (tag == TypeTags.ARRAY_TAG) {
             ArrayType arrayType = (ArrayType) type;
             Type elementType = arrayType.getElementType();
             return createNodeForType(name, elementType);
         } else if (tag == TypeTags.UNION_TAG) {
             return createNodeForUnionType(name, (UnionType) type);
+        } else if (tag == TypeTags.TABLE_TAG) {
+            TableType tableType = (TableType) type;
+            return createNodeForTableType(name, tableType);
         } else {
             String message = "Unsupported type found: " + type.getName();
             throw createError(message, NOT_SUPPORTED_ERROR);
@@ -129,19 +129,19 @@ public class TypeTreeGenerator {
         return recordNode;
     }
 
-    private Node createNodeForMapType(String name, MapType mapType) {
-        Type constrainedType = mapType.getConstrainedType();
-        Node mapNode = new Node(name, mapType);
-        Node node = createNodeForType(constrainedType.getName(), constrainedType);
-        mapNode.addChild(node);
-        return mapNode;
-    }
-
     private Node createNodeForUnionType(String name, UnionType unionType) {
         // TODO: Finite Type?
         List<Type> memberTypes = unionType.getMemberTypes();
         Type type = getNonNullNonErrorTypeFromUnion(memberTypes);
         return createNodeForType(name, type);
+    }
+
+    private Node createNodeForTableType(String name, TableType tableType) {
+        Type constrainedType = tableType.getConstrainedType();
+        Node tableNode = new Node(name, tableType);
+        Node node = createNodeForType(constrainedType.getName(), constrainedType);
+        tableNode.addChild(node);
+        return tableNode;
     }
 
     public static Type getNonNullNonErrorTypeFromUnion(List<Type> memberTypes) {


### PR DESCRIPTION
## Purpose
With this PR, the Ballerina GraphQL services can return `table` types from a GraphQL service resource function. The GraphQL TypeKind of the resource function will be `LIST`, and it will return the results as a JSON array.

Each field of the table can be queried separately and querying for the whole table will return an error.

Fixes: [#648](https://github.com/ballerina-platform/ballerina-standard-library/issues/648)

## Examples

```ballerina
import ballerina/graphql;

public type Employee record {|
    int id;
    string name;
    decimal salary;
|};

public type EmployeeTable table<Employee> key(id);

service graphql:Service /graphql on new graphql:Listener(9090) {
    isolated resource function get employees() returns EmployeeTable {
        return table [
            { id: 1, name: "John Doe", salary: 1000.00 },
            { id: 2, name: "Jane Doe", salary: 2000.00 },
            { id: 3, name: "Johnny Roe", salary: 500.00 }
        ];
    }
}
```

Now, this can be queried using the following document:

```
{
    employees {
        name
    }
}
```

This will return the following JSON:

```json
{
    "data": {
        "employees": [
            {
                "name": "John Doe"
            },
            {
                "name": "Jane Doe"
            },
            {
               "name": "Johnny Roe"
            }
        ]
    }
}
```