### PR TITLE
Use Included Record Parameters in Listener Init Function

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ This file contains all the notable changes done to the Ballerina GraphQL package
 - [[#1339] Improve Input Parameter Validation Logic in Compiler Plugin](https://github.com/ballerina-platform/ballerina-standard-library/issues/1339)
 - [[#1344] Improve Return Type Validation Logic in Compiler Plugin](https://github.com/ballerina-platform/ballerina-standard-library/issues/1344)
 - [[#1348] Add Validation to Return Type Service Class Definitions in Compiler Plugin](https://github.com/ballerina-platform/ballerina-standard-library/issues/1348)
+- [[#998] Use Included Record Parameters for Listener Config](https://github.com/ballerina-platform/ballerina-standard-library/issues/998)
 
 ### Fixed
 - [[#1305] Allow Enum as an Input Parameter](https://github.com/ballerina-platform/ballerina-standard-library/issues/1305)

--- a/graphql-ballerina/build.gradle
+++ b/graphql-ballerina/build.gradle
@@ -33,7 +33,7 @@ def ballerinaCentralAccessToken = System.getenv('BALLERINA_CENTRAL_ACCESS_TOKEN'
 def originalBallerinaToml = ballerinaTomlFile.text
 def originalDependenciesToml = dependenciesTomlFile.text
 def originalCompilerPluginToml = compilerPluginTomlFile.text
-def testCoverageParam = "--code-coverage --includes=io.ballerina.stdlib.graphql.*:ballerina.*"
+def testCoverageParam = "--code-coverage --jacoco-xml --includes=io.ballerina.stdlib.graphql.*:ballerina.graphql*"
 def distributionBinPath = project.projectDir.absolutePath + "/build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bin"
 
 def stripBallerinaExtensionVersion(String extVersion) {

--- a/graphql-ballerina/listener.bal
+++ b/graphql-ballerina/listener.bal
@@ -28,26 +28,16 @@ public class Listener {
     # + listenTo - An `http:Listener` or a port number to listen for the GraphQL service
     # + configuration - Configurations for the GraphQL service listener
     # + return - A `graphql:Error` if the listener initialization is failed, otherwise nil
-    public isolated function init(int|http:Listener listenTo, ListenerConfiguration? configuration = ())
+    public isolated function init(int|http:Listener listenTo, *ListenerConfiguration configuration)
     returns Error? {
         if (listenTo is int) {
-            http:Listener|error httpListener;
-            if (configuration is ListenerConfiguration) {
-                httpListener = new(listenTo, configuration);
-            } else {
-                httpListener = new(listenTo);
-            }
+            http:Listener|error httpListener = new(listenTo, configuration);
             if (httpListener is error) {
                 return error ServiceHandlingError("Listener initialization failed", httpListener);
             } else {
                 self.httpListener = httpListener;
             }
         } else {
-            if (configuration is ListenerConfiguration) {
-                string message =
-                    "Provided `HttpConfiguration` will be overridden by the given http listener configurations";
-                return error InvalidConfigurationError(message);
-            }
             self.httpListener = listenTo;
         }
         self.engine = check new(self);

--- a/graphql-ballerina/tests/11_listener_configurations_test.bal
+++ b/graphql-ballerina/tests/11_listener_configurations_test.bal
@@ -73,20 +73,6 @@ isolated function testTimeoutResponse() returns error? {
 @test:Config {
     groups: ["negative", "configs", "unit"]
 }
-function testConfigurationsWithHttpListener() returns error? {
-    http:Listener httpListener = check new(91021);
-    var graphqlListener = new Listener(httpListener, configs);
-    if (graphqlListener is Error) {
-        string message = "Provided `HttpConfiguration` will be overridden by the given http listener configurations";
-        test:assertEquals(message, graphqlListener.message());
-    } else {
-        test:assertFail("This must throw an error");
-    }
-}
-
-@test:Config {
-    groups: ["negative", "configs", "unit"]
-}
 function testInvalidMaxDepth() returns error? {
     Listener graphqlListener = check new Listener(91022);
     var result = graphqlListener.attach(InvalidDepthLimitService);

--- a/graphql-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/CompilerPluginTest.java
+++ b/graphql-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/CompilerPluginTest.java
@@ -44,7 +44,7 @@ public class CompilerPluginTest {
             .toAbsolutePath();
 
     @Test
-    public void testValidService1() {
+    public void testValidResourceReturnTypes() {
         Package currentPackage = loadPackage("valid_service_1");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -52,7 +52,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testValidService2() {
+    public void testValidResourceInputTypes() {
         Package currentPackage = loadPackage("valid_service_2");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -60,7 +60,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testValidService3() {
+    public void testValidServiceConfigurationAnnotation() {
         Package currentPackage = loadPackage("valid_service_3");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -68,7 +68,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testValidService4() {
+    public void testResourceReturningEnum() {
         Package currentPackage = loadPackage("valid_service_4");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -76,7 +76,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testValidService5() {
+    public void testEnumAsResourceInputParameter() {
         Package currentPackage = loadPackage("valid_service_5");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -84,7 +84,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testValidService6() {
+    public void testValidListenerConfigurations() {
         Package currentPackage = loadPackage("valid_service_6");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -92,7 +92,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testValidService7() {
+    public void testOptionalInputParametersInResources() {
         Package currentPackage = loadPackage("valid_service_7");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -100,7 +100,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testValidService8() {
+    public void testReturningUnionOfDistinctServiceObjects() {
         Package currentPackage = loadPackage("valid_service_8");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -108,7 +108,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testInvalidService1() {
+    public void testMultipleListenersOnSameService() {
         Package currentPackage = loadPackage("invalid_service_1");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -118,7 +118,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testInvalidService2() {
+    public void testRemoteFunctionsInService() {
         Package currentPackage = loadPackage("invalid_service_2");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -128,7 +128,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testInvalidService3() {
+    public void testInvalidResourceAccessor() {
         Package currentPackage = loadPackage("invalid_service_3");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -138,7 +138,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testInvalidService4() {
+    public void testInvalidResourceReturnTypes() {
         Package currentPackage = loadPackage("invalid_service_4");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -151,7 +151,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testInvalidService5() {
+    public void testInvalidResourceInputParameterTypes() {
         Package currentPackage = loadPackage("invalid_service_5");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -164,7 +164,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testInvalidService6() {
+    public void testInvalidMaxQueryDepthValue() {
         Package currentPackage = loadPackage("invalid_service_6");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -177,7 +177,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testInvalidService7() {
+    public void testReturningOnlyErrorOrNil() {
         Package currentPackage = loadPackage("invalid_service_7");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -187,7 +187,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testInvalidService8() {
+    public void testReturningOnlyNil() {
         Package currentPackage = loadPackage("invalid_service_8");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -197,7 +197,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testInvalidService9() {
+    public void testReturningOnlyError() {
         Package currentPackage = loadPackage("invalid_service_9");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -207,7 +207,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testInvalidService10() {
+    public void testListenerInitParameters() {
         Package currentPackage = loadPackage("invalid_service_10");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -220,7 +220,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testInvalidService11() {
+    public void testInvalidInputParameterUnions() {
         Package currentPackage = loadPackage("invalid_service_11");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -233,7 +233,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testInvalidService12() {
+    public void testInvalidResourceReturnTypeUnions() {
         Package currentPackage = loadPackage("invalid_service_12");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -246,7 +246,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testInvalidService13() {
+    public void testInvalidAccessorsInServicesReturningFromResources() {
         Package currentPackage = loadPackage("invalid_service_13");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -259,7 +259,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testInvalidService14() {
+    public void testInvalidReturnTypesInServicesReturningFromResources() {
         Package currentPackage = loadPackage("invalid_service_14");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -272,7 +272,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testInvalidService15() {
+    public void testInvalidInputParametersInServicesReturningFromResources() {
         Package currentPackage = loadPackage("invalid_service_15");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
@@ -281,6 +281,19 @@ public class CompilerPluginTest {
         for (Object obj : diagnostics) {
             Diagnostic diagnostic = (Diagnostic) obj;
             assertDiagnostic(diagnostic, CompilationErrors.INVALID_RESOURCE_INPUT_PARAM);
+        }
+    }
+
+    @Test
+    public void testInvalidListenerInitParameters() {
+        Package currentPackage = loadPackage("invalid_service_16");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
+        Object[] diagnostics = diagnosticResult.diagnostics().toArray();
+        for (Object obj : diagnostics) {
+            Diagnostic diagnostic = (Diagnostic) obj;
+            assertDiagnostic(diagnostic, CompilationErrors.INVALID_LISTENER_INIT);
         }
     }
 

--- a/graphql-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_16/Ballerina.toml
+++ b/graphql-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_16/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "graphql_test"
+name = "invalid_service_16"
+version = "0.1.0"

--- a/graphql-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_16/service.bal
+++ b/graphql-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_16/service.bal
@@ -17,26 +17,11 @@
 import ballerina/graphql;
 import ballerina/http;
 
-http:Listener httpListener = check new(91021);
-listener graphql:Listener listener1 = new(httpListener);
+http:Listener httpListener = check new(4000);
 
-graphql:ListenerConfiguration configs = {
-    timeout: 1.0
-};
-
-service graphql:Service on new graphql:Listener(4000, configs) {
-    resource function get name() returns string {
-            return "John";
-    }
-}
+listener graphql:Listener listener1 = new(httpListener, timeout = 1000, server = "0.0.0.0");
 
 service graphql:Service on listener1 {
-    resource function get name() returns string {
-            return "John";
-    }
-}
-
-service graphql:Service on new graphql:Listener(4000, timeout = 5, server = "0.0.0.0") {
     resource function get name() returns string {
             return "John";
     }

--- a/graphql-compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/GraphqlListenerValidator.java
+++ b/graphql-compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/GraphqlListenerValidator.java
@@ -80,9 +80,9 @@ public class GraphqlListenerValidator implements AnalysisTask<SyntaxNodeAnalysis
     private void verifyListenerArgType(SyntaxNodeAnalysisContext context,
                                        SeparatedNodeList<FunctionArgumentNode> functionArgs) {
         // two args are valid only if the first arg is numeric (i.e, port and config)
-        if (functionArgs.size() == 2) {
+        if (functionArgs.size() > 1) {
             PositionalArgumentNode firstArg = (PositionalArgumentNode) functionArgs.get(0);
-            PositionalArgumentNode secondArg = (PositionalArgumentNode) functionArgs.get(1);
+            FunctionArgumentNode secondArg = functionArgs.get(1);
             SyntaxKind firstArgSyntaxKind = firstArg.expression().kind();
             if (firstArgSyntaxKind != SyntaxKind.NUMERIC_LITERAL) {
                 PluginUtils.updateContext(context, PluginConstants.CompilationErrors.INVALID_LISTENER_INIT,


### PR DESCRIPTION
## Purpose
With this PR, instead of passing the` graphql:ListnerConfiguration` record, the input parameters can be passed separately as named parameters. 

Fixes: [#998](https://github.com/ballerina-platform/ballerina-standard-library/issues/998)

## Examples

```ballerina
import ballerina/graphql;

service graphql:Service on new graphql:Listener(9090, timeout = 5, host = "0.0.0.0") {
    // ....
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
