### PR TITLE
Add Support to Enum Type in Resource Function Params

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ This file contains all the notable changes done to the Ballerina GraphQL package
 ## [Unreleased]
 
 ### Fixed
+- [[#1305] Allow Enum as an Input Parameter](https://github.com/ballerina-platform/ballerina-standard-library/issues/1305)
 - [[#1250] Fix Hanging the Service when Returning Array](https://github.com/ballerina-platform/ballerina-standard-library/issues/1250)
 - [[#1307] Returning Union of Service Types from a Resource](https://github.com/ballerina-platform/ballerina-standard-library/issues/1307)
 - [[#1274] Fix Recursive Type Reference Causing Stack Overflow](https://github.com/ballerina-platform/ballerina-standard-library/issues/1274)

--- a/graphql-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/CompilerPluginTest.java
+++ b/graphql-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/CompilerPluginTest.java
@@ -76,6 +76,14 @@ public class CompilerPluginTest {
     }
 
     @Test
+    public void testValidService5() {
+        Package currentPackage = loadPackage("valid_service_5");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 0);
+    }
+
+    @Test
     public void testInvalidService1() {
         Package currentPackage = loadPackage("invalid_service_1");
         PackageCompilation compilation = currentPackage.getCompilation();

--- a/graphql-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_5/Ballerina.toml
+++ b/graphql-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_5/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "graphql_test"
+name = "valid_service_5"
+version = "0.1.0"

--- a/graphql-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_5/service.bal
+++ b/graphql-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_5/service.bal
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/graphql;
+
+enum Color {
+  RED,
+  GREEN,
+  BLUE
+}
+
+service graphql:Service on new graphql:Listener(4000) {
+    isolated resource function get color(Color color) returns Color {
+        return RED;
+    }
+}

--- a/graphql-compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/GraphqlFunctionValidator.java
+++ b/graphql-compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/GraphqlFunctionValidator.java
@@ -61,7 +61,7 @@ public class GraphqlFunctionValidator {
                 // object methods are valid, object methods that are remote functions are invalid
                 if (PluginUtils.isRemoteFunction(context, functionDefinitionNode)) {
                     PluginUtils.updateContext(context, CompilationErrors.INVALID_FUNCTION,
-                            functionDefinitionNode.location());
+                                              functionDefinitionNode.location());
                 }
             }
         }
@@ -80,15 +80,16 @@ public class GraphqlFunctionValidator {
         Optional<Symbol> symbolOptional = semanticModel.symbol(functionDefinitionNode);
         if (symbolOptional.isPresent()) {
             ResourceMethodSymbol resourceMethodSymbol = (ResourceMethodSymbol) symbolOptional.get();
-            if (resourceMethodSymbol.getName().isPresent()) {
-                if (!resourceMethodSymbol.getName().get().equals(PluginConstants.RESOURCE_FUNCTION_GET)) {
-                    PluginUtils.updateContext(context,
-                            CompilationErrors.INVALID_RESOURCE_FUNCTION_ACCESSOR, functionDefinitionNode.location());
+            Optional<String> methodName = resourceMethodSymbol.getName();
+            if (methodName.isPresent()) {
+                if (!methodName.get().equals(PluginConstants.RESOURCE_FUNCTION_GET)) {
+                    PluginUtils.updateContext(context, CompilationErrors.INVALID_RESOURCE_FUNCTION_ACCESSOR,
+                                              functionDefinitionNode.location());
                 }
             } else {
                 PluginUtils.updateContext(context,
-                        CompilationErrors.INVALID_RESOURCE_FUNCTION_ACCESSOR,
-                        functionDefinitionNode.location());
+                                          CompilationErrors.INVALID_RESOURCE_FUNCTION_ACCESSOR,
+                                          functionDefinitionNode.location());
             }
         }
     }
@@ -123,8 +124,8 @@ public class GraphqlFunctionValidator {
                     }
                     if (type == 0 && primitiveType == 0) { // error? - invalid
                         PluginUtils.updateContext(context,
-                                CompilationErrors.INVALID_RETURN_TYPE_ERROR_OR_NIL,
-                                functionDefinitionNode.location());
+                                                  CompilationErrors.INVALID_RETURN_TYPE_ERROR_OR_NIL,
+                                                  functionDefinitionNode.location());
                     } else if (primitiveType > 0 && type > 0) { // Person|string - invalid
                         PluginUtils.updateContext(context, CompilationErrors.INVALID_RETURN_TYPE
                                 , functionDefinitionNode.location());
@@ -137,14 +138,14 @@ public class GraphqlFunctionValidator {
                     // nil alone is invalid - must have a return type
                     if (returnTypeDesc.get().typeKind() == TypeDescKind.NIL) {
                         PluginUtils.updateContext(context, CompilationErrors.INVALID_RETURN_TYPE_NIL,
-                                functionDefinitionNode.location());
+                                                  functionDefinitionNode.location());
                     } else if (returnTypeDesc.get().typeKind() == TypeDescKind.ERROR) {
                         PluginUtils.updateContext(context, CompilationErrors.INVALID_RETURN_TYPE_ERROR,
-                                functionDefinitionNode.location());
+                                                  functionDefinitionNode.location());
                     } else {
                         if (hasInvalidReturnType(returnTypeDesc.get())) {
                             PluginUtils.updateContext(context, CompilationErrors.INVALID_RETURN_TYPE,
-                                    functionDefinitionNode.location());
+                                                      functionDefinitionNode.location());
                         }
                     }
                 }
@@ -162,9 +163,9 @@ public class GraphqlFunctionValidator {
                     List<ParameterSymbol> parameterSymbols = functionTypeSymbol.params().get();
                     // can have any number of valid input params
                     for (ParameterSymbol param : parameterSymbols) {
-                        if (hasInvalidInputParamType(param)) {
+                        if (hasInvalidInputParamType(param.typeDescriptor())) {
                             PluginUtils.updateContext(context, CompilationErrors.INVALID_RESOURCE_INPUT_PARAM,
-                                    functionDefinitionNode.location());
+                                                      functionDefinitionNode.location());
                         }
                     }
                 }
@@ -172,15 +173,21 @@ public class GraphqlFunctionValidator {
         }
     }
 
-    private boolean hasInvalidInputParamType(ParameterSymbol inputTypeSymbol) {
-        return !hasPrimitiveType(inputTypeSymbol.typeDescriptor());
+    private boolean hasInvalidInputParamType(TypeSymbol inputTypeSymbol) {
+        if (inputTypeSymbol.typeKind() == TypeDescKind.TYPE_REFERENCE) {
+            if ((((TypeReferenceTypeSymbol) inputTypeSymbol).definition()).kind() == SymbolKind.ENUM) {
+                return false;
+            }
+        } else {
+            return !hasPrimitiveType(inputTypeSymbol);
+        }
+        return true;
     }
 
     private boolean hasInvalidReturnType(TypeSymbol returnTypeSymbol) {
         boolean hasInvalidReturnType = false;
-        if (returnTypeSymbol.typeKind() == TypeDescKind.MAP ||
-                returnTypeSymbol.typeKind() == TypeDescKind.JSON ||
-                returnTypeSymbol.typeKind() == TypeDescKind.BYTE) {
+        if (returnTypeSymbol.typeKind() == TypeDescKind.MAP || returnTypeSymbol.typeKind() == TypeDescKind.JSON ||
+            returnTypeSymbol.typeKind() == TypeDescKind.BYTE) {
             return true;
         } else if (returnTypeSymbol.typeKind() == TypeDescKind.ARRAY) {
             // check member type
@@ -210,10 +217,10 @@ public class GraphqlFunctionValidator {
 
     private boolean hasPrimitiveType(TypeSymbol returnType) {
         return returnType.typeKind() == TypeDescKind.STRING ||
-                returnType.typeKind() == TypeDescKind.INT ||
-                returnType.typeKind() == TypeDescKind.FLOAT ||
-                returnType.typeKind() == TypeDescKind.BOOLEAN ||
-                returnType.typeKind() == TypeDescKind.DECIMAL;
+               returnType.typeKind() == TypeDescKind.INT ||
+               returnType.typeKind() == TypeDescKind.FLOAT ||
+               returnType.typeKind() == TypeDescKind.BOOLEAN ||
+               returnType.typeKind() == TypeDescKind.DECIMAL;
     }
 
     private boolean isValidServiceType(TypeSymbol returnTypeSymbol) {

--- a/graphql-compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/PluginConstants.java
+++ b/graphql-compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/PluginConstants.java
@@ -38,23 +38,23 @@ public class PluginConstants {
      * Compilation errors.
      */
     enum CompilationErrors {
-        INVALID_FUNCTION("Invalid method. Remote methods are not allowed.",
+        INVALID_FUNCTION("Invalid method. Remote methods are not allowed",
                 "GRAPHQL_101", DiagnosticSeverity.ERROR),
-        INVALID_RETURN_TYPE("Invalid return type for resource function.", "GRAPHQL_102",
+        INVALID_RETURN_TYPE("Invalid return type for resource function", "GRAPHQL_102",
                 DiagnosticSeverity.ERROR),
-        INVALID_RESOURCE_INPUT_PARAM("Invalid resource input parameter type.", "GRAPHQL_103",
+        INVALID_RESOURCE_INPUT_PARAM("Invalid resource input parameter type", "GRAPHQL_103",
                 DiagnosticSeverity.ERROR),
-        INVALID_RETURN_TYPE_NIL("Invalid return type nil. Resource function must have a return type.",
+        INVALID_RETURN_TYPE_NIL("Invalid return type nil. Resource function must have a return type",
                 "GRAPHQL_104", DiagnosticSeverity.ERROR),
         INVALID_RETURN_TYPE_ERROR_OR_NIL("Invalid return type error or nil. " +
-                "Resource function must have a return data type.", "GRAPHQL_105", DiagnosticSeverity.ERROR),
+                "Resource function must have a return data type", "GRAPHQL_105", DiagnosticSeverity.ERROR),
         INVALID_RESOURCE_FUNCTION_ACCESSOR("Invalid resource function accessor. Only get is allowed",
                 "GRAPHQL_106", DiagnosticSeverity.ERROR),
-        INVALID_MULTIPLE_LISTENERS("Multiple listener attachments. Only one graphql:Listener is allowed.",
+        INVALID_MULTIPLE_LISTENERS("Multiple listener attachments. Only one graphql:Listener is allowed",
                 "GRAPHQL_107", DiagnosticSeverity.ERROR),
         INVALID_MAX_QUERY_DEPTH("Invalid maxQueryDepth value. Value must be a positive integer",
                 "GRAPHQL_108", DiagnosticSeverity.ERROR),
-        INVALID_RETURN_TYPE_ERROR("Invalid return type error. Resource function must have a return data type.",
+        INVALID_RETURN_TYPE_ERROR("Invalid return type error. Resource function must have a return data type",
                 "GRAPHQL_109", DiagnosticSeverity.ERROR);
 
         private final String error;


### PR DESCRIPTION
## Purpose

Support Enum Type in GraphQL Resource Function Input Params.

## Examples
```
enum Color {
  RED,
  GREEN,
  BLUE
}

service graphql:Service on new graphql:Listener(4000) {
    isolated resource function get color(Color color) returns Color {
        return RED;
    }
} 
```
## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
