### PR TITLE
Support Enum Type in GraphQL Schema

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ This file contains all the notable changes done to the Ballerina GraphQL package
 
 ### Added
 - [[#1224] Fragment Support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1224)
+- [[#1000] Enum Support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1000)
 
 ## [0.2.0-alpha6] - 2021-04-02
 

--- a/graphql-ballerina/records.bal
+++ b/graphql-ballerina/records.bal
@@ -83,7 +83,7 @@ public type __Type record {
     __TypeKind kind;
     string? name;
     __Field[] fields?;
-    map<anydata> enumValues?;
+    __EnumValue[] enumValues?;
     __Type ofType?;
 };
 

--- a/graphql-ballerina/tests/08_resources_returning_union_types.bal
+++ b/graphql-ballerina/tests/08_resources_returning_union_types.bal
@@ -27,7 +27,7 @@ function testResourcesReturningInvalidUnionType() returns error? {
     Error err = <Error> result;
 
     string expectedErrorMessage =
-        "Unsupported union: If a field type is a union, it should be a subtype of \"<T>|error?\", except \"error?\"";
+        string`Unsupported union: If a field type is a union, it should be a subtype of "<T>|error?", except "error?"`;
     test:assertEquals(err.message(), expectedErrorMessage);
 }
 

--- a/graphql-ballerina/tests/15_enums.bal
+++ b/graphql-ballerina/tests/15_enums.bal
@@ -1,0 +1,154 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+service /graphql on new Listener(9107) {
+    isolated resource function get weekday(int number) returns Weekday {
+        match number {
+            1 => {
+                return MONDAY;
+            }
+            2 => {
+                return TUESDAY;
+            }
+            3 => {
+                return WEDNESDAY;
+            }
+            4 => {
+                return THURSDAY;
+            }
+            5 => {
+                return FRIDAY;
+            }
+            6 => {
+                return SATURDAY;
+            }
+        }
+        return SUNDAY;
+    }
+
+    isolated resource function get day(int number) returns Weekday|error {
+        if (number < 1 || number > 7) {
+            return error("Invalid number");
+        } else if (number == 1) {
+            return MONDAY;
+        } else if (number == 2) {
+            return TUESDAY;
+        } else if (number == 3) {
+            return WEDNESDAY;
+        } else if (number == 4) {
+            return THURSDAY;
+        } else if (number == 5) {
+            return FRIDAY;
+        } else if (number == 6) {
+            return SATURDAY;
+        } else {
+            return SUNDAY;
+        }
+    }
+
+    isolated resource function get time() returns Time {
+        return {
+            weekday: MONDAY,
+            time: "22:10:33"
+        };
+    }
+}
+
+@test:Config {
+    groups: ["enum", "unit"]
+}
+isolated function testEnum() returns error? {
+    string document = "query { time { weekday } }";
+    string url = "http://localhost:9107/graphql";
+    json actualPayload = check getJsonPayloadFromService(url, document);
+    json expectedPayload = {
+        data: {
+            time: {
+                weekday: "MONDAY"
+            }
+        }
+    };
+    test:assertEquals(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["enum", "unit"]
+}
+isolated function testEnumInsideRecord() returns error? {
+    string document = "query { weekday(number: 3) }";
+    string url = "http://localhost:9107/graphql";
+    json actualPayload = check getJsonPayloadFromService(url, document);
+    json expectedPayload = {
+        data: {
+            weekday: "WEDNESDAY"
+        }
+    };
+    test:assertEquals(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["enum", "unit"]
+}
+function testEnumIntrospection() returns error? {
+    string document = "{ __schema { types { name enumValues { name } } } }";
+    string url = "http://localhost:9107/graphql";
+    json actualPayload = check getJsonPayloadFromService(url, document);
+    test:assertEquals(actualPayload, enumTypeInspectionResult);
+}
+
+@test:Config {
+    groups: ["enum", "unit"]
+}
+isolated function testEnumWithUnion() returns error? {
+    string document = "query { day(number: 10) }";
+    string url = "http://localhost:9107/graphql";
+    json actualPayload = check getJsonPayloadFromService(url, document);
+    json expectedPayload = {
+        errors: [
+            {
+                message: "Invalid number",
+                locations: [
+                    {
+                        line: 1,
+                        column: 9
+                    }
+                ]
+            }
+        ]
+    };
+    test:assertEquals(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["enum", "unit"]
+}
+function testEnumWithInvalidUnion() returns error? {
+    Listener l = check new(9108);
+    var result = l.attach(serviceWithInvalidUnion, "/graphql");
+    test:assertTrue(result is error);
+    error err = <error>result;
+    string expectedMessage =
+        string`Unsupported union: If a field type is a union, it should be a subtype of "<T>|error?", except "error?"`;
+    test:assertEquals(err.message(), expectedMessage);
+}
+
+Service serviceWithInvalidUnion = service object {
+    isolated resource function get invalidResource() returns Weekday|string {
+        return "John Doe";
+    }
+};

--- a/graphql-ballerina/tests/expected_values.bal
+++ b/graphql-ballerina/tests/expected_values.bal
@@ -19,11 +19,17 @@ json expectedSchemaForMultipleResources = {
         "__TypeKind": {
             "kind": "ENUM",
             "name": "__TypeKind",
-            "enumValues": {
-                "SCALAR": "SCALAR",
-                "OBJECT": "OBJECT",
-                "ENUM": "ENUM"
-            }
+            "enumValues": [
+                {
+                    "name": "SCALAR"
+                },
+                {
+                    "name": "OBJECT"
+                },
+                {
+                    "name": "ENUM"
+                }
+            ]
         },
         "__Field": {
             "kind": "OBJECT",
@@ -208,11 +214,17 @@ json expectedSchemaForResourcesReturningRecords = {
         "__TypeKind": {
             "kind": "ENUM",
             "name": "__TypeKind",
-            "enumValues": {
-                "SCALAR": "SCALAR",
-                "OBJECT": "OBJECT",
-                "ENUM": "ENUM"
-            }
+            "enumValues": [
+                {
+                    "name": "SCALAR"
+                },
+                {
+                    "name": "OBJECT"
+                },
+                {
+                    "name": "ENUM"
+                }
+            ]
         },
         "__Field": {
             "kind": "OBJECT",
@@ -634,6 +646,87 @@ json hierarchicalResourcePathIntrospectionResult = {
                             "name": "types"
                         }
                     ]
+                }
+            ]
+        }
+    }
+};
+
+json enumTypeInspectionResult = {
+    "data": {
+        "__schema": {
+            "types": [
+                {
+                    "name": "__TypeKind",
+                    "enumValues": [
+                        {
+                            "name": "SCALAR"
+                        },
+                        {
+                            "name": "OBJECT"
+                        },
+                        {
+                            "name": "ENUM"
+                        }
+                    ]
+                },
+                {
+                    "name": "__Field",
+                    "enumValues": null
+                },
+                {
+                    "name": "ballerina/graphql:0.2.0-alpha8:Weekday",
+                    "enumValues": [
+                        {
+                            "name": "SATURDAY"
+                        },
+                        {
+                            "name": "FRIDAY"
+                        },
+                        {
+                            "name": "THURSDAY"
+                        },
+                        {
+                            "name": "WEDNESDAY"
+                        },
+                        {
+                            "name": "TUESDAY"
+                        },
+                        {
+                            "name": "MONDAY"
+                        },
+                        {
+                            "name": "SUNDAY"
+                        }
+                    ]
+                },
+                {
+                    "name": "Query",
+                    "enumValues": null
+                },
+                {
+                    "name": "__Type",
+                    "enumValues": null
+                },
+                {
+                    "name": "Time",
+                    "enumValues": null
+                },
+                {
+                    "name": "String",
+                    "enumValues": null
+                },
+                {
+                    "name": "__InputValue",
+                    "enumValues": null
+                },
+                {
+                    "name": "Int",
+                    "enumValues": null
+                },
+                {
+                    "name": "__Schema",
+                    "enumValues": null
                 }
             ]
         }

--- a/graphql-ballerina/tests/records.bal
+++ b/graphql-ballerina/tests/records.bal
@@ -49,3 +49,18 @@ type Employee record {|
 |};
 
 type EmployeeTable table<Employee> key(id);
+
+public enum Weekday {
+    SUNDAY,
+    MONDAY,
+    TUESDAY,
+    WEDNESDAY,
+    THURSDAY,
+    FRIDAY,
+    SATURDAY
+}
+
+type Time record {|
+    Weekday weekday;
+    string time;
+|};

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/EngineUtils.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/EngineUtils.java
@@ -61,7 +61,7 @@ public class EngineUtils {
     public static final String TYPE_RECORD = "__Type";
     public static final String INPUT_VALUE_RECORD = "__InputValue";
     public static final String TYPE_KIND_ENUM = "__TypeKind";
-    public static final String QUERY_TYPE_NAME = "queryType";
+    public static final String ENUM_VALUE_RECORD = "__EnumValue";
 
     // Schema related record field names
     private static final BString QUERY_TYPE_FIELD = StringUtils.fromString("queryType");
@@ -157,10 +157,13 @@ public class EngineUtils {
         return fieldArray;
     }
 
-    private static BMap<BString, Object> getEnumValuesMapFromEnumValues(List<Object> enumValues) {
-        BMap<BString, Object> result = ValueCreator.createMapValue();
+    private static BArray getEnumValuesMapFromEnumValues(List<Object> enumValues) {
+        Type elementType = ValueCreator.createRecordValue(getModule(), ENUM_VALUE_RECORD).getType();
+        BArray result = ValueCreator.createArrayValue(TypeCreator.createArrayType(elementType));
         for (Object value : enumValues) {
-            result.put(StringUtils.fromString(value.toString()), value);
+            BMap<BString, Object> enumRecord = ValueCreator.createRecordValue(getModule(), ENUM_VALUE_RECORD);
+            enumRecord.put(NAME_FIELD, value);
+            result.append(enumRecord);
         }
         return result;
     }

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/tree/SchemaGenerator.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/tree/SchemaGenerator.java
@@ -19,6 +19,7 @@
 package io.ballerina.stdlib.graphql.runtime.schema.tree;
 
 import io.ballerina.runtime.api.TypeTags;
+import io.ballerina.runtime.api.flags.SymbolFlags;
 import io.ballerina.runtime.api.types.ArrayType;
 import io.ballerina.runtime.api.types.Field;
 import io.ballerina.runtime.api.types.RecordType;
@@ -35,6 +36,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import static io.ballerina.stdlib.graphql.runtime.schema.tree.SchemaTreeGenerator.addEnumValueToEnumType;
 import static io.ballerina.stdlib.graphql.runtime.schema.tree.TypeTreeGenerator.getNonNullNonErrorTypeFromUnion;
 import static io.ballerina.stdlib.graphql.runtime.schema.tree.TypeTreeGenerator.getScalarTypeName;
 import static io.ballerina.stdlib.graphql.runtime.utils.Utils.INVALID_TYPE_ERROR;
@@ -146,8 +148,13 @@ public class SchemaGenerator {
             schemaType = getSchemaTypeFromType(tableType.getConstrainedType());
         } else if (tag == TypeTags.UNION_TAG) {
             UnionType unionType = (UnionType) type;
-            Type mainType = getNonNullNonErrorTypeFromUnion(unionType.getMemberTypes());
-            schemaType = getSchemaTypeFromType(mainType);
+            if (SymbolFlags.isFlagOn(unionType.getFlags(), SymbolFlags.ENUM)) {
+                schemaType = new SchemaType(unionType.getName(), TypeKind.ENUM);
+                addEnumValueToEnumType(schemaType, unionType);
+            } else {
+                Type mainType = getNonNullNonErrorTypeFromUnion(unionType);
+                schemaType = getSchemaTypeFromType(mainType);
+            }
         } else {
             String message = "Unsupported type for schema field: " + type.getName();
             throw createError(message, NOT_SUPPORTED_ERROR);

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/tree/SchemaTreeGenerator.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/tree/SchemaTreeGenerator.java
@@ -141,9 +141,20 @@ public class SchemaTreeGenerator {
     }
 
     private SchemaType getSchemaTypeForUnionType(UnionType unionType) {
-        Type mainType = getNonNullNonErrorTypeFromUnion(unionType.getMemberTypes());
+        if (SymbolFlags.isFlagOn(unionType.getFlags(), SymbolFlags.ENUM)) {
+            SchemaType schemaType = new SchemaType(unionType.getName(), TypeKind.ENUM);
+            addEnumValueToEnumType(schemaType, unionType);
+            return schemaType;
+        }
+        Type mainType = getNonNullNonErrorTypeFromUnion(unionType);
         SchemaType schemaType = getSchemaTypeForField(mainType);
         return schemaType.getOfType();
+    }
+
+    public static void addEnumValueToEnumType(SchemaType schemaType, UnionType unionType) {
+        for (Type type : unionType.getMemberTypes()) {
+            schemaType.addEnumValue(type.getZeroValue());
+        }
     }
 
     private SchemaType createSchemaTypeForRecordType(RecordType recordType) {


### PR DESCRIPTION
## Purpose
Add support for enums in Ballerina GraphQL schemas.

Fixes: [#1000](https://github.com/ballerina-platform/ballerina-standard-library/issues/1000)

## Examples

The following is now allowed:

```ballerina
import ballerina/graphql;

service graphql:Service /grraphql on new graphql:Listener(9090) {
    isolated resource function get day(int number) returns Weekday|error {
        if (number < 1 || number > 7) {
            return error("Invalid number");
        } else if (number == 1) {
            return MONDAY;
        } else if (number == 2) {
            return TUESDAY;
        } else if (number == 3) {
            return WEDNESDAY;
        } else if (number == 4) {
            return THURSDAY;
        } else if (number == 5) {
            return FRIDAY;
        } else if (number == 6) {
            return SATURDAY;
        } else {
            return SUNDAY;
        }
    }
}

public enum Weekday {
    SUNDAY,
    MONDAY,
    TUESDAY,
    WEDNESDAY,
    THURSDAY,
    FRIDAY,
    SATURDAY
}
```

This can be queried using the following document:

```
query {
    day(number: 5)
}
```

The result will be:

```json
{
    "data": {
        "day": "FRIDAY"
    }
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
