### PR TITLE
Enable windows tests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,4 +44,5 @@ jobs:
                 env:
                     packageUser: ${{ github.actor }}
                     packagePAT: ${{ secrets.GITHUB_TOKEN }}
-                run: ./gradlew.bat build -x test --no-daemon
+                run: |
+                    ./gradlew.bat build --no-daemon --scan

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,5 +44,6 @@ jobs:
                 env:
                     packageUser: ${{ github.actor }}
                     packagePAT: ${{ secrets.GITHUB_TOKEN }}
+                    JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
                 run: |
                     ./gradlew.bat build --no-daemon --scan

--- a/ballerina/modules/parser/tests/lexer_tests.bal
+++ b/ballerina/modules/parser/tests/lexer_tests.bal
@@ -520,12 +520,7 @@ isolated function testReadIntInvalidCharacter() returns error? {
     groups: ["lexer"]
 }
 isolated function testReadCommentToken() returns error? {
-    string document = string
-`{
-    name # Get Name
-    # New Line
-    address,age # Get Age
-}`;
+    string document = check getGraphQLDocumentFromFile("read_comment_token.txt");
     Lexer lexer = new(document);
     Token token = check lexer.read();
     Token expectedToken = getExpectedToken("{", T_OPEN_BRACE, 1, 1);

--- a/ballerina/modules/parser/tests/parser_tests.bal
+++ b/ballerina/modules/parser/tests/parser_tests.bal
@@ -117,18 +117,7 @@ fragment on on Profile {
     groups: ["operations", "parser"]
 }
 isolated function testMultipleAnonymousOperations() returns error? {
-    string document = string
-`{
-    profile {
-        name
-    }
-}
-
-{
-    profile {
-        age
-    }
-}`;
+    string document = check getGraphQLDocumentFromFile("multiple_anonymous_operations.txt");
     Parser parser = new(document);
     DocumentNode documentNode = check parser.parse();
     ErrorDetail[] errors = documentNode.getErrors();
@@ -151,8 +140,8 @@ isolated function testMultipleAnonymousOperations() returns error? {
             }
         ]
     };
-    test:assertEquals(e1, errors[0]);
-    test:assertEquals(e2, errors[1]);
+    test:assertEquals(errors[0], e1);
+    test:assertEquals(errors[1], e2);
 }
 
 @test:Config {
@@ -184,25 +173,14 @@ query getData {
             }
         ]
     };
-    test:assertEquals(e1, errors[0]);
+    test:assertEquals(errors[0], e1);
 }
 
 @test:Config {
     groups: ["operations", "parser"]
 }
 isolated function testNamedOperationWithAnonymousOperation() returns error? {
-    string document = string
-`query getData {
-    profile {
-        name
-    }
-}
-
-{
-    profile {
-        age
-    }
-}`;
+    string document = check getGraphQLDocumentFromFile("named_operation_with_anonymous_operation.txt");
     Parser parser = new(document);
     DocumentNode documentNode = check parser.parse();
     ErrorDetail[] errors = documentNode.getErrors();
@@ -216,7 +194,7 @@ isolated function testNamedOperationWithAnonymousOperation() returns error? {
             }
         ]
     };
-    test:assertEquals(e1, errors[0]);
+    test:assertEquals(errors[0], e1);
 }
 
 
@@ -224,24 +202,7 @@ isolated function testNamedOperationWithAnonymousOperation() returns error? {
     groups: ["operations", "parser"]
 }
 isolated function testNamedOperationWithMultipleAnonymousOperations() returns error? {
-    string document = string
-`{
-    profile {
-        name
-    }
-}
-
-query getData {
-    profile {
-        age
-    }
-}
-
-{
-    profile {
-        age
-    }
-}`;
+    string document = check getGraphQLDocumentFromFile("named_operation_with_multiple_anonymous_operations.txt");
     Parser parser = new(document);
     DocumentNode documentNode = check parser.parse();
     ErrorDetail[] errors = documentNode.getErrors();
@@ -264,32 +225,15 @@ query getData {
             }
         ]
     };
-    test:assertEquals(e1, errors[0]);
-    test:assertEquals(e2, errors[1]);
+    test:assertEquals(errors[0], e1);
+    test:assertEquals(errors[1], e2);
 }
 
 @test:Config {
     groups: ["operations", "parser"]
 }
 isolated function testThreeAnonymousOperations() returns error? {
-    string document = string
-`{
-    profile {
-        name
-    }
-}
-
-{
-    profile {
-        age
-    }
-}
-
-{
-    profile {
-        age
-    }
-}`;
+    string document = check getGraphQLDocumentFromFile("three_anonymous_operations.txt");
     Parser parser = new(document);
     DocumentNode documentNode = check parser.parse();
     ErrorDetail[] errors = documentNode.getErrors();
@@ -321,33 +265,16 @@ isolated function testThreeAnonymousOperations() returns error? {
             }
         ]
     };
-    test:assertEquals(e1, errors[0]);
-    test:assertEquals(e2, errors[1]);
-    test:assertEquals(e3, errors[2]);
+    test:assertEquals(errors[0], e1);
+    test:assertEquals(errors[1], e2);
+    test:assertEquals(errors[2], e3);
 }
 
 @test:Config {
     groups: ["operations", "parser"]
 }
 isolated function testMultipleOperationsWithSameName() returns error? {
-    string document = string
-`query getData {
-    profile {
-        name
-    }
-}
-
-query getData {
-    profile {
-        age
-    }
-}
-
-query getData {
-    profile {
-        age
-    }
-}`;
+    string document = check getGraphQLDocumentFromFile("multiple_operations_with_same_name.txt");
     Parser parser = new(document);
     DocumentNode documentNode = check parser.parse();
     ErrorDetail[] errors = documentNode.getErrors();
@@ -378,8 +305,8 @@ query getData {
             }
         ]
     };
-    test:assertEquals(e1, errors[0]);
-    test:assertEquals(e2, errors[1]);
+    test:assertEquals(errors[0], e1);
+    test:assertEquals(errors[1], e2);
 }
 
 @test:Config {

--- a/ballerina/modules/parser/tests/resources/documents/multiple_anonymous_operations.txt
+++ b/ballerina/modules/parser/tests/resources/documents/multiple_anonymous_operations.txt
@@ -1,0 +1,11 @@
+{
+    profile {
+        name
+    }
+}
+
+{
+    profile {
+        age
+    }
+}

--- a/ballerina/modules/parser/tests/resources/documents/multiple_operations_with_same_name.txt
+++ b/ballerina/modules/parser/tests/resources/documents/multiple_operations_with_same_name.txt
@@ -1,0 +1,17 @@
+query getData {
+    profile {
+        name
+    }
+}
+
+query getData {
+    profile {
+        age
+    }
+}
+
+query getData {
+    profile {
+        age
+    }
+}

--- a/ballerina/modules/parser/tests/resources/documents/named_operation_with_anonymous_operation.txt
+++ b/ballerina/modules/parser/tests/resources/documents/named_operation_with_anonymous_operation.txt
@@ -1,0 +1,11 @@
+query getData {
+    profile {
+        name
+    }
+}
+
+{
+    profile {
+        age
+    }
+}

--- a/ballerina/modules/parser/tests/resources/documents/named_operation_with_multiple_anonymous_operations.txt
+++ b/ballerina/modules/parser/tests/resources/documents/named_operation_with_multiple_anonymous_operations.txt
@@ -1,0 +1,17 @@
+{
+    profile {
+        name
+    }
+}
+
+query getData {
+    profile {
+        age
+    }
+}
+
+{
+    profile {
+        age
+    }
+}

--- a/ballerina/modules/parser/tests/resources/documents/read_comment_token.txt
+++ b/ballerina/modules/parser/tests/resources/documents/read_comment_token.txt
@@ -1,0 +1,5 @@
+{
+    name # Get Name
+    # New Line
+    address,age # Get Age
+}

--- a/ballerina/modules/parser/tests/resources/documents/three_anonymous_operations.txt
+++ b/ballerina/modules/parser/tests/resources/documents/three_anonymous_operations.txt
@@ -1,0 +1,17 @@
+{
+    profile {
+        name
+    }
+}
+
+{
+    profile {
+        age
+    }
+}
+
+{
+    profile {
+        age
+    }
+}

--- a/ballerina/modules/parser/tests/utils.bal
+++ b/ballerina/modules/parser/tests/utils.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/file;
+import ballerina/io;
+
+isolated function getGraphQLDocumentFromFile(string fileName) returns string|error {
+    string path = check file:joinPath("modules", "parser", "tests", "resources", "documents", fileName);
+    return io:fileReadString(path);
+}

--- a/ballerina/tests/14_fragments.bal
+++ b/ballerina/tests/14_fragments.bal
@@ -20,10 +20,7 @@ import ballerina/test;
     groups: ["fragments", "validation"]
 }
 isolated function testUnknownFragment() returns error? {
-    string document = string
-`query {
-    ...friend
-}`;
+    string document = check getGraphQLDocumentFromFile("unknown_fragment.txt");
     string url = "http://localhost:9091/validation";
     json actualPayload = check getJsonPayloadFromBadRequest(url, document);
     string message = string`Unknown fragment "friend".`;

--- a/ballerina/tests/19_distinct_service_unions.bal
+++ b/ballerina/tests/19_distinct_service_unions.bal
@@ -38,12 +38,7 @@ isolated function testUnionOfDistinctServiceObjects() returns error? {
     groups: ["service", "union", "negative"]
 }
 isolated function testInvalidQueryWithDistinctServiceUnions() returns error? {
-    string document = string
-`query {
-    profile(id: 200) {
-        name
-    }
-}`;
+    string document = check getGraphQLDocumentFromFile("invalid_query_with_distinct_service_unions.txt");
     string url = "http://localhost:9092/unions";
     json actualPayload = check getJsonPayloadFromBadRequest(url, document);
     json expectedPayload = {

--- a/ballerina/tests/resources/documents/invalid_query_with_distinct_service_unions.txt
+++ b/ballerina/tests/resources/documents/invalid_query_with_distinct_service_unions.txt
@@ -1,0 +1,5 @@
+query {
+    profile(id: 200) {
+        name
+    }
+}

--- a/ballerina/tests/resources/documents/unknown_fragment.txt
+++ b/ballerina/tests/resources/documents/unknown_fragment.txt
@@ -1,0 +1,3 @@
+query {
+    ...friend
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ shadowJarPluginVersion=5.2.0
 downloadPluginVersion=4.0.4
 releasePluginVersion=2.6.0
 testngVersion=7.4.0
-ballerinaGradlePluginVersion=0.10.1
+ballerinaGradlePluginVersion=0.10.2
 
 # Direct Dependencies
 stdlibAuthVersion=1.1.0-beta.3-20210709-185300-42be42e


### PR DESCRIPTION
## Purpose
$Subject

In Windows tests, the expected line numbers are incorrect compared to the actual ones when we use `string` literal inside ballerina code as the document. The reason is that the end of line character acts differently in *nix systems and the Windows systems. Therefore, the GraphQL documents are moved to a separate text file and read when running the tests.

Fixes: [#835](https://github.com/ballerina-platform/ballerina-standard-library/issues/835)

## Examples
N/A

## Checklist
- [x] Linked to an issue
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
