### PR TITLE
Add Block Strings Support

### DIFF
--- a/ballerina/modules/parser/tests/lexer_tests.bal
+++ b/ballerina/modules/parser/tests/lexer_tests.bal
@@ -223,6 +223,48 @@ isolated function testStringWithVariableDefinition() returns error? {
 @test:Config {
     groups: ["lexer"]
 }
+isolated function testBlockString() returns error? {
+    string document = string`{ greet(msg: """
+    Hello,
+        World!,
+
+            This is
+        GraphQL
+    Block String
+    """)}`;
+    Lexer lexer = new(document);
+    Token token = check lexer.read();
+
+    Token expectedToken = getExpectedToken("{", T_OPEN_BRACE, 1, 1);
+    test:assertEquals(token, expectedToken);
+
+    token = check lexer.read(); // Space
+    token = check lexer.read();
+    expectedToken = getExpectedToken("greet", T_IDENTIFIER, 1, 3);
+    test:assertEquals(token, expectedToken);
+
+    token = check lexer.read();
+    expectedToken = getExpectedToken("(", T_OPEN_PARENTHESES, 1, 8);
+    test:assertEquals(token, expectedToken);
+
+    token = check lexer.read(); // Space
+    expectedToken = getExpectedToken("msg", T_IDENTIFIER, 1, 9);
+    test:assertEquals(token, expectedToken);
+
+    token = check lexer.read();
+    expectedToken = getExpectedToken(":", T_COLON, 1, 12);
+    test:assertEquals(token, expectedToken);
+
+    token = check lexer.read(); // Space
+    token = check lexer.read();
+    string expectedValue = "Hello,         \n        World!,\n\n            This is\n        GraphQL\n    Block String";
+    expectedToken = getExpectedToken(expectedValue, T_STRING, 1, 16);
+    test:assertEquals(token, expectedToken);
+}
+
+@test:Config {
+    groups: ["lexer"]
+}
 isolated function testComplexString() returns error? {
     string document = "\n\n\nquery getData {\n    picture(h: 128,,, w: 248)\n}";
     Lexer lexer = new(document);

--- a/ballerina/tests/24_block_strings.bal
+++ b/ballerina/tests/24_block_strings.bal
@@ -1,0 +1,82 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/test;
+
+@test:Config {
+    groups: ["block_strings"]
+}
+isolated function testBlockStrings() returns error? {
+    http:Request request = new;
+    string document = check getGraphQLDocumentFromFile("block_strings.txt");
+    string url = "http://localhost:9091/inputs";
+    json actualPayload = check getJsonPayloadFromService(url, document);
+    json expectedPayload = check getJsonContentFromFile("block_strings.json");
+    test:assertEquals(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["block_strings", "variables"]
+}
+isolated function testBlockStringsWithVariables() returns error? {
+    http:Request request = new;
+    string document = check getGraphQLDocumentFromFile("block_strings_with_variables.txt");
+    json variables = { 
+        block: string`
+        This,
+            is
+                Graphql
+                    Block
+                        Strings!` 
+    };
+    string url = "http://localhost:9091/inputs";
+    json actualPayload = check getJsonPayloadFromService(url, document, variables);
+    json expectedPayload = check getJsonContentFromFile("block_strings_with_variables.json");
+    test:assertEquals(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["block_strings"]
+}
+isolated function testBlockStringsWithVariableDefaultValue() returns error? {
+    http:Request request = new;
+    string document = check getGraphQLDocumentFromFile("block_string_with_variable_default_value.txt");
+    string url = "http://localhost:9091/inputs";
+    json actualPayload = check getJsonPayloadFromService(url, document);
+    json expectedPayload = check getJsonContentFromFile("block_strings_with_variables_default_value.json");
+    test:assertEquals(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["block_strings", "variables"]
+}
+isolated function testBlockStringsWithVariablesIncludedInvalidCharacters() returns error? {
+    http:Request request = new;
+    string document = check getGraphQLDocumentFromFile("block_strings_with_variables.txt");
+    json variables = { 
+        block: string`
+        Hello,
+            World!,
+\"""
+        Yours, """
+            GraphQL` 
+    };
+    string url = "http://localhost:9091/inputs";
+    json actualPayload = check getJsonPayloadFromBadRequest(url, document, variables);
+    json expectedPayload = check getJsonContentFromFile("block_strings_with_variables_included_invalid_characters.json");
+    test:assertEquals(actualPayload, expectedPayload);
+}

--- a/ballerina/tests/resources/documents/block_string_with_variable_default_value.txt
+++ b/ballerina/tests/resources/documents/block_string_with_variable_default_value.txt
@@ -1,0 +1,5 @@
+($block: String = """
+        Hello,
+            GraphQL!,""" ){
+    sendEmail(message: $block) 
+}

--- a/ballerina/tests/resources/documents/block_strings.txt
+++ b/ballerina/tests/resources/documents/block_strings.txt
@@ -1,0 +1,9 @@
+{
+    sendEmail(message: """
+        Hello,
+            World!,
+
+        Yours,
+            GraphQL
+    """) 
+}

--- a/ballerina/tests/resources/documents/block_strings_with_variables.txt
+++ b/ballerina/tests/resources/documents/block_strings_with_variables.txt
@@ -1,0 +1,3 @@
+($block: String){
+    sendEmail(message: $block) 
+}

--- a/ballerina/tests/resources/expected_results/block_strings.json
+++ b/ballerina/tests/resources/expected_results/block_strings.json
@@ -1,0 +1,5 @@
+{
+    "data": {
+        "sendEmail": "Hello,\n            World!,\n\n        Yours,\n            GraphQL"
+    }
+}

--- a/ballerina/tests/resources/expected_results/block_strings_with_variables.json
+++ b/ballerina/tests/resources/expected_results/block_strings_with_variables.json
@@ -1,0 +1,5 @@
+{
+    "data": {
+        "sendEmail": "This,\n            is\n                Graphql\n                    Block\n                        Strings!"
+    }
+}

--- a/ballerina/tests/resources/expected_results/block_strings_with_variables_default_value.json
+++ b/ballerina/tests/resources/expected_results/block_strings_with_variables_default_value.json
@@ -1,0 +1,5 @@
+{
+    "data": {
+        "sendEmail": "Hello,\n            GraphQL!,"
+    }
+}

--- a/ballerina/tests/resources/expected_results/block_strings_with_variables_included_invalid_characters.json
+++ b/ballerina/tests/resources/expected_results/block_strings_with_variables_included_invalid_characters.json
@@ -1,0 +1,13 @@
+{
+    "errors": [
+        {
+            "message": "Variable \"block\" included invalid characters.",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 25
+                }
+            ]
+        }
+    ]
+}

--- a/ballerina/tests/test_services.bal
+++ b/ballerina/tests/test_services.bal
@@ -93,6 +93,10 @@ service /inputs on basicListener {
         }
         return [MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY];
     }
+
+    isolated resource function get sendEmail(string message) returns string {
+        return message;
+    }
 }
 
 service /records on basicListener {

--- a/ballerina/variable_validator.bal
+++ b/ballerina/variable_validator.bal
@@ -128,13 +128,29 @@ class VariableValidator {
         if argument.getKind() == parser:T_IDENTIFIER {
             argument.setValue(value);
         } else if getTypeNameFromValue(value) == getTypeName(argument) {
-            argument.setValue(value);
+            if getTypeNameFromValue(value) == STRING {
+                if self.hasInvalidCharaters(<string>value) {
+                    string message = string`Variable "${<string> argument.getVariableName()}" included invalid characters.`;
+                    self.errors.push(getErrorDetailRecord(message, location));
+                } else {
+                    argument.setValue((<string>value).trim());
+                }
+            } else {
+                argument.setValue(value);
+            }
         } else if value is int && getTypeName(argument) == FLOAT {
             argument.setValue(value);
         } else {
             string message = string`Variable "$${<string> argument.getVariableName()}" got invalid value ${value.toString()};` +
             string`Expected type ${getTypeName(argument)}. ${getTypeName(argument)} cannot represent value: ${value.toString()}`;
-            self.errors.push(getErrorDetailRecord(message, location)); 
+            self.errors.push(getErrorDetailRecord(message, location));
         }
+    }
+
+    public isolated function hasInvalidCharaters(string value) returns boolean {
+        if value.includes(string`"""`) || value.includes(string`\"""`)  {
+            return true;
+        }
+        return false;
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [[#1361] Add Variable Support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1361)
 - [[#1492] Add Mutation Support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1492)
 - [[#1723] Add Type Name Introspection](https://github.com/ballerina-platform/ballerina-standard-library/issues/1723)
+- [[#1704] Add Block String Support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1704)
 
 ### Changed
 - [[#1597] Validate Max Query Depth at Runtime](https://github.com/ballerina-platform/ballerina-standard-library/issues/1597)


### PR DESCRIPTION
## Purpose

Fixes: [#1704](https://github.com/ballerina-platform/ballerina-standard-library/issues/1704)

## Examples
In GraphQL documents, when we need multi-line strings, we can use block strings as follow:
```graphql
query sendEmail() {
    sendEmail(message: """
        Hello,
          World!,

        Yours,
            GraphQL
    """)
}
```
## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
