### PR TITLE
Add Context Support for GraphQL Resolvers

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -62,6 +62,31 @@ modules = [
 
 [[package]]
 org = "ballerina"
+name = "graphql"
+version = "1.0.0"
+transitive = false
+dependencies = [
+	{org = "ballerina", name = "auth"},
+	{org = "ballerina", name = "file"},
+	{org = "ballerina", name = "http"},
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "jwt"},
+	{org = "ballerina", name = "lang.array"},
+	{org = "ballerina", name = "lang.runtime"},
+	{org = "ballerina", name = "lang.value"},
+	{org = "ballerina", name = "oauth2"},
+	{org = "ballerina", name = "regex"},
+	{org = "ballerina", name = "test"},
+	{org = "ballerina", name = "url"}
+]
+modules = [
+	{org = "ballerina", packageName = "graphql", moduleName = "graphql"},
+	{org = "ballerina", packageName = "graphql", moduleName = "graphql.parser"}
+]
+
+[[package]]
+org = "ballerina"
 name = "http"
 version = "2.0.0"
 transitive = false
@@ -220,6 +245,7 @@ name = "log"
 version = "2.0.0"
 transitive = true
 dependencies = [
+	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "observe"}
 ]

--- a/ballerina/annotation_processor.bal
+++ b/ballerina/annotation_processor.bal
@@ -27,11 +27,10 @@ isolated function getListenerAuthConfig(GraphqlServiceConfig? serviceConfig) ret
 }
 
 isolated function getContextInit(GraphqlServiceConfig? serviceConfig) returns ContextInit {
-    ContextInit? contextInit = serviceConfig?.contextInit;
-    if contextInit is ContextInit {
-        return contextInit;
+    if serviceConfig is GraphqlServiceConfig {
+        return serviceConfig.contextInit;
     }
-    return initContext;
+    return initDefaultContext;
 }
 
 isolated function getServiceConfig(Service serviceObject) returns GraphqlServiceConfig? {

--- a/ballerina/annotation_processor.bal
+++ b/ballerina/annotation_processor.bal
@@ -26,6 +26,14 @@ isolated function getListenerAuthConfig(GraphqlServiceConfig? serviceConfig) ret
     }
 }
 
+isolated function getContextInit(GraphqlServiceConfig? serviceConfig) returns ContextInit {
+    ContextInit? contextInit = serviceConfig?.contextInit;
+    if contextInit is ContextInit {
+        return contextInit;
+    }
+    return initContext;
+}
+
 isolated function getServiceConfig(Service serviceObject) returns GraphqlServiceConfig? {
     typedesc<any> serviceType = typeof serviceObject;
     return serviceType.@ServiceConfig;

--- a/ballerina/annotations.bal
+++ b/ballerina/annotations.bal
@@ -14,8 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/http;
-
 # Provides a set of configurations for the GraphQL service.
 #
 # + maxQueryDepth - The maximum depth allowed for a query
@@ -24,10 +22,8 @@ import ballerina/http;
 public type GraphqlServiceConfig record {|
     int maxQueryDepth?;
     ListenerAuthConfig[] auth?;
-    ContextInit contextInit?;
+    ContextInit contextInit = initDefaultContext;
 |};
 
 # The annotation to configure a GraphQL service.
 public annotation GraphqlServiceConfig ServiceConfig on service;
-
-type ContextInit isolated function (http:Request request, http:RequestContext requestContext) returns Context|error;

--- a/ballerina/annotations.bal
+++ b/ballerina/annotations.bal
@@ -14,14 +14,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/http;
+
 # Provides a set of configurations for the GraphQL service.
 #
 # + maxQueryDepth - The maximum depth allowed for a query
 # + auth - Listener authenticaton configurations
+# + contextInit - Function to initialize the context. If not provided, an empty context will be created
 public type GraphqlServiceConfig record {|
     int maxQueryDepth?;
     ListenerAuthConfig[] auth?;
+    ContextInit contextInit?;
 |};
 
 # The annotation to configure a GraphQL service.
 public annotation GraphqlServiceConfig ServiceConfig on service;
+
+type ContextInit isolated function (http:Request request) returns Context|error;

--- a/ballerina/annotations.bal
+++ b/ballerina/annotations.bal
@@ -30,4 +30,4 @@ public type GraphqlServiceConfig record {|
 # The annotation to configure a GraphQL service.
 public annotation GraphqlServiceConfig ServiceConfig on service;
 
-type ContextInit isolated function (http:Request request) returns Context|error;
+type ContextInit isolated function (http:Request request, http:RequestContext requestContext) returns Context|error;

--- a/ballerina/auth_utils.bal
+++ b/ballerina/auth_utils.bal
@@ -95,7 +95,7 @@ isolated function create401Response() returns http:Response {
     ErrorDetail authnError = {
         message: "Required authentication information is either missing or not valid for the resource."
     };
-    response.setJsonPayload({ errors: [authnError] });
+    response.setPayload({ errors: [authnError] });
     return response;
 }
 
@@ -105,6 +105,6 @@ isolated function create403Response() returns http:Response {
     ErrorDetail authzError = {
         message: "Access is denied to the requested resource. The user might not have enough permission."
     };
-    response.setJsonPayload({ errors: [authzError] });
+    response.setPayload({ errors: [authzError] });
     return response;
 }

--- a/ballerina/auth_utils.bal
+++ b/ballerina/auth_utils.bal
@@ -95,7 +95,7 @@ isolated function create401Response() returns http:Response {
     ErrorDetail authnError = {
         message: "Required authentication information is either missing or not valid for the resource."
     };
-    response.setPayload({ errors: [authnError] });
+    response.setJsonPayload({ errors: [authnError] });
     return response;
 }
 
@@ -105,6 +105,6 @@ isolated function create403Response() returns http:Response {
     ErrorDetail authzError = {
         message: "Access is denied to the requested resource. The user might not have enough permission."
     };
-    response.setPayload({ errors: [authzError] });
+    response.setJsonPayload({ errors: [authzError] });
     return response;
 }

--- a/ballerina/context.bal
+++ b/ballerina/context.bal
@@ -65,6 +65,6 @@ public isolated class Context {
     }
 }
 
-isolated function initContext(http:Request request, http:RequestContext requestContext) returns Context|error {
+isolated function initDefaultContext(http:Request request, http:RequestContext requestContext) returns Context|error {
     return new;
 }

--- a/ballerina/context.bal
+++ b/ballerina/context.bal
@@ -20,7 +20,7 @@ import ballerina/lang.value;
 public isolated class Context {
     private final map<value:Cloneable|isolated object {}> attributes;
 
-    isolated function init() {
+    public isolated function init() {
         self.attributes = {};
     }
 

--- a/ballerina/context.bal
+++ b/ballerina/context.bal
@@ -65,6 +65,6 @@ public isolated class Context {
     }
 }
 
-isolated function initContext(http:Request request) returns Context|error {
+isolated function initContext(http:Request request, http:RequestContext requestContext) returns Context|error {
     return new;
 }

--- a/ballerina/context.bal
+++ b/ballerina/context.bal
@@ -1,0 +1,70 @@
+// Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/lang.value;
+
+public isolated class Context {
+    private final map<value:Cloneable|isolated object {}> attributes;
+
+    isolated function init() {
+        self.attributes = {};
+    }
+
+    public isolated function add(string 'key, value:Cloneable|isolated object {} value) returns Error? {
+        lock {
+            if self.attributes.hasKey('key) {
+                return error Error(string`Cannot add attribute to the context. Key "${'key}" already exists`);
+            } else if value is value:Cloneable {
+                self.attributes['key] = value.clone();
+            } else {
+                self.attributes['key] = value;
+            }
+        }
+    }
+
+    public isolated function get(string 'key) returns value:Cloneable|isolated object {} {
+        lock {
+            if self.attributes.hasKey('key) {
+                value:Cloneable|isolated object {} value = self.attributes.get('key);
+                if value is value:Cloneable {
+                    return value.clone();
+                } else {
+                    return value;
+                }
+            }
+        }
+        return error Error(string`Attribute with the key "${'key}" not found in the context`);
+    }
+
+    public isolated function remove(string 'key) returns value:Cloneable|isolated object {} {
+        lock {
+            if self.attributes.hasKey('key) {
+                value:Cloneable|isolated object {} value = self.attributes.remove('key);
+                if value is value:Cloneable {
+                    return value.clone();
+                } else {
+                    return value;
+                }
+            }
+        }
+        return error Error(string`Attribute with the key "${'key}" not found in the context`);
+    }
+}
+
+isolated function initContext(http:Request request) returns Context|error {
+    return new;
+}

--- a/ballerina/context.bal
+++ b/ballerina/context.bal
@@ -36,7 +36,7 @@ public isolated class Context {
         }
     }
 
-    public isolated function get(string 'key) returns value:Cloneable|isolated object {} {
+    public isolated function get(string 'key) returns value:Cloneable|isolated object {}|Error {
         lock {
             if self.attributes.hasKey('key) {
                 value:Cloneable|isolated object {} value = self.attributes.get('key);
@@ -50,7 +50,7 @@ public isolated class Context {
         return error Error(string`Attribute with the key "${'key}" not found in the context`);
     }
 
-    public isolated function remove(string 'key) returns value:Cloneable|isolated object {} {
+    public isolated function remove(string 'key) returns value:Cloneable|isolated object {}|Error {
         lock {
             if self.attributes.hasKey('key) {
                 value:Cloneable|isolated object {} value = self.attributes.remove('key);

--- a/ballerina/engine.bal
+++ b/ballerina/engine.bal
@@ -19,16 +19,15 @@ import graphql.parser;
 isolated class Engine {
     private final readonly & __Schema schema;
     private final int? maxQueryDepth;
-    private final readonly & ListenerAuthConfig[]? auth;
+    private final Context context;
 
-    isolated function init(__Schema schema, GraphqlServiceConfig? serviceConfig) returns Error? {
+    isolated function init(__Schema schema, int? maxQueryDepth) returns Error? {
         self.schema = schema.cloneReadOnly();
-        self.auth = getListenerAuthConfig(serviceConfig).cloneReadOnly();
-        int? maxQueryDepth = getMaxQueryDepth(serviceConfig);
         if maxQueryDepth is int && maxQueryDepth < 1 {
             return error Error("Max query depth value must be a positive integer");
         }
         self.maxQueryDepth = maxQueryDepth;
+        self.context = new;
     }
 
     isolated function validate(string documentString, string? operationName, map<json>? variables) returns parser:OperationNode|OutputObject {
@@ -125,7 +124,7 @@ isolated class Engine {
         }
     }
 
-    isolated function getAuthConfigs() returns ListenerAuthConfig[]? {
-        return self.auth;
+    isolated function getContext() returns Context {
+        return self.context;
     }
 }

--- a/ballerina/engine.bal
+++ b/ballerina/engine.bal
@@ -19,7 +19,6 @@ import graphql.parser;
 isolated class Engine {
     private final readonly & __Schema schema;
     private final int? maxQueryDepth;
-    private final Context context;
 
     isolated function init(__Schema schema, int? maxQueryDepth) returns Error? {
         self.schema = schema.cloneReadOnly();
@@ -27,7 +26,6 @@ isolated class Engine {
             return error Error("Max query depth value must be a positive integer");
         }
         self.maxQueryDepth = maxQueryDepth;
-        self.context = new;
     }
 
     isolated function validate(string documentString, string? operationName, map<json>? variables) returns parser:OperationNode|OutputObject {
@@ -44,8 +42,8 @@ isolated class Engine {
         }
     }
 
-    isolated function execute(parser:OperationNode operationNode) returns OutputObject {
-        ExecutorVisitor executor = new(self, self.schema);
+    isolated function execute(parser:OperationNode operationNode, Context context) returns OutputObject {
+        ExecutorVisitor executor = new(self, self.schema, context);
         OutputObject outputObject = executor.getExecutorResult(operationNode);
         ResponseCoerceVisitor responseCoerceVisitor = new(self.schema, outputObject);
         return responseCoerceVisitor.getCoercedOutputObject(operationNode);
@@ -122,9 +120,5 @@ isolated class Engine {
             };
             return getOutputObjectFromErrorDetail(errorDetail);
         }
-    }
-
-    isolated function getContext() returns Context {
-        return self.context;
     }
 }

--- a/ballerina/executor_visitor.bal
+++ b/ballerina/executor_visitor.bal
@@ -23,10 +23,12 @@ class ExecutorVisitor {
     private final Engine engine;
     private Data data;
     private ErrorDetail[] errors;
+    private Context context;
 
-    isolated function init(Engine engine, __Schema schema) {
+    isolated function init(Engine engine, __Schema schema, Context context) {
         self.engine = engine;
         self.schema = schema;
+        self.context = context;
         self.data = {};
         self.errors = [];
     }

--- a/ballerina/http_service.bal
+++ b/ballerina/http_service.bal
@@ -28,7 +28,9 @@ isolated service class HttpService {
     }
 
     isolated resource function get .(http:Request request) returns http:Response {
-        Context|http:Response context = self.initContext(request);
+         // TODO: Temporary initiate the request context here, since it is not yet added in the HTTP resource
+        http:RequestContext requestContext = new;
+        Context|http:Response context = self.initContext(request, requestContext);
         if context is http:Response {
             return context;
         } else {
@@ -41,7 +43,9 @@ isolated service class HttpService {
     }
 
     isolated resource function post .(http:Request request) returns http:Response {
-        Context|http:Response context = self.initContext(request);
+         // TODO: Temporary initiate the request context here, since it is not yet added in the HTTP resource
+        http:RequestContext requestContext = new;
+        Context|http:Response context = self.initContext(request, requestContext);
         if context is http:Response {
             return context;
         } else {
@@ -53,10 +57,10 @@ isolated service class HttpService {
         }
     }
 
-    isolated function initContext(http:Request request) returns Context|http:Response {
+    isolated function initContext(http:Request request, http:RequestContext requestContext) returns Context|http:Response {
         ContextInit? contextInit = self.contextInit;
         if contextInit != () {
-            Context|error context = contextInit(request);
+            Context|error context = contextInit(request, requestContext);
             if context is error {
                 json payload = { errors: [{ message: context.message() }] };
                 http:Response response = new;

--- a/ballerina/http_service.bal
+++ b/ballerina/http_service.bal
@@ -18,24 +18,55 @@ import ballerina/http;
 
 isolated service class HttpService {
     private final Engine engine;
+    private final readonly & ListenerAuthConfig[]? authConfig;
+    private final ContextInit contextInit;
 
-    isolated function init(Engine engine) {
+    isolated function init(Engine engine, GraphqlServiceConfig? serviceConfig) {
         self.engine = engine;
+        self.authConfig = getListenerAuthConfig(serviceConfig).cloneReadOnly();
+        self.contextInit = getContextInit(serviceConfig);
     }
 
     isolated resource function get .(http:Request request) returns http:Response {
-        http:Response? authResult = authenticateService(self.engine.getAuthConfigs(), request);
-        if authResult is http:Response {
-            return authResult;
+        Context|http:Response context = self.initContext(request);
+        if context is http:Response {
+            return context;
+        } else {
+            http:Response? authResult = authenticateService(self.authConfig, request);
+            if authResult is http:Response {
+                return authResult;
+            }
+            return handleGetRequests(self.engine, request);
         }
-        return handleGetRequests(self.engine, request);
     }
 
     isolated resource function post .(http:Request request) returns http:Response {
-        http:Response? authResult = authenticateService(self.engine.getAuthConfigs(), request);
-        if authResult is http:Response {
-            return authResult;
+        Context|http:Response context = self.initContext(request);
+        if context is http:Response {
+            return context;
+        } else {
+            http:Response? authResult = authenticateService(self.authConfig, request);
+            if authResult is http:Response {
+                return authResult;
+            }
+            return handlePostRequests(self.engine, request);
         }
-        return handlePostRequests(self.engine, request);
+    }
+
+    isolated function initContext(http:Request request) returns Context|http:Response {
+        ContextInit? contextInit = self.contextInit;
+        if contextInit != () {
+            Context|error context = contextInit(request);
+            if context is error {
+                json payload = { errors: [{ message: context.message() }] };
+                http:Response response = new;
+                response.statusCode = http:STATUS_INTERNAL_SERVER_ERROR;
+                response.setPayload(payload);
+                return response;
+            } else {
+                return context;
+            }
+        }
+        return new Context();
     }
 }

--- a/ballerina/http_service.bal
+++ b/ballerina/http_service.bal
@@ -38,7 +38,7 @@ isolated service class HttpService {
             if authResult is http:Response {
                 return authResult;
             }
-            return handleGetRequests(self.engine, request);
+            return handleGetRequests(self.engine, request, context);
         }
     }
 
@@ -53,24 +53,20 @@ isolated service class HttpService {
             if authResult is http:Response {
                 return authResult;
             }
-            return handlePostRequests(self.engine, request);
+            return handlePostRequests(self.engine, request, context);
         }
     }
 
     isolated function initContext(http:Request request, http:RequestContext requestContext) returns Context|http:Response {
-        ContextInit? contextInit = self.contextInit;
-        if contextInit != () {
-            Context|error context = contextInit(request, requestContext);
-            if context is error {
-                json payload = { errors: [{ message: context.message() }] };
-                http:Response response = new;
-                response.statusCode = http:STATUS_INTERNAL_SERVER_ERROR;
-                response.setPayload(payload);
-                return response;
-            } else {
-                return context;
-            }
+        Context|error context = self.contextInit(request, requestContext);
+        if context is error {
+            json payload = { errors: [{ message: context.message() }] };
+            http:Response response = new;
+            response.statusCode = http:STATUS_INTERNAL_SERVER_ERROR;
+            response.setPayload(payload);
+            return response;
+        } else {
+            return context;
         }
-        return new Context();
     }
 }

--- a/ballerina/listener.bal
+++ b/ballerina/listener.bal
@@ -51,10 +51,11 @@ public class Listener {
     public isolated function attach(Service s, string[]|string? name = ()) returns Error? {
         __Schema schema = check createSchema(s);
         GraphqlServiceConfig? serviceConfig = getServiceConfig(s);
-        Engine engine = check new(schema, serviceConfig);
+        int? maxQueryDepth = getMaxQueryDepth(serviceConfig);
+        Engine engine = check new(schema, maxQueryDepth);
         attachServiceToEngine(s, engine);
 
-        HttpService httpService = new(engine);
+        HttpService httpService = new(engine, serviceConfig);
         error? result = self.httpListener.attach(httpService, name);
         if (result is error) {
             return error Error("Error occurred while attaching the service", result);

--- a/ballerina/tests/26_nullable_values.bal
+++ b/ballerina/tests/26_nullable_values.bal
@@ -89,7 +89,7 @@ isolated function testNullValueForDefaultableArguments() returns error? {
 }
 
 @test:Config {
-    groups: ["inputs", "nullable", "test"]
+    groups: ["inputs", "nullable"]
 }
 isolated function testNullValueInInputObjectField() returns error? {
     string url = "http://localhost:9091/null_values";
@@ -106,7 +106,7 @@ isolated function testNullValueInInputObjectField() returns error? {
 }
 
 @test:Config {
-    groups: ["inputs", "nullable", "test"]
+    groups: ["inputs", "nullable"]
 }
 isolated function testNullAsResourceFunctionName() returns error? {
     string url = "http://localhost:9091/null_values";

--- a/ballerina/tests/27_context.bal
+++ b/ballerina/tests/27_context.bal
@@ -21,15 +21,17 @@ import ballerina/test;
     groups: ["context"]
 }
 function testCreatingContextWithScalarValues() returns error? {
-    ContextInit contextInit = isolated function (http:Request request) returns Context|error {
-        Context context = new;
-        check context.add("String", "Ballerina");
-        check context.add("Int", 5);
-        check context.add("Boolean", false);
-        return context;
-    };
+    ContextInit contextInit =
+        isolated function (http:Request request, http:RequestContext requestContext) returns Context|error {
+            Context context = new;
+            check context.add("String", "Ballerina");
+            check context.add("Int", 5);
+            check context.add("Boolean", false);
+            return context;
+        };
     http:Request request = new;
-    Context context = check contextInit(request);
+    http:RequestContext requestContext = new;
+    Context context = check contextInit(request, requestContext);
     test:assertEquals(<string> check context.get("String"), "Ballerina");
     test:assertEquals(<int> check context.get("Int"), 5);
     test:assertEquals(<boolean> check context.get("Boolean"), false);
@@ -39,13 +41,15 @@ function testCreatingContextWithScalarValues() returns error? {
     groups: ["context"]
 }
 function testCreatingContextWithObjectValues() returns error? {
-    ContextInit contextInit = isolated function (http:Request request) returns Context|error {
-        Context context = new;
-        check context.add("HierarchicalServiceObject", new HierarchicalName());
-        return context;
-    };
+    ContextInit contextInit =
+        isolated function (http:Request request, http:RequestContext requestContext) returns Context|error {
+            Context context = new;
+            check context.add("HierarchicalServiceObject", new HierarchicalName());
+            return context;
+        };
     http:Request request = new;
-    Context context = check contextInit(request);
+    http:RequestContext requestContext = new;
+    Context context = check contextInit(request, requestContext);
     test:assertTrue((check context.get("HierarchicalServiceObject")) is HierarchicalName);
 }
 
@@ -53,13 +57,15 @@ function testCreatingContextWithObjectValues() returns error? {
     groups: ["context"]
 }
 function testRemovingAttributeFromContext() returns error? {
-    ContextInit contextInit = isolated function (http:Request request) returns Context|error {
-        Context context = new;
-        check context.add("String", "Ballerina");
-        return context;
-    };
+    ContextInit contextInit =
+        isolated function (http:Request request, http:RequestContext requestContext) returns Context|error {
+            Context context = new;
+            check context.add("String", "Ballerina");
+            return context;
+        };
     http:Request request = new;
-    Context context = check contextInit(request);
+    http:RequestContext requestContext = new;
+    Context context = check contextInit(request, requestContext);
     var attribute1 = check context.remove("String");
     test:assertTrue(attribute1 is string);
     test:assertEquals(<string>attribute1, "Ballerina");
@@ -73,13 +79,15 @@ function testRemovingAttributeFromContext() returns error? {
     groups: ["context"]
 }
 function testRequestingInvalidAttributeFromContext() returns error? {
-    ContextInit contextInit = isolated function (http:Request request) returns Context|error {
-        Context context = new;
-        check context.add("String", "Ballerina");
-        return context;
-    };
+    ContextInit contextInit =
+        isolated function (http:Request request, http:RequestContext requestContext) returns Context|error {
+            Context context = new;
+            check context.add("String", "Ballerina");
+            return context;
+        };
     http:Request request = new;
-    Context context = check contextInit(request);
+    http:RequestContext requestContext = new;
+    Context context = check contextInit(request, requestContext);
     var invalidAttribute = context.get("No");
     test:assertTrue(invalidAttribute is Error);
     test:assertEquals((<Error>invalidAttribute).message(), "Attribute with the key \"No\" not found in the context");
@@ -89,14 +97,16 @@ function testRequestingInvalidAttributeFromContext() returns error? {
     groups: ["context"]
 }
 function testAddingDuplicateAttribute() returns error? {
-    ContextInit contextInit = isolated function (http:Request request) returns Context|error {
-        Context context = new;
-        check context.add("String", "Ballerina");
-        check context.add("String", "Ballerina");
-        return context;
-    };
+    ContextInit contextInit =
+        isolated function (http:Request request, http:RequestContext requestContext) returns Context|error {
+            Context context = new;
+            check context.add("String", "Ballerina");
+            check context.add("String", "Ballerina");
+            return context;
+        };
     http:Request request = new;
-    Context|error context = contextInit(request);
+    http:RequestContext requestContext = new;
+    Context|error context = contextInit(request, requestContext);
     test:assertTrue(context is error);
     test:assertEquals((<error>context).message(), "Cannot add attribute to the context. Key \"String\" already exists");
 }

--- a/ballerina/tests/27_context.bal
+++ b/ballerina/tests/27_context.bal
@@ -232,20 +232,12 @@ isolated function testContextWithHttpHeaderValuesInRemoteFunctionWithInvalidScop
 isolated function testContextWithMissingAttribute() returns error? {
     string url = "http://localhost:9092/context";
     string document = "mutation { update { name } }";
-    http:Request request = new;
-    request.setPayload({ query: document });
-    json actualPayload = check getJsonPayloadFromRequest(url, request);
+    json actualPayload = check assertResponseAndGetPayload(url, document,
+                                                           statusCode = http:STATUS_INTERNAL_SERVER_ERROR);
     json expectedPayload = {
         errors: [
             {
-                message: "Http header does not exist",
-                locations: [
-                    {
-                        line: 1,
-                        column: 12
-                    }
-                ],
-                path: ["update"]
+                message: "Http header does not exist"
             }
         ]
     };

--- a/ballerina/tests/27_context.bal
+++ b/ballerina/tests/27_context.bal
@@ -78,6 +78,27 @@ function testRemovingAttributeFromContext() returns error? {
 @test:Config {
     groups: ["context"]
 }
+function testRemovingObjectAttributeFromContext() returns error? {
+    ContextInit contextInit =
+        isolated function (http:Request request, http:RequestContext requestContext) returns Context|error {
+            Context context = new;
+            check context.add("HierarchicalServiceObject", new HierarchicalName());
+            return context;
+        };
+    http:Request request = new;
+    http:RequestContext requestContext = new;
+    Context context = check contextInit(request, requestContext);
+    var attribute1 = check context.remove("HierarchicalServiceObject");
+    test:assertTrue(attribute1 is HierarchicalName);
+
+    var attribute2 = context.remove("String");
+    test:assertTrue(attribute2 is Error);
+    test:assertEquals((<Error>attribute2).message(), "Attribute with the key \"String\" not found in the context");
+}
+
+@test:Config {
+    groups: ["context"]
+}
 function testRequestingInvalidAttributeFromContext() returns error? {
     ContextInit contextInit =
         isolated function (http:Request request, http:RequestContext requestContext) returns Context|error {

--- a/ballerina/tests/auth_test_utils.bal
+++ b/ballerina/tests/auth_test_utils.bal
@@ -95,7 +95,7 @@ isolated function sendNoTokenRequest(int port, string path) returns http:Respons
         }
     });
     json payload = { "query": "{ greeting }" };
-    return <@untainted> clientEP->post(path, payload);
+    return clientEP->post(path, payload);
 }
 
 isolated function sendBasicTokenRequest(int port, string path, string username, string password) returns http:Response|http:ClientError {
@@ -112,7 +112,7 @@ isolated function sendBasicTokenRequest(int port, string path, string username, 
         }
     });
     json payload = { "query": "{ greeting }" };
-    return <@untainted> clientEP->post(path, payload);
+    return clientEP->post(path, payload);
 }
 
 isolated function sendBearerTokenRequest(int port, string path, string token) returns http:Response|http:ClientError {
@@ -128,7 +128,7 @@ isolated function sendBearerTokenRequest(int port, string path, string token) re
         }
     });
     json payload = { "query": "{ greeting }" };
-    return <@untainted> clientEP->post(path, payload);
+    return clientEP->post(path, payload);
 }
 
 isolated function sendJwtRequest(int port, string path) returns http:Response|http:ClientError {
@@ -159,7 +159,7 @@ isolated function sendJwtRequest(int port, string path) returns http:Response|ht
         }
     });
     json payload = { "query": "{ greeting }" };
-    return <@untainted> clientEP->post(path, payload);
+    return clientEP->post(path, payload);
 }
 
 isolated function sendOAuth2TokenRequest(int port, string path) returns http:Response|http:ClientError {
@@ -185,7 +185,7 @@ isolated function sendOAuth2TokenRequest(int port, string path) returns http:Res
         }
     });
     json payload = { "query": "{ greeting }" };
-    return <@untainted> clientEP->post(path, payload);
+    return clientEP->post(path, payload);
 }
 
 isolated function assertSuccess(http:Response|http:ClientError response) {

--- a/ballerina/tests/test_services.bal
+++ b/ballerina/tests/test_services.bal
@@ -727,7 +727,7 @@ service /null_values on basicListener {
 @ServiceConfig {
     contextInit: isolated function (http:Request request, http:RequestContext requestContext) returns Context|error {
         Context context = new;
-        check context.add("scope", request.getHeader("scope"));
+        check context.add("scope", check request.getHeader("scope"));
         return context;
     }
 }

--- a/ballerina/tests/test_services.bal
+++ b/ballerina/tests/test_services.bal
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/http;
 import ballerina/lang.runtime;
 
 Service simpleService = service object {
@@ -719,6 +720,41 @@ service /null_values on basicListener {
     resource function get 'null(int? value) returns string? {
         if value != () {
             return "Hello";
+        }
+    }
+}
+
+@ServiceConfig {
+    contextInit: isolated function (http:Request request, http:RequestContext requestContext) returns Context|error {
+        Context context = new;
+        check context.add("scope", request.getHeader("scope"));
+        return context;
+    }
+}
+service /context on serviceTypeListener {
+    isolated resource function get profile(Context context) returns Person|error {
+        var scope = check context.get("scope");
+        if scope is string && scope == "admin" {
+            return {
+                name: "Walter White",
+                age: 51,
+                address: {
+                    number: "308",
+                    street: "Negra Arroyo Lane",
+                    city: "Albuquerque"
+                }
+            };
+        } else {
+            return error("You don't have permission to retrieve data");
+        }
+    }
+
+    remote function update(Context context) returns (Person|error)[]|error {
+        var scope = check context.get("scope");
+        if scope is string && scope == "admin" {
+            return people;
+        } else {
+            return [p1, error("You don't have permission to retrieve data"), p3];
         }
     }
 }

--- a/ballerina/tests/utils.bal
+++ b/ballerina/tests/utils.bal
@@ -25,6 +25,11 @@ returns json|error {
     return httpClient->post("/", { query: document, operationName: operationName, variables: variables});
 }
 
+isolated function getJsonPayloadFromRequest(string url, http:Request request) returns json|error {
+    http:Client httpClient = check new(url);
+    return httpClient->post("/", request);
+}
+
 isolated function getJsonContentFromFile(string fileName) returns json|error {
     string path = check file:joinPath("tests", "resources", "expected_results", fileName);
     return io:fileReadJson(path);

--- a/ballerina/tests/utils.bal
+++ b/ballerina/tests/utils.bal
@@ -48,6 +48,14 @@ returns json|error {
     return response.getJsonPayload();
 }
 
+isolated function assertResponseAndGetPayload(string url, string document, json? variables = {},
+string? operationName = (), int statusCode = http:STATUS_OK) returns json|error {
+    http:Client httpClient = check new(url);
+    http:Response response = check httpClient->post("/", { query: document, operationName: operationName, variables: variables});
+    test:assertEquals(response.statusCode, statusCode);
+    return response.getJsonPayload();
+}
+
 isolated function getTextPayloadFromBadRequest(string url, http:Request request) returns string|error {
     http:Client httpClient = check new(url);
     http:Response response = check httpClient->post("/", request);

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -14,6 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/http;
+
 # Represents the Scalar types supported by the Ballerina GraphQL module.
 public type Scalar boolean|int|float|string;
 
@@ -22,3 +24,11 @@ public type Service service object {
 };
 
 type AnydataMap map<anydata>;
+
+# Function type for initializing the `graphql:Context` object.
+# This function will be called with the `http:Request` and the `http:RequestContext` objects from the original request
+# received to the GraphQL endpoint.
+#
+# + request - The `http:Request` object from the original request
+# + requestContext - The `http:RequestContext` object from the original request
+public type ContextInit isolated function (http:Request request, http:RequestContext requestContext) returns Context|error;

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [[#1723] Add Type Name Introspection](https://github.com/ballerina-platform/ballerina-standard-library/issues/1723)
 - [[#1704] Add Block String Support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1704)
 - [[#1365] Add Input Object Support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1365)
+- [[#1906] Add Context Support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1906)
 
 ### Changed
 - [[#1597] Validate Max Query Depth at Runtime](https://github.com/ballerina-platform/ballerina-standard-library/issues/1597)
@@ -29,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [[#1911] Fix Variable Default Value With Invalid Type Retuning Error](https://github.com/ballerina-platform/ballerina-standard-library/issues/1911)
 - [[#1912] Fix Nullable Variables Return Error when Value is not Present](https://github.com/ballerina-platform/ballerina-standard-library/issues/1912)
 - [[#1912] GraphQL auth errors are not in proper format](https://github.com/ballerina-platform/ballerina-standard-library/issues/1920)
+- [[#1953] Fix Allowing Record Fields to Have Invalid Types](https://github.com/ballerina-platform/ballerina-standard-library/issues/1953)
 
 ## [0.2.0.beta.2]  - 2021-07-06
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/CompilerPluginTest.java
@@ -134,6 +134,22 @@ public class CompilerPluginTest {
     }
 
     @Test
+    public void testGraphQLContextAsFirstParameter() {
+        Package currentPackage = loadPackage("valid_service_12");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.errorCount(), 0);
+    }
+
+    @Test
+    public void testGraphQLContextInsideReturningServices() {
+        Package currentPackage = loadPackage("valid_service_13");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.errorCount(), 0);
+    }
+
+    @Test
     public void testMultipleListenersOnSameService() {
         Package currentPackage = loadPackage("invalid_service_1");
         PackageCompilation compilation = currentPackage.getCompilation();
@@ -483,6 +499,34 @@ public class CompilerPluginTest {
 
         diagnostic = diagnosticIterator.next();
         assertError(diagnostic, CompilationError.INVALID_RESOURCE_INPUT_PARAM, 130, 40);
+    }
+
+    @Test
+    public void testGraphQLContextAsAnotherParameter() {
+        Package currentPackage = loadPackage("invalid_service_23");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.errorCount(), 2);
+        Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
+        Diagnostic diagnostic = diagnosticIterator.next();
+        assertError(diagnostic, CompilationError.INVALID_LOCATION_FOR_CONTEXT_PARAMETER, 20, 64);
+
+        diagnostic = diagnosticIterator.next();
+        assertError(diagnostic, CompilationError.INVALID_LOCATION_FOR_CONTEXT_PARAMETER, 24, 61);
+    }
+
+    @Test
+    public void testInvalidContextObject() {
+        Package currentPackage = loadPackage("invalid_service_24");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.errorCount(), 2);
+        Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
+        Diagnostic diagnostic = diagnosticIterator.next();
+        assertError(diagnostic, CompilationError.INVALID_RESOURCE_INPUT_PARAM, 21, 43);
+
+        diagnostic = diagnosticIterator.next();
+        assertError(diagnostic, CompilationError.INVALID_RESOURCE_INPUT_PARAM, 25, 40);
     }
 
     private Package loadPackage(String path) {

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/CompilerPluginTest.java
@@ -529,6 +529,17 @@ public class CompilerPluginTest {
         assertError(diagnostic, CompilationError.INVALID_RESOURCE_INPUT_PARAM, 25, 40);
     }
 
+    @Test
+    public void testInvalidRecordFieldType() {
+        Package currentPackage = loadPackage("invalid_service_25");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.errorCount(), 1);
+        Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
+        Diagnostic diagnostic = diagnosticIterator.next();
+        assertError(diagnostic, CompilationError.INVALID_RETURN_TYPE_ERROR_OR_NIL, 20, 12);
+    }
+
     private Package loadPackage(String path) {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve(path);
         BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath);

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_23/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_23/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "graphql_test"
+name = "invalid_service_23"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_23/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_23/service.bal
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/graphql;
+
+service /graphql on new graphql:Listener(4000) {
+    resource function get profile(string name, graphql:Context context) returns string {
+        return "Walter White";
+    }
+
+    remote function updateName(string name, graphql:Context context) returns string {
+        return name;
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_24/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_24/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "graphql_test"
+name = "invalid_service_24"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_24/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_24/service.bal
@@ -1,0 +1,76 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/graphql;
+import ballerina/lang.value;
+
+service /graphql on new graphql:Listener(4000) {
+    resource function get profile(Context context) returns string {
+        return "Walter White";
+    }
+
+    remote function updateName(Context context, string name) returns string {
+        return name;
+    }
+}
+
+public isolated class Context {
+    private final map<value:Cloneable|isolated object {}> attributes;
+
+    public isolated function init() {
+        self.attributes = {};
+    }
+
+    public isolated function add(string 'key, value:Cloneable|isolated object {} value) returns graphql:Error? {
+        lock {
+            if self.attributes.hasKey('key) {
+                return error graphql:Error(string`Cannot add attribute to the context. Key "${'key}" already exists`);
+            } else if value is value:Cloneable {
+                self.attributes['key] = value.clone();
+            } else {
+                self.attributes['key] = value;
+            }
+        }
+    }
+
+    public isolated function get(string 'key) returns value:Cloneable|isolated object {}|graphql:Error {
+        lock {
+            if self.attributes.hasKey('key) {
+                value:Cloneable|isolated object {} value = self.attributes.get('key);
+                if value is value:Cloneable {
+                    return value.clone();
+                } else {
+                    return value;
+                }
+            }
+        }
+        return error graphql:Error(string`Attribute with the key "${'key}" not found in the context`);
+    }
+
+    public isolated function remove(string 'key) returns value:Cloneable|isolated object {}|graphql:Error {
+        lock {
+            if self.attributes.hasKey('key) {
+                value:Cloneable|isolated object {} value = self.attributes.remove('key);
+                if value is value:Cloneable {
+                    return value.clone();
+                } else {
+                    return value;
+                }
+            }
+        }
+        return error graphql:Error(string`Attribute with the key "${'key}" not found in the context`);
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_25/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_25/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "graphql_test"
+name = "invalid_service_25"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_25/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_25/service.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/graphql;
+
+public type Person record {
+    error? err;
+    string name;
+};
+
+service /graphql on new graphql:Listener(4000) {
+    resource function get profile(string name) returns Person {
+        return { name: "Walter White", err: () };
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_12/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_12/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "graphql_test"
+name = "valid_service_12"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_12/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_12/service.bal
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/graphql;
+import ballerina/http;
+
+public isolated function initContext(http:Request request, http:RequestContext requestContext)
+returns graphql:Context|error {
+    graphql:Context context = new;
+    check context.add("auth", "TOKEN");
+    return context;
+}
+
+@graphql:ServiceConfig {
+    contextInit: initContext
+}
+service graphql:Service on new graphql:Listener(4000) {
+    resource function get name(graphql:Context context) returns string {
+        return "Walter White";
+    }
+
+    remote function setName(graphql:Context context, string name) returns string {
+        return name;
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_13/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_13/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "graphql_test"
+name = "valid_service_13"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_13/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_13/service.bal
@@ -1,0 +1,41 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/graphql;
+
+service graphql:Service on new graphql:Listener(4000) {
+    resource function get greeting() returns First {
+        return new;
+    }
+}
+
+distinct service class First {
+    resource function get civilStatus() returns Second {
+        return new;
+    }
+}
+
+distinct service class Second {
+    resource function get firstName(graphql:Context context) returns Third {
+        return new;
+    }
+}
+
+distinct service class Third {
+    resource function get firstName(graphql:Context context) returns First {
+        return new;
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/FunctionValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/FunctionValidator.java
@@ -433,8 +433,10 @@ public class FunctionValidator {
                                       Location location) {
         Map<String, RecordFieldSymbol> recordFieldSymbolMap = recordTypeSymbol.fieldDescriptors();
         for (RecordFieldSymbol recordField : recordFieldSymbolMap.values()) {
-            if (recordField.typeDescriptor().typeKind() == TypeDescKind.TYPE_REFERENCE) {
-                validateReturnType(recordField.typeDescriptor(), location, context);
+            if (recordField.typeDescriptor().typeKind() == TypeDescKind.TYPE_REFERENCE ||
+                    recordField.typeDescriptor().typeKind() == TypeDescKind.UNION) {
+                Location fieldLocation = getLocation(recordField, location);
+                validateReturnType(recordField.typeDescriptor(), fieldLocation, context);
             } else {
                 if (Utils.isInvalidFieldName(recordField.getName().orElse(""))) {
                     Location fieldLocation = getLocation(recordField, location);

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/Utils.java
@@ -53,6 +53,7 @@ public class Utils {
     public static final String RESOURCE_FUNCTION_GET = "get";
     public static final String LISTENER_IDENTIFIER = "Listener";
     public static final String DOUBLE_UNDERSCORES = "__";
+    public static final String CONTEXT_IDENTIFIER = "Context";
 
     /**
      * Compilation errors.
@@ -88,10 +89,12 @@ public class Utils {
         MISSING_RESOURCE_FUNCTIONS("A GraphQL service must have at least one resource function", "GRAPHQL_113",
                                    DiagnosticSeverity.ERROR),
         INVALID_RETURN_TYPE_INPUT_OBJECT("A GraphQL resource/remote function cannot return an input type",
-                "GRAPHQL_113", DiagnosticSeverity.ERROR),
+                                         "GRAPHQL_113", DiagnosticSeverity.ERROR),
         INVALID_RESOURCE_INPUT_OBJECT_PARAM(
                 "A GraphQL resource/remote function cannot use an output type as an input type",
-                "GRAPHQL_114", DiagnosticSeverity.ERROR);
+                "GRAPHQL_114", DiagnosticSeverity.ERROR),
+        INVALID_LOCATION_FOR_CONTEXT_PARAMETER("The graphql:Context should be the first parameter", "GRAPHQL_115",
+                                               DiagnosticSeverity.ERROR);
 
         private final String error;
         private final String errorCode;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/Utils.java
@@ -61,20 +61,18 @@ public class Utils {
     enum CompilationError {
         INVALID_FUNCTION("Remote methods are not allowed inside the service classes returned from GraphQL resources",
                          "GRAPHQL_101", DiagnosticSeverity.ERROR),
-        INVALID_RETURN_TYPE("Invalid return type for GraphQL resource/remote function", "GRAPHQL_102",
-                            DiagnosticSeverity.ERROR),
+        INVALID_RETURN_TYPE("Invalid GraphQL field Type", "GRAPHQL_102", DiagnosticSeverity.ERROR),
         INVALID_RESOURCE_INPUT_PARAM("Invalid input parameter type for GraphQL resource/remote function", "GRAPHQL_103",
                                      DiagnosticSeverity.ERROR),
-        INVALID_RETURN_TYPE_NIL("A GraphQL resource/remote function must have a return type", "GRAPHQL_104",
-                                DiagnosticSeverity.ERROR),
-        INVALID_RETURN_TYPE_ERROR_OR_NIL("A GraphQL resource/remote function must have a return data type",
-                                         "GRAPHQL_105", DiagnosticSeverity.ERROR),
+        INVALID_RETURN_TYPE_NIL("A GraphQL field must have a return type", "GRAPHQL_104", DiagnosticSeverity.ERROR),
+        INVALID_RETURN_TYPE_ERROR_OR_NIL("A GraphQL field must have a return data type", "GRAPHQL_105",
+                                         DiagnosticSeverity.ERROR),
         INVALID_RESOURCE_FUNCTION_ACCESSOR(
                 "Only \"" + RESOURCE_FUNCTION_GET + "\" accessor is allowed for GraphQL resource function",
                 "GRAPHQL_106", DiagnosticSeverity.ERROR),
         INVALID_MULTIPLE_LISTENERS("A GraphQL service cannot be attached to multiple listeners", "GRAPHQL_107",
                                    DiagnosticSeverity.ERROR),
-        INVALID_RETURN_TYPE_ERROR("A GraphQL resource/remote function must have a return data type", "GRAPHQL_108",
+        INVALID_RETURN_TYPE_ERROR("A GraphQL field must have a return data type", "GRAPHQL_108",
                                   DiagnosticSeverity.ERROR),
         INVALID_LISTENER_INIT("http:Listener and graphql:ListenerConfiguration are mutually exclusive", "GRAPHQL_109",
                               DiagnosticSeverity.ERROR),
@@ -84,15 +82,14 @@ public class Utils {
                                    "\", which is reserved by GraphQL introspection", "GRAPHQL_111",
                            DiagnosticSeverity.ERROR),
         INVALID_RETURN_TYPE_ANY(
-                "A GraphQL resource/remote function cannot return \"any\" or \"anydata\", instead use specific type " +
-                        "names", "GRAPHQL_112", DiagnosticSeverity.ERROR),
+                "A GraphQL field cannot have \"any\" or \"anydata\" as the type, instead use specific types",
+                "GRAPHQL_112", DiagnosticSeverity.ERROR),
         MISSING_RESOURCE_FUNCTIONS("A GraphQL service must have at least one resource function", "GRAPHQL_113",
                                    DiagnosticSeverity.ERROR),
-        INVALID_RETURN_TYPE_INPUT_OBJECT("A GraphQL resource/remote function cannot return an input type",
-                                         "GRAPHQL_113", DiagnosticSeverity.ERROR),
-        INVALID_RESOURCE_INPUT_OBJECT_PARAM(
-                "A GraphQL resource/remote function cannot use an output type as an input type",
-                "GRAPHQL_114", DiagnosticSeverity.ERROR),
+        INVALID_RETURN_TYPE_INPUT_OBJECT("A GraphQL field type cannot be an input type", "GRAPHQL_113",
+                                         DiagnosticSeverity.ERROR),
+        INVALID_RESOURCE_INPUT_OBJECT_PARAM("A GraphQL field cannot use an output type as an input type", "GRAPHQL_114",
+                                            DiagnosticSeverity.ERROR),
         INVALID_LOCATION_FOR_CONTEXT_PARAMETER("The graphql:Context should be the first parameter", "GRAPHQL_115",
                                                DiagnosticSeverity.ERROR);
 

--- a/examples/snowtooth/Dependencies.toml
+++ b/examples/snowtooth/Dependencies.toml
@@ -220,6 +220,7 @@ name = "log"
 version = "2.0.0"
 transitive = true
 dependencies = [
+	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "observe"}
 ]
@@ -327,6 +328,22 @@ dependencies = [
 ]
 modules = [
 	{org = "ballerinai", packageName = "observe", moduleName = "observe"}
+]
+
+[[package]]
+org = "graphql"
+name = "snowtooth"
+version = "0.1.0"
+transitive = false
+dependencies = [
+	{org = "ballerina", name = "graphql"},
+	{org = "ballerina", name = "http"},
+	{org = "ballerina", name = "test"},
+	{org = "ballerinai", name = "observe"}
+]
+modules = [
+	{org = "graphql", packageName = "snowtooth", moduleName = "snowtooth"},
+	{org = "graphql", packageName = "snowtooth", moduleName = "snowtooth.datasource"}
 ]
 
 

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/Engine.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/Engine.java
@@ -114,7 +114,7 @@ public class Engine {
         String fieldName = node.getStringValue(NAME_FIELD).getValue();
         CallbackHandler callbackHandler = new CallbackHandler(future);
         List<Object> pathSegments = new ArrayList<>();
-        pathSegments.add(fieldName);
+        pathSegments.add(StringUtils.fromString(fieldName));
         ExecutionContext executionContext = new ExecutionContext(environment, visitor, callbackHandler, MUTATION);
         executeRemoteMethod(executionContext, service, node, data, pathSegments);
     }

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/Engine.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/Engine.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.ARGUMENTS_FIELD;
+import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.CONTEXT_FIELD;
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.DATA_FIELD;
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.ENGINE_FIELD;
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.GRAPHQL_SERVICE_OBJECT;
@@ -57,8 +58,11 @@ import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.VARIABLE_DE
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.VARIABLE_VALUE_FIELD;
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.isPathsMatching;
 import static io.ballerina.stdlib.graphql.runtime.engine.ResponseGenerator.getDataFromService;
+import static io.ballerina.stdlib.graphql.runtime.utils.Utils.ERROR_TYPE;
 import static io.ballerina.stdlib.graphql.runtime.utils.Utils.REMOTE_STRAND_METADATA;
 import static io.ballerina.stdlib.graphql.runtime.utils.Utils.RESOURCE_STRAND_METADATA;
+import static io.ballerina.stdlib.graphql.runtime.utils.Utils.createError;
+import static io.ballerina.stdlib.graphql.runtime.utils.Utils.isContext;
 
 /**
  * This handles Ballerina GraphQL Engine.
@@ -80,7 +84,7 @@ public class Engine {
             SchemaRecordGenerator schemaRecordGenerator = new SchemaRecordGenerator(schema);
             return schemaRecordGenerator.getSchemaRecord();
         } catch (BError e) {
-            return e;
+            return createError("Error occurred while creating the schema", ERROR_TYPE, e);
         }
     }
 
@@ -158,7 +162,7 @@ public class Engine {
                                            MethodType method, BMap<BString, Object> data, List<Object> pathSegments,
                                            StrandMetadata strandMetadata) {
         BMap<BString, Object> arguments = getArgumentsFromField(node);
-        Object[] args = getArgsForMethod(method, arguments);
+        Object[] args = getArgsForMethod(method, arguments, executionContext);
         ResourceCallback callback =
                 new ResourceCallback(executionContext, node, data, pathSegments);
         executionContext.getCallbackHandler().addCallback(callback);
@@ -227,10 +231,16 @@ public class Engine {
         }
     }
 
-    private static Object[] getArgsForMethod(MethodType method, BMap<BString, Object> arguments) {
+    private static Object[] getArgsForMethod(MethodType method, BMap<BString, Object> arguments,
+                                             ExecutionContext executionContext) {
         Parameter[] parameters = method.getParameters();
         Object[] result = new Object[parameters.length * 2];
         for (int i = 0, j = 0; i < parameters.length; i += 1, j += 2) {
+            if (i == 0 && isContext(parameters[i].type)) {
+                result[i] = executionContext.getVisitor().getObjectValue(CONTEXT_FIELD);
+                result[j + 1] = true;
+                continue;
+            }
             if (arguments.get(StringUtils.fromString(parameters[i].name)) == null) {
                 result[j] = parameters[i].type.getZeroValue();
                 result[j + 1] = false;

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/EngineUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/EngineUtils.java
@@ -98,10 +98,12 @@ public class EngineUtils {
     static final BString ERRORS_FIELD = StringUtils.fromString("errors");
     static final BString ENGINE_FIELD = StringUtils.fromString("engine");
     static final BString DATA_FIELD = StringUtils.fromString("data");
+    static final BString CONTEXT_FIELD = StringUtils.fromString("context");
 
-    // Record Types
+    // Internal Types
     static final String ERROR_DETAIL_RECORD = "ErrorDetail";
     static final String DATA_RECORD = "Data";
+    static final String CONTEXT_OBJECT = "Context";
 
     // Record fields
     static final BString LOCATION_FIELD = StringUtils.fromString("location");

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/EngineUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/EngineUtils.java
@@ -103,7 +103,6 @@ public class EngineUtils {
     // Internal Types
     static final String ERROR_DETAIL_RECORD = "ErrorDetail";
     static final String DATA_RECORD = "Data";
-    static final String CONTEXT_OBJECT = "Context";
 
     // Record fields
     static final BString LOCATION_FIELD = StringUtils.fromString("location");

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/ResponseGenerator.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/ResponseGenerator.java
@@ -157,7 +157,13 @@ public class ResponseGenerator {
                 Object resultElement = result.get(i);
                 BMap<BString, Object> subData = createDataRecord();
                 populateResponse(executionContext, node, resultElement, subData, updatedPathSegments);
-                resultArray.append(subData.get(node.getStringValue(NAME_FIELD)));
+                if (result.get(i) instanceof BError) {
+                    BMap<BString, Object> subField = createDataRecord();
+                    subField.put(node.getStringValue(NAME_FIELD), null);
+                    resultArray.append(subField);
+                } else {
+                    resultArray.append(subData.get(node.getStringValue(NAME_FIELD)));
+                }
             }
             data.put(node.getStringValue(ALIAS_FIELD), resultArray);
         }

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/FieldFinder.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/FieldFinder.java
@@ -57,6 +57,7 @@ import static io.ballerina.stdlib.graphql.runtime.schema.Utils.getUnionTypeName;
 import static io.ballerina.stdlib.graphql.runtime.schema.Utils.isEnum;
 import static io.ballerina.stdlib.graphql.runtime.schema.Utils.isRequired;
 import static io.ballerina.stdlib.graphql.runtime.utils.ModuleUtils.getModule;
+import static io.ballerina.stdlib.graphql.runtime.utils.Utils.isContext;
 import static io.ballerina.stdlib.graphql.runtime.utils.Utils.removeFirstElementFromArray;
 
 /**
@@ -275,6 +276,9 @@ public class FieldFinder {
         for (Parameter parameter : method.getParameters()) {
             Type inputType;
             InputValue inputValue;
+            if (isContext(parameter.type)) {
+                return;
+            }
             if (parameter.type.isNilable()) {
                 inputType = getInputTypeFromNilableType((UnionType) parameter.type);
                 inputValue = new InputValue(parameter.name, this.getType(getTypeNameFromType(inputType)));

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/TypeFinder.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/TypeFinder.java
@@ -48,8 +48,9 @@ import static io.ballerina.stdlib.graphql.runtime.schema.Utils.getTypeNameFromTy
 import static io.ballerina.stdlib.graphql.runtime.schema.Utils.getUnionTypeName;
 import static io.ballerina.stdlib.graphql.runtime.schema.Utils.isEnum;
 import static io.ballerina.stdlib.graphql.runtime.utils.ModuleUtils.getModule;
-import static io.ballerina.stdlib.graphql.runtime.utils.Utils.NOT_SUPPORTED_ERROR;
+import static io.ballerina.stdlib.graphql.runtime.utils.Utils.ERROR_TYPE;
 import static io.ballerina.stdlib.graphql.runtime.utils.Utils.createError;
+import static io.ballerina.stdlib.graphql.runtime.utils.Utils.isContext;
 import static io.ballerina.stdlib.graphql.runtime.utils.Utils.removeFirstElementFromArray;
 
 /**
@@ -176,9 +177,11 @@ public class TypeFinder {
             MapType mapType = (MapType) type;
             Type constrainedType = mapType.getConstrainedType();
             getSchemaTypeFromBalType(constrainedType);
+        } else if (isContext(type)) {
+            // Do nothing
         } else {
             String message = "Unsupported type found in GraphQL service: " + type.getName();
-            throw createError(message, NOT_SUPPORTED_ERROR);
+            throw createError(message, ERROR_TYPE);
         }
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/TypeFinder.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/TypeFinder.java
@@ -186,7 +186,6 @@ public class TypeFinder {
         if (isEnum(unionType)) {
             this.createSchemaType(getTypeNameFromType(unionType), TypeKind.ENUM, unionType);
         } else {
-            // TODO: Handle cases where record fields have `error?` type.
             List<Type> memberTypes = getMemberTypes(unionType);
             if (memberTypes.size() == 1) {
                 getSchemaTypeFromBalType(memberTypes.get(0));

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/utils/Utils.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/utils/Utils.java
@@ -20,6 +20,7 @@ package io.ballerina.stdlib.graphql.runtime.utils;
 
 import io.ballerina.runtime.api.async.StrandMetadata;
 import io.ballerina.runtime.api.creators.ErrorCreator;
+import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BError;
 
@@ -36,7 +37,9 @@ public class Utils {
     static final String EXECUTE_SERVICE_FUNCTION = "executeService";
     static final String EXECUTE_MUTATION_FUNCTION = "executeMutation";
 
-    public static final String NOT_SUPPORTED_ERROR = "NotSupportedError";
+    // Internal type names
+    public static final String ERROR_TYPE = "Error";
+    public static final String CONTEXT_OBJECT = "Context";
 
     public static final StrandMetadata RESOURCE_STRAND_METADATA = new StrandMetadata(getModule().getOrg(),
                                                                                      getModule().getName(),
@@ -51,10 +54,23 @@ public class Utils {
         return ErrorCreator.createError(getModule(), errorTypeName, StringUtils.fromString(message), null, null);
     }
 
+    public static BError createError(String message, String errorTypeName, BError cause) {
+        return ErrorCreator.createError(getModule(), errorTypeName, StringUtils.fromString(message), cause, null);
+    }
+
     public static String[] removeFirstElementFromArray(String[] array) {
         int length = array.length - 1;
         String[] result = new String[length];
         System.arraycopy(array, 1, result, 0, length);
         return result;
+    }
+
+    public static boolean isContext(Type type) {
+        if (type.getPackage().getOrg() == null || type.getPackage().getName() == null) {
+            return false;
+        }
+        return type.getPackage().getOrg().equals(ModuleUtils.getModule().getOrg()) &&
+                type.getPackage().getName().equals(ModuleUtils.getModule().getName()) &&
+                type.getName().equals(CONTEXT_OBJECT);
     }
 }


### PR DESCRIPTION
## Purpose
Add GraphQL context support that can be used to share metadata between the resolvers.

Fixes: [#1906](https://github.com/ballerina-platform/ballerina-standard-library/issues/1906)
Fixes: [#1953](https://github.com/ballerina-platform/ballerina-standard-library/issues/1953)

## Examples

Developers can provide a function to initialize the context which must be an isolated function, and must have two input parameters: `http:Request` and `http:RequestContext`. This function must have the return type of `graphql:Context|error`. 

Inside this function, the `graphql:Context` object can be created and the developer can add attributes to the context as key-value pairs. The key is always a string, the value can be a `value:Clonable|isolated object {}`. Simply put, this can be a primitive value, any `readonly` value, or an isolated function pointer, or an isolated object. The context object has three functions, `add`, `get`, and `remove`. 
Then this function can be provided as a service config field. Using this function, a context will be created per request. When needed, the context can be defined as the **first parameter** of a resolver (resource/remote) function. Following is an example:

```ballerina
import ballerina/graphql;
import ballerina/http;

isolated function initContext(http:Request request, http:RequestContext requestContext) returns graphql:Context|error {
    graphql:Context context = new;
    check context.add("scope", request.getHeader("scope"));
    return context;
}

@graphql:ServiceConfig {
    contextInit: initContext
} 
service on new graphql:Listener(9000) {
    resource function get greting(graphql:Context context) returns string {
        if context.get("scope") is string && context.get("scope") == "admin" {
            return "Hello, admin!";
        } else {
            return "Hello, user!";
        }
    }
}
```


## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
