### PR TITLE
Add Support to Union Types in GraphQL Services

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ This file contains all the notable changes done to the Ballerina GraphQL package
 - [[#1000] Enum Support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1000)
 - [[#999] Map Support](https://github.com/ballerina-platform/ballerina-standard-library/issues/999)
 - [[#1091] Compiler plugin validations for GraphQL services](https://github.com/ballerina-platform/ballerina-standard-library/issues/1091)
+- [[#1001] Support Union Types](https://github.com/ballerina-platform/ballerina-standard-library/issues/1001)
 
 ## [0.2.0-alpha6] - 2021-04-02
 

--- a/graphql-ballerina/common_utils.bal
+++ b/graphql-ballerina/common_utils.bal
@@ -53,6 +53,12 @@ isolated function getInvalidFieldOnUnionTypeError(string fieldName, __Type union
     return string`Cannot query field "${fieldName}" on type "${unionType?.name.toString()}". Did you mean to use a fragment on ${onTypes}?`;
 }
 
+isolated function getFragmetCannotSpreadError(parser:FragmentNode fragmentNode, string fragmentName, __Type ofType)
+returns string {
+    string fragmentOnTypeName = fragmentNode.getOnType();
+    return string`Fragment "${fragmentName}" cannot be spread here as objects of type "${ofType.name.toString()}" can never be of type "${fragmentOnTypeName}".`;
+}
+
 isolated function getMissingRequiredArgError(parser:FieldNode node, __InputValue input) returns string {
     string typeName = getTypeNameFromType(input.'type);
     return string`Field "${node.getName()}" argument "${input.name}" of type "${typeName}" is required, but it was not provided.`;

--- a/graphql-ballerina/common_utils.bal
+++ b/graphql-ballerina/common_utils.bal
@@ -44,6 +44,15 @@ isolated function getMissingSubfieldsError(string fieldName, string typeName) re
     return string`Field "${fieldName}" of type "${typeName}" must have a selection of subfields. Did you mean "${fieldName} { ... }"?`;
 }
 
+isolated function getInvalidFieldOnUnionTypeError(string fieldName, __Type unionType) returns string {
+    __Type[] possibleTypes = <__Type[]>unionType?.possibleTypes;
+    string onTypes = string`"${getOfType(possibleTypes[0]).name.toString()}"`;
+    foreach int i in 1...possibleTypes.length() - 1 {
+        onTypes += string` or "${getOfType(possibleTypes[i]).name.toString()}"`;
+    }
+    return string`Cannot query field "${fieldName}" on type "${unionType?.name.toString()}". Did you mean to use a fragment on ${onTypes}?`;
+}
+
 isolated function getMissingRequiredArgError(parser:FieldNode node, __InputValue input) returns string {
     string typeName = getTypeNameFromType(input.'type);
     return string`Field "${node.getName()}" argument "${input.name}" of type "${typeName}" is required, but it was not provided.`;

--- a/graphql-ballerina/constants.bal
+++ b/graphql-ballerina/constants.bal
@@ -22,11 +22,6 @@ const CONTENT_TYPE_GQL = "application/graphql";
 const PARAM_QUERY = "query";
 const PARAM_OPERATION_NAME = "operationName";
 
-const SCALAR = "SCALAR";
-const OBJECT = "OBJECT";
-const LIST = "LIST";
-const NON_NULL = "NON_NULL";
-
 const SCHEMA_FIELD = "__schema";
 const TYPES_FIELD = "types";
 const SCHEMA_TYPE_NAME = "__Schema";

--- a/graphql-ballerina/records.bal
+++ b/graphql-ballerina/records.bal
@@ -120,7 +120,14 @@ public type __InputValue record {|
 |};
 
 # Represents the type kind of a GraphQL type.
-public type __TypeKind "SCALAR"|"OBJECT"|"ENUM"|"NON_NULL"|"LIST"|"UNION";
+public enum __TypeKind {
+    SCALAR,
+    OBJECT,
+    ENUM,
+    NON_NULL,
+    LIST,
+    UNION
+}
 
 type __Directive record {|
     string name;

--- a/graphql-ballerina/records.bal
+++ b/graphql-ballerina/records.bal
@@ -79,12 +79,15 @@ public type __Schema record {|
 # + fields - The fields of the given type, if the type qaulifies to have fields
 # + enumValues - The possible set of values, if the type is an enum
 # + ofType - If the type is a `NON_NULL` or a `LIST`, the `__Type` of the wrapped type
+# + possibleTypes - The list of types that can be represented from this type. Only applies for the Union types, and
+#                   the the list can only contain object types
 public type __Type record {
     __TypeKind kind;
     string? name;
     __Field[] fields?;
     __EnumValue[] enumValues?;
     __Type ofType?;
+    __Type[] possibleTypes?;
 };
 
 # Represents a GraphQL enum.
@@ -117,7 +120,7 @@ public type __InputValue record {|
 |};
 
 # Represents the type kind of a GraphQL type.
-public type __TypeKind "SCALAR"|"OBJECT"|"ENUM"|"NON_NULL"|"LIST";
+public type __TypeKind "SCALAR"|"OBJECT"|"ENUM"|"NON_NULL"|"LIST"|"UNION";
 
 type __Directive record {|
     string name;

--- a/graphql-ballerina/tests/08_resources_returning_union_types.bal
+++ b/graphql-ballerina/tests/08_resources_returning_union_types.bal
@@ -113,6 +113,109 @@ fragment personFragment on Person {
 @test:Config {
     groups: ["union", "unit"]
 }
+isolated function testQueryUnionTypeWithIncorrectFragment() returns error? {
+    string graphqlUrl = "http://localhost:9098/graphql";
+    string document = string`query {
+    information(id: 3) {
+        ...invalidFragment
+        ...personFragment
+    }
+}
+
+fragment invalidFragment on Student {
+    name
+}
+
+fragment personFragment on Person {
+    name
+}
+`;
+    json result = check getJsonPayloadFromService(graphqlUrl, document);
+    json expectedPayload = {
+        errors: [
+            {
+                message: string`Fragment "invalidFragment" cannot be spread here as objects of type "Information" can never be of type "Student".`,
+                locations: [
+                    {
+                        line: 3,
+                        column: 12
+                    }
+                ]
+            }
+        ]
+    };
+    test:assertEquals(result, expectedPayload);
+}
+
+@test:Config {
+    groups: ["union", "unit"]
+}
+isolated function testQueryUnionTypeWithFieldAndFragment() returns error? {
+    string graphqlUrl = "http://localhost:9098/graphql";
+    string document = string`query {
+    information(id: 3) {
+        name
+        ...personFragment
+    }
+}
+
+fragment personFragment on Person {
+    name
+}
+`;
+    json result = check getJsonPayloadFromService(graphqlUrl, document);
+    json expectedPayload = {
+        errors: [
+            {
+                message: string`Cannot query field "name" on type "Information". Did you mean to use a fragment on "Address" or "Person"?`,
+                locations: [
+                    {
+                        line: 3,
+                        column: 9
+                    }
+                ]
+            }
+        ]
+    };
+    test:assertEquals(result, expectedPayload);
+}
+
+@test:Config {
+    groups: ["union", "unit"]
+}
+isolated function testQueryUnionTypeWithFragmentAndField() returns error? {
+    string graphqlUrl = "http://localhost:9098/graphql";
+    string document = string`query {
+    information(id: 3) {
+        ...personFragment
+        name
+    }
+}
+
+fragment personFragment on Person {
+    name
+}
+`;
+    json result = check getJsonPayloadFromService(graphqlUrl, document);
+    json expectedPayload = {
+        errors: [
+            {
+                message: string`Cannot query field "name" on type "Information". Did you mean to use a fragment on "Address" or "Person"?`,
+                locations: [
+                    {
+                        line: 4,
+                        column: 9
+                    }
+                ]
+            }
+        ]
+    };
+    test:assertEquals(result, expectedPayload);
+}
+
+@test:Config {
+    groups: ["union", "unit"]
+}
 isolated function testQueryUnionTypeWithoutSelection() returns error? {
     string graphqlUrl = "http://localhost:9098/graphql";
     string document = "{ information(id: 2) }";

--- a/graphql-ballerina/tests/08_resources_returning_union_types.bal
+++ b/graphql-ballerina/tests/08_resources_returning_union_types.bal
@@ -15,7 +15,6 @@
 // under the License.
 
 import ballerina/test;
-import ballerina/io;
 
 type Information Address|Person;
 
@@ -108,7 +107,6 @@ fragment personFragment on Person {
             }
         }
     };
-    io:println(result);
     test:assertEquals(result, expectedPayload);
 }
 

--- a/graphql-ballerina/tests/15_enums.bal
+++ b/graphql-ballerina/tests/15_enums.bal
@@ -133,22 +133,3 @@ isolated function testEnumWithUnion() returns error? {
     };
     test:assertEquals(actualPayload, expectedPayload);
 }
-
-@test:Config {
-    groups: ["enum", "unit"]
-}
-function testEnumWithInvalidUnion() returns error? {
-    Listener l = check new(9108);
-    var result = l.attach(serviceWithInvalidUnion, "/graphql");
-    test:assertTrue(result is error);
-    error err = <error>result;
-    string expectedMessage =
-        string`Unsupported union: If a field type is a union, it should be a subtype of "<T>|error?", except "error?"`;
-    test:assertEquals(err.message(), expectedMessage);
-}
-
-Service serviceWithInvalidUnion = service object {
-    isolated resource function get invalidResource() returns Weekday|string {
-        return "John Doe";
-    }
-};

--- a/graphql-ballerina/tests/expected_values.bal
+++ b/graphql-ballerina/tests/expected_values.bal
@@ -675,6 +675,32 @@ json enumTypeInspectionResult = {
         "__schema": {
             "types": [
                 {
+                    "name": "Weekday",
+                    "enumValues": [
+                        {
+                            "name": "SATURDAY"
+                        },
+                        {
+                            "name": "FRIDAY"
+                        },
+                        {
+                            "name": "THURSDAY"
+                        },
+                        {
+                            "name": "WEDNESDAY"
+                        },
+                        {
+                            "name": "TUESDAY"
+                        },
+                        {
+                            "name": "MONDAY"
+                        },
+                        {
+                            "name": "SUNDAY"
+                        }
+                    ]
+                },
+                {
                     "name": "__TypeKind",
                     "enumValues": [
                         {
@@ -700,32 +726,6 @@ json enumTypeInspectionResult = {
                 {
                     "name": "__Field",
                     "enumValues": null
-                },
-                {
-                    "name": "ballerina/graphql:0.2.0-alpha8:Weekday",
-                    "enumValues": [
-                        {
-                            "name": "SATURDAY"
-                        },
-                        {
-                            "name": "FRIDAY"
-                        },
-                        {
-                            "name": "THURSDAY"
-                        },
-                        {
-                            "name": "WEDNESDAY"
-                        },
-                        {
-                            "name": "TUESDAY"
-                        },
-                        {
-                            "name": "MONDAY"
-                        },
-                        {
-                            "name": "SUNDAY"
-                        }
-                    ]
                 },
                 {
                     "name": "Query",

--- a/graphql-ballerina/tests/expected_values.bal
+++ b/graphql-ballerina/tests/expected_values.bal
@@ -28,6 +28,15 @@ json expectedSchemaForMultipleResources = {
                 },
                 {
                     "name": "ENUM"
+                },
+                {
+                    "name": "NON_NULL"
+                },
+                {
+                    "name": "LIST"
+                },
+                {
+                    "name": "UNION"
                 }
             ]
         },
@@ -223,6 +232,15 @@ json expectedSchemaForResourcesReturningRecords = {
                 },
                 {
                     "name": "ENUM"
+                },
+                {
+                    "name": "NON_NULL"
+                },
+                {
+                    "name": "LIST"
+                },
+                {
+                    "name": "UNION"
                 }
             ]
         },
@@ -667,6 +685,15 @@ json enumTypeInspectionResult = {
                         },
                         {
                             "name": "ENUM"
+                        },
+                        {
+                            "name": "NON_NULL"
+                        },
+                        {
+                            "name": "LIST"
+                        },
+                        {
+                            "name": "UNION"
                         }
                     ]
                 },

--- a/graphql-ballerina/validator_visitor.bal
+++ b/graphql-ballerina/validator_visitor.bal
@@ -15,7 +15,6 @@
 // under the License.
 
 import graphql.parser;
-//import ballerina/io;
 
 class ValidatorVisitor {
     *parser:Visitor;
@@ -96,7 +95,8 @@ class ValidatorVisitor {
                     };
                     self.visitFragment(fragmentNode, fragmentParent);
                 } else {
-
+                    string message = getFragmetCannotSpreadError(fragmentNode, selection.name, parentType);
+                    self.errors.push(getErrorDetailRecord(message, selection.location));
                 }
             }
             return;
@@ -301,7 +301,7 @@ class ValidatorVisitor {
             __Type schemaType = <__Type>self.schema.types[schemaTypeName];
             __Type ofType = getOfType(schemaType);
             if (fragmentOnType != ofType) {
-                string message = string`Fragment "${fragment.name}" cannot be spread here as objects of type "${ofType.name.toString()}" can never be of type "${fragmentOnTypeName}".`;
+                string message = getFragmetCannotSpreadError(fragmentNode, fragment.name, ofType);
                 ErrorDetail errorDetail = getErrorDetailRecord(message, fragment.location);
                 self.errors.push(errorDetail);
             }
@@ -320,7 +320,8 @@ isolated function getFieldFromFieldArray(__Field[] fields, string fieldName) ret
 
 isolated function getTypeFromTypeArray(__Type[] types, string typeName) returns __Type? {
     foreach __Type schemaType in types {
-        if (schemaType.name == typeName) {
+        __Type ofType = getOfType(schemaType);
+        if (ofType.name == typeName) {
             return schemaType;
         }
     }

--- a/graphql-compiler-plugin-tests/build.gradle
+++ b/graphql-compiler-plugin-tests/build.gradle
@@ -111,6 +111,6 @@ test {
     useTestNG()
 }
 
-copyDistribution.dependsOn ":graphql-ballerina:build"
+copyDistribution.dependsOn ":graphql-ballerina:ballerinaBuild"
 copyPackageBala.dependsOn copyDistribution
 test.dependsOn copyPackageBala

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/CallableUnitCallback.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/CallableUnitCallback.java
@@ -42,6 +42,7 @@ import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.IS_FRAGMENT
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.KEY;
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.NAME_FIELD;
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.NODE_FIELD;
+import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.ON_TYPE_FIELD;
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.SELECTIONS_FIELD;
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.createDataRecord;
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.getErrorDetailRecord;
@@ -142,7 +143,9 @@ public class CallableUnitCallback implements Callback {
             boolean isFragment = selection.getBooleanValue(IS_FRAGMENT_FIELD);
             BObject subNode = selection.getObjectValue(NODE_FIELD);
             if (isFragment) {
-                processFragmentNodes(subNode, record, subData);
+                if (subNode.getStringValue(ON_TYPE_FIELD).getValue().equals(record.getType().getName())) {
+                    processFragmentNodes(subNode, record, subData);
+                }
             } else {
                 BString fieldName = subNode.getStringValue(NAME_FIELD);
                 Object fieldValue = record.get(fieldName);

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/EngineUtils.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/EngineUtils.java
@@ -103,6 +103,7 @@ public class EngineUtils {
     static final BString VALUE_FIELD = StringUtils.fromString("value");
     static final BString IS_FRAGMENT_FIELD = StringUtils.fromString("isFragment");
     static final BString NODE_FIELD = StringUtils.fromString("node");
+    static final BString ON_TYPE_FIELD = StringUtils.fromString("onType");
 
     public static String getResourceName(ResourceMethodType resourceMethod) {
         String[] nameArray = resourceMethod.getResourcePath();

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/EngineUtils.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/EngineUtils.java
@@ -74,6 +74,7 @@ public class EngineUtils {
     private static final BString DEFAULT_VALUE_FIELD = StringUtils.fromString("defaultValue");
     private static final BString ENUM_VALUES_FIELD = StringUtils.fromString("enumValues");
     private static final BString OF_TYPE_FIELD = StringUtils.fromString("ofType");
+    private static final BString POSSIBLE_TYPES_FIELD = StringUtils.fromString("possibleTypes");
 
     // Schema related type names
     public static final String INTEGER = "Int";
@@ -146,7 +147,21 @@ public class EngineUtils {
         if (ofType != null) {
             typeRecord.put(OF_TYPE_FIELD, getTypeRecordFromTypeObject(ofType));
         }
+        List<SchemaType> possibleTypes = typeObject.getPossibleTypes();
+        if (possibleTypes != null) {
+            typeRecord.put(POSSIBLE_TYPES_FIELD, getPossibleTypesArrayFromSchemaTypeArray(possibleTypes));
+        }
         return typeRecord;
+    }
+
+    private static BArray getPossibleTypesArrayFromSchemaTypeArray(List<SchemaType> possibleTypes) {
+        BMap<BString, Object> typeRecord = ValueCreator.createRecordValue(getModule(), TYPE_RECORD);
+        ArrayType arrayType = TypeCreator.createArrayType(typeRecord.getType());
+        BArray possibleTypesArray = ValueCreator.createArrayValue(arrayType);
+        for (SchemaType schemaType : possibleTypes) {
+            possibleTypesArray.append(getTypeRecordFromTypeObject(schemaType));
+        }
+        return possibleTypesArray;
     }
 
     private static BArray getFieldArrayFromFields(Collection<SchemaField> fields) {

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/IntrospectionUtils.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/IntrospectionUtils.java
@@ -50,9 +50,9 @@ public class IntrospectionUtils {
 
     private static SchemaType createTypeKindSchemaType() {
         SchemaType typeKindSchemaType = new SchemaType(TYPE_KIND_ENUM, TypeKind.ENUM);
-        typeKindSchemaType.addEnumValue(StringUtils.fromString(TypeKind.SCALAR.toString()));
-        typeKindSchemaType.addEnumValue(StringUtils.fromString(TypeKind.OBJECT.toString()));
-        typeKindSchemaType.addEnumValue(StringUtils.fromString(TypeKind.ENUM.toString()));
+        for (TypeKind typeKind : TypeKind.values()) {
+            typeKindSchemaType.addEnumValue(StringUtils.fromString(typeKind.name()));
+        }
         return typeKindSchemaType;
     }
 

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/SchemaType.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/SchemaType.java
@@ -33,6 +33,7 @@ public class SchemaType {
     private String name;
     private Map<String, SchemaField> fields;
     private List<Object> enumValues;
+    private List<SchemaType> possibleTypes;
     SchemaType ofType;
 
     public SchemaType(String name, TypeKind kind) {
@@ -40,6 +41,7 @@ public class SchemaType {
         this.kind = kind;
         this.fields = new HashMap<>();
         this.enumValues = new ArrayList<>();
+        this.possibleTypes = new ArrayList<>();
     }
 
     public String getName() {
@@ -80,5 +82,16 @@ public class SchemaType {
 
     public void setOfType(SchemaType ofType) {
         this.ofType = ofType;
+    }
+
+    public void addPossibleType(SchemaType schemaType) {
+        this.possibleTypes.add(schemaType);
+    }
+
+    public List<SchemaType> getPossibleTypes() {
+        if (this.possibleTypes.size() == 0) {
+            return null;
+        }
+        return this.possibleTypes;
     }
 }

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/TypeKind.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/TypeKind.java
@@ -26,5 +26,6 @@ public enum TypeKind {
     OBJECT,
     ENUM,
     NON_NULL,
-    LIST
+    LIST,
+    UNION
 }

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/tree/Node.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/tree/Node.java
@@ -21,6 +21,7 @@ package io.ballerina.stdlib.graphql.runtime.schema.tree;
 import io.ballerina.runtime.api.types.Type;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -33,6 +34,7 @@ public class Node {
     private Type type;
     private Map<String, Node> children;
     private Node returnType;
+    private List<Type> possibleTypes;
 
     public Node(String name) {
         this(name, null, null);
@@ -43,11 +45,17 @@ public class Node {
     }
 
     public Node(String name, Type type, Node returnType) {
+        this(name, type, returnType, null);
+    }
+
+    public Node(String name, Type type, Node returnType, List<Type> possibleTypes) {
         this.name = name;
         this.type = type;
         this.returnType = returnType;
+        this.possibleTypes = possibleTypes;
         this.children = new HashMap<>();
     }
+
 
     public Type getType() {
         return this.type;
@@ -61,6 +69,10 @@ public class Node {
         if (child != null) {
             this.children.put(child.getName(), child);
         }
+    }
+
+    public List<Type> getPossibleTypes() {
+        return this.possibleTypes;
     }
 
     public Node getChild(String name) {

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/tree/SchemaGenerator.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/tree/SchemaGenerator.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import static io.ballerina.stdlib.graphql.runtime.schema.tree.SchemaTreeGenerator.addEnumValueToEnumType;
 import static io.ballerina.stdlib.graphql.runtime.schema.tree.TypeTreeGenerator.getScalarTypeName;
 import static io.ballerina.stdlib.graphql.runtime.schema.tree.Utils.getMemberTypes;
+import static io.ballerina.stdlib.graphql.runtime.schema.tree.Utils.getTypeNameFromType;
 import static io.ballerina.stdlib.graphql.runtime.schema.tree.Utils.isEnum;
 import static io.ballerina.stdlib.graphql.runtime.utils.Utils.INVALID_TYPE_ERROR;
 import static io.ballerina.stdlib.graphql.runtime.utils.Utils.NOT_SUPPORTED_ERROR;
@@ -113,6 +114,7 @@ public class SchemaGenerator {
                 for (Type member : node.getPossibleTypes()) {
                     schemaType.addPossibleType(getSchemaTypeFromType(member));
                 }
+                this.addType(schemaType);
                 return schemaType;
             } else {
                 // This code shouldn't be reached
@@ -157,7 +159,7 @@ public class SchemaGenerator {
         } else if (tag == TypeTags.UNION_TAG) {
             UnionType unionType = (UnionType) type;
             if (isEnum(unionType)) {
-                schemaType = new SchemaType(unionType.getName(), TypeKind.ENUM);
+                schemaType = new SchemaType(getTypeNameFromType(unionType), TypeKind.ENUM);
                 addEnumValueToEnumType(schemaType, unionType);
             } else {
                 List<Type> memberTypes = getMemberTypes(unionType);
@@ -165,7 +167,7 @@ public class SchemaGenerator {
                     Type mainType = memberTypes.get(0);
                     schemaType = getSchemaTypeFromType(mainType);
                 } else {
-                    schemaType = new SchemaType(unionType.getName(), TypeKind.UNION);
+                    schemaType = new SchemaType(getTypeNameFromType(unionType), TypeKind.UNION);
                     for (Type member : memberTypes) {
                         schemaType.addPossibleType(getSchemaTypeFromType(member));
                     }

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/tree/SchemaGenerator.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/tree/SchemaGenerator.java
@@ -108,6 +108,12 @@ public class SchemaGenerator {
         if (type == null) {
             if (node.getReturnType() != null) {
                 return populateTypesMap(node.getReturnType());
+            } else if (node.getPossibleTypes() != null) {
+                SchemaType schemaType = new SchemaType(node.getName(), TypeKind.UNION);
+                for (Type member : node.getPossibleTypes()) {
+                    schemaType.addPossibleType(getSchemaTypeFromType(member));
+                }
+                return schemaType;
             } else {
                 // This code shouldn't be reached
                 String message = "Type not found for the resource: " + node.getName();

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/tree/SchemaTreeGenerator.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/tree/SchemaTreeGenerator.java
@@ -43,6 +43,7 @@ import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.QUERY;
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.STRING;
 import static io.ballerina.stdlib.graphql.runtime.schema.tree.TypeTreeGenerator.getScalarTypeName;
 import static io.ballerina.stdlib.graphql.runtime.schema.tree.Utils.getMemberTypes;
+import static io.ballerina.stdlib.graphql.runtime.schema.tree.Utils.getTypeNameFromType;
 import static io.ballerina.stdlib.graphql.runtime.schema.tree.Utils.isEnum;
 import static io.ballerina.stdlib.graphql.runtime.utils.Utils.INVALID_TYPE_ERROR;
 import static io.ballerina.stdlib.graphql.runtime.utils.Utils.createError;
@@ -149,7 +150,7 @@ public class SchemaTreeGenerator {
 
     private SchemaType getSchemaTypeForUnionType(UnionType unionType) {
         if (isEnum(unionType)) {
-            SchemaType schemaType = new SchemaType(unionType.getName(), TypeKind.ENUM);
+            SchemaType schemaType = new SchemaType(getTypeNameFromType(unionType), TypeKind.ENUM);
             addEnumValueToEnumType(schemaType, unionType);
             return schemaType;
         }
@@ -158,7 +159,7 @@ public class SchemaTreeGenerator {
             SchemaType schemaType = getSchemaTypeForField(memberTypes.get(0));
             return schemaType.getOfType();
         } else {
-            SchemaType schemaType = new SchemaType(unionType.getName(), TypeKind.UNION);
+            SchemaType schemaType = new SchemaType(getTypeNameFromType(unionType), TypeKind.UNION);
             for (Type member : memberTypes) {
                 SchemaType memberType = getSchemaTypeForField(member);
                 schemaType.addPossibleType(memberType);

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/tree/TypeTreeGenerator.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/tree/TypeTreeGenerator.java
@@ -39,6 +39,7 @@ import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.INTEGER;
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.QUERY;
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.STRING;
 import static io.ballerina.stdlib.graphql.runtime.schema.tree.Utils.getMemberTypes;
+import static io.ballerina.stdlib.graphql.runtime.schema.tree.Utils.getTypeNameFromType;
 import static io.ballerina.stdlib.graphql.runtime.schema.tree.Utils.isEnum;
 import static io.ballerina.stdlib.graphql.runtime.utils.Utils.INVALID_TYPE_ERROR;
 import static io.ballerina.stdlib.graphql.runtime.utils.Utils.NOT_SUPPORTED_ERROR;
@@ -146,12 +147,12 @@ public class TypeTreeGenerator {
     private Node createNodeForUnionType(String name, UnionType unionType) {
         List<Type> memberTypes = getMemberTypes(unionType);
         if (isEnum(unionType)) {
-            return new Node(unionType.getName(), unionType);
+            return new Node(getTypeNameFromType(unionType), unionType);
         } else if (memberTypes.size() == 1) {
             return createNodeForType(name, memberTypes.get(0));
         } else {
             // Compiler plugin validates the union types so this should be a GraphQL union type.
-            return new Node(unionType.getName(), null, null, memberTypes);
+            return new Node(getTypeNameFromType(unionType), null, null, memberTypes);
         }
     }
 

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/tree/Utils.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/tree/Utils.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.graphql.runtime.schema.tree;
+
+import io.ballerina.runtime.api.TypeTags;
+import io.ballerina.runtime.api.flags.SymbolFlags;
+import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.types.UnionType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility methods for the Ballerina GraphQL schema generator.
+ */
+public class Utils {
+    public static boolean isEnum(UnionType unionType) {
+        return SymbolFlags.isFlagOn(unionType.getFlags(), SymbolFlags.ENUM);
+    }
+
+    public static List<Type> getMemberTypes(UnionType unionType) {
+        List<Type> members = new ArrayList<>();
+        if (isEnum(unionType)) {
+            members.add(unionType);
+        } else {
+            List<Type> originalMembers = unionType.getOriginalMemberTypes();
+            for (Type type : originalMembers) {
+                if (type.getTag() == TypeTags.ERROR_TAG || type.getTag() == TypeTags.NULL_TAG) {
+                    continue;
+                }
+                if (type.getTag() == TypeTags.UNION_TAG) {
+                    members.addAll(getMemberTypes((UnionType) type));
+                } else {
+                    members.add(type);
+                }
+            }
+        }
+        return members;
+    }
+}

--- a/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/tree/Utils.java
+++ b/graphql-native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/tree/Utils.java
@@ -53,4 +53,10 @@ public class Utils {
         }
         return members;
     }
+
+    // TODO: This is a temporary fix for https://github.com/ballerina-platform/ballerina-lang/issues/30108
+    public static String getTypeNameFromType(Type type) {
+        String[] splitName = type.getName().split(":");
+        return (splitName[splitName.length - 1]);
+    }
 }


### PR DESCRIPTION
## Purpose
Support Union Types in GraphQL Schemas.

With this PR, the Ballerina GraphQL services can have union types as fields.

Fixes: [#1001](https://github.com/ballerina-platform/ballerina-standard-library/issues/1001)

## Examples

Following Ballerina code is now valid:

```ballerina
import ballerina/graphql;

type Student record {
    int id;
    string name;
    string[] subjects;
};

type Teacher record {
    int id;
    string name;
    string subject;
    float salary;
};

type Person Student|Teacher;

service graphql:Service /graphql on new graphql:Listener(9090) {
    resource function get profile(int id) returns Person {
        // return a Student or Teacher
    }
}
```

To query this the following query can be used:

```
query {
    profile(id: 4) {
        ...studentFragment
        ...teacherFragment
    }
}

fragment studentFragment on Student {
    id
    name
}

fragment teacherFragment on Student {
    id
    name
    subject
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
