### PR TITLE
Change the Context Init Parameter Order

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,6 @@ dependencies-toml-version = "2"
 org = "ballerina"
 name = "auth"
 version = "2.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -27,7 +26,6 @@ modules = [
 org = "ballerina"
 name = "cache"
 version = "3.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "task"},
@@ -38,7 +36,6 @@ dependencies = [
 org = "ballerina"
 name = "crypto"
 version = "2.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -48,7 +45,6 @@ dependencies = [
 org = "ballerina"
 name = "file"
 version = "1.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},
@@ -64,7 +60,6 @@ modules = [
 org = "ballerina"
 name = "graphql"
 version = "1.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "file"},
@@ -89,7 +84,6 @@ modules = [
 org = "ballerina"
 name = "http"
 version = "2.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -120,7 +114,6 @@ modules = [
 org = "ballerina"
 name = "io"
 version = "1.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -133,7 +126,6 @@ modules = [
 org = "ballerina"
 name = "jballerina.java"
 version = "0.0.0"
-transitive = false
 modules = [
 	{org = "ballerina", packageName = "jballerina.java", moduleName = "jballerina.java"}
 ]
@@ -142,7 +134,6 @@ modules = [
 org = "ballerina"
 name = "jwt"
 version = "2.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -161,7 +152,6 @@ modules = [
 org = "ballerina"
 name = "lang.__internal"
 version = "0.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -171,7 +161,6 @@ dependencies = [
 org = "ballerina"
 name = "lang.array"
 version = "0.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.__internal"}
@@ -184,7 +173,6 @@ modules = [
 org = "ballerina"
 name = "lang.decimal"
 version = "0.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -193,7 +181,6 @@ dependencies = [
 org = "ballerina"
 name = "lang.int"
 version = "0.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -202,13 +189,11 @@ dependencies = [
 org = "ballerina"
 name = "lang.object"
 version = "0.0.0"
-transitive = true
 
 [[package]]
 org = "ballerina"
 name = "lang.runtime"
 version = "0.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.array"},
@@ -222,7 +207,6 @@ modules = [
 org = "ballerina"
 name = "lang.string"
 version = "0.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -231,7 +215,6 @@ dependencies = [
 org = "ballerina"
 name = "lang.value"
 version = "0.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -243,7 +226,6 @@ modules = [
 org = "ballerina"
 name = "log"
 version = "2.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -254,7 +236,6 @@ dependencies = [
 org = "ballerina"
 name = "mime"
 version = "2.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -265,7 +246,6 @@ dependencies = [
 org = "ballerina"
 name = "oauth2"
 version = "2.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -281,7 +261,6 @@ modules = [
 org = "ballerina"
 name = "observe"
 version = "0.9.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -290,7 +269,6 @@ dependencies = [
 org = "ballerina"
 name = "os"
 version = "1.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -299,7 +277,6 @@ dependencies = [
 org = "ballerina"
 name = "regex"
 version = "1.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -311,7 +288,6 @@ modules = [
 org = "ballerina"
 name = "task"
 version = "2.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -322,7 +298,6 @@ org = "ballerina"
 name = "test"
 version = "0.0.0"
 scope = "testOnly"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -334,7 +309,6 @@ modules = [
 org = "ballerina"
 name = "time"
 version = "2.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -343,7 +317,6 @@ dependencies = [
 org = "ballerina"
 name = "url"
 version = "2.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/context.bal
+++ b/ballerina/context.bal
@@ -65,6 +65,6 @@ public isolated class Context {
     }
 }
 
-isolated function initDefaultContext(http:Request request, http:RequestContext requestContext) returns Context|error {
+isolated function initDefaultContext(http:RequestContext requestContext, http:Request request) returns Context|error {
     return new;
 }

--- a/ballerina/http_service.bal
+++ b/ballerina/http_service.bal
@@ -30,7 +30,7 @@ isolated service class HttpService {
     isolated resource function get .(http:Request request) returns http:Response {
          // TODO: Temporary initiate the request context here, since it is not yet added in the HTTP resource
         http:RequestContext requestContext = new;
-        Context|http:Response context = self.initContext(request, requestContext);
+        Context|http:Response context = self.initContext(requestContext, request);
         if context is http:Response {
             return context;
         } else {
@@ -38,14 +38,14 @@ isolated service class HttpService {
             if authResult is http:Response {
                 return authResult;
             }
-            return handleGetRequests(self.engine, request, context);
+            return handleGetRequests(self.engine, context, request);
         }
     }
 
     isolated resource function post .(http:Request request) returns http:Response {
          // TODO: Temporary initiate the request context here, since it is not yet added in the HTTP resource
         http:RequestContext requestContext = new;
-        Context|http:Response context = self.initContext(request, requestContext);
+        Context|http:Response context = self.initContext(requestContext, request);
         if context is http:Response {
             return context;
         } else {
@@ -53,12 +53,12 @@ isolated service class HttpService {
             if authResult is http:Response {
                 return authResult;
             }
-            return handlePostRequests(self.engine, request, context);
+            return handlePostRequests(self.engine, context, request);
         }
     }
 
-    isolated function initContext(http:Request request, http:RequestContext requestContext) returns Context|http:Response {
-        Context|error context = self.contextInit(request, requestContext);
+    isolated function initContext(http:RequestContext requestContext, http:Request request) returns Context|http:Response {
+        Context|error context = self.contextInit(requestContext, request);
         if context is error {
             json payload = { errors: [{ message: context.message() }] };
             http:Response response = new;

--- a/ballerina/listener_utils.bal
+++ b/ballerina/listener_utils.bal
@@ -18,7 +18,7 @@ import ballerina/http;
 
 import graphql.parser;
 
-isolated function handleGetRequests(Engine engine, http:Request request, Context context) returns http:Response {
+isolated function handleGetRequests(Engine engine, Context context, http:Request request) returns http:Response {
     string? query = request.getQueryParamValue(PARAM_QUERY);
     if query is string && query != "" {
         string? operationName = request.getQueryParamValue(PARAM_OPERATION_NAME);
@@ -33,10 +33,10 @@ isolated function handleGetRequests(Engine engine, http:Request request, Context
     }
 }
 
-isolated function handlePostRequests(Engine engine, http:Request request, Context context) returns http:Response {
+isolated function handlePostRequests(Engine engine, Context context, http:Request request) returns http:Response {
     string contentType = request.getContentType();
     if contentType == CONTENT_TYPE_JSON {
-        return getResponseFromJsonPayload(engine, request, context);
+        return getResponseFromJsonPayload(engine, context, request);
     } else if contentType == CONTENT_TYPE_GQL {
         return createResponse("Content-Type 'application/graphql' is not yet supported", http:STATUS_BAD_REQUEST);
     } else {
@@ -44,7 +44,7 @@ isolated function handlePostRequests(Engine engine, http:Request request, Contex
     }
 }
 
-isolated function getResponseFromJsonPayload(Engine engine, http:Request request, Context context)
+isolated function getResponseFromJsonPayload(Engine engine, Context context, http:Request request)
 returns http:Response {
     var payload = request.getJsonPayload();
     if payload is json {

--- a/ballerina/tests/27_context.bal
+++ b/ballerina/tests/27_context.bal
@@ -22,7 +22,7 @@ import ballerina/test;
 }
 function testCreatingContextWithScalarValues() returns error? {
     ContextInit contextInit =
-        isolated function (http:Request request, http:RequestContext requestContext) returns Context|error {
+        isolated function (http:RequestContext requestContext, http:Request request) returns Context|error {
             Context context = new;
             check context.add("String", "Ballerina");
             check context.add("Int", 5);
@@ -31,7 +31,7 @@ function testCreatingContextWithScalarValues() returns error? {
         };
     http:Request request = new;
     http:RequestContext requestContext = new;
-    Context context = check contextInit(request, requestContext);
+    Context context = check contextInit(requestContext, request);
     test:assertEquals(<string> check context.get("String"), "Ballerina");
     test:assertEquals(<int> check context.get("Int"), 5);
     test:assertEquals(<boolean> check context.get("Boolean"), false);
@@ -42,14 +42,14 @@ function testCreatingContextWithScalarValues() returns error? {
 }
 function testCreatingContextWithObjectValues() returns error? {
     ContextInit contextInit =
-        isolated function (http:Request request, http:RequestContext requestContext) returns Context|error {
+        isolated function (http:RequestContext requestContext, http:Request request) returns Context|error {
             Context context = new;
             check context.add("HierarchicalServiceObject", new HierarchicalName());
             return context;
         };
     http:Request request = new;
     http:RequestContext requestContext = new;
-    Context context = check contextInit(request, requestContext);
+    Context context = check contextInit(requestContext, request);
     test:assertTrue((check context.get("HierarchicalServiceObject")) is HierarchicalName);
 }
 
@@ -58,14 +58,14 @@ function testCreatingContextWithObjectValues() returns error? {
 }
 function testRemovingAttributeFromContext() returns error? {
     ContextInit contextInit =
-        isolated function (http:Request request, http:RequestContext requestContext) returns Context|error {
+        isolated function (http:RequestContext requestContext, http:Request request) returns Context|error {
             Context context = new;
             check context.add("String", "Ballerina");
             return context;
         };
     http:Request request = new;
     http:RequestContext requestContext = new;
-    Context context = check contextInit(request, requestContext);
+    Context context = check contextInit(requestContext, request);
     var attribute1 = check context.remove("String");
     test:assertTrue(attribute1 is string);
     test:assertEquals(<string>attribute1, "Ballerina");
@@ -80,14 +80,14 @@ function testRemovingAttributeFromContext() returns error? {
 }
 function testRemovingObjectAttributeFromContext() returns error? {
     ContextInit contextInit =
-        isolated function (http:Request request, http:RequestContext requestContext) returns Context|error {
+        isolated function (http:RequestContext requestContext, http:Request request) returns Context|error {
             Context context = new;
             check context.add("HierarchicalServiceObject", new HierarchicalName());
             return context;
         };
     http:Request request = new;
     http:RequestContext requestContext = new;
-    Context context = check contextInit(request, requestContext);
+    Context context = check contextInit(requestContext, request);
     var attribute1 = check context.remove("HierarchicalServiceObject");
     test:assertTrue(attribute1 is HierarchicalName);
 
@@ -101,14 +101,14 @@ function testRemovingObjectAttributeFromContext() returns error? {
 }
 function testRequestingInvalidAttributeFromContext() returns error? {
     ContextInit contextInit =
-        isolated function (http:Request request, http:RequestContext requestContext) returns Context|error {
+        isolated function (http:RequestContext requestContext, http:Request request) returns Context|error {
             Context context = new;
             check context.add("String", "Ballerina");
             return context;
         };
     http:Request request = new;
     http:RequestContext requestContext = new;
-    Context context = check contextInit(request, requestContext);
+    Context context = check contextInit(requestContext, request);
     var invalidAttribute = context.get("No");
     test:assertTrue(invalidAttribute is Error);
     test:assertEquals((<Error>invalidAttribute).message(), "Attribute with the key \"No\" not found in the context");
@@ -119,7 +119,7 @@ function testRequestingInvalidAttributeFromContext() returns error? {
 }
 function testAddingDuplicateAttribute() returns error? {
     ContextInit contextInit =
-        isolated function (http:Request request, http:RequestContext requestContext) returns Context|error {
+        isolated function (http:RequestContext requestContext, http:Request request) returns Context|error {
             Context context = new;
             check context.add("String", "Ballerina");
             check context.add("String", "Ballerina");
@@ -127,7 +127,7 @@ function testAddingDuplicateAttribute() returns error? {
         };
     http:Request request = new;
     http:RequestContext requestContext = new;
-    Context|error context = contextInit(request, requestContext);
+    Context|error context = contextInit(requestContext, request);
     test:assertTrue(context is error);
     test:assertEquals((<error>context).message(), "Cannot add attribute to the context. Key \"String\" already exists");
 }

--- a/ballerina/tests/test_services.bal
+++ b/ballerina/tests/test_services.bal
@@ -725,7 +725,7 @@ service /null_values on basicListener {
 }
 
 @ServiceConfig {
-    contextInit: isolated function (http:Request request, http:RequestContext requestContext) returns Context|error {
+    contextInit: isolated function (http:RequestContext requestContext, http:Request request) returns Context|error {
         Context context = new;
         check context.add("scope", check request.getHeader("scope"));
         return context;

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -29,6 +29,6 @@ type AnydataMap map<anydata>;
 # This function will be called with the `http:Request` and the `http:RequestContext` objects from the original request
 # received to the GraphQL endpoint.
 #
-# + request - The `http:Request` object from the original request
 # + requestContext - The `http:RequestContext` object from the original request
-public type ContextInit isolated function (http:Request request, http:RequestContext requestContext) returns Context|error;
+# + request - The `http:Request` object from the original request
+public type ContextInit isolated function (http:RequestContext requestContext, http:Request request) returns Context|error;

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_12/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_12/service.bal
@@ -17,7 +17,7 @@
 import ballerina/graphql;
 import ballerina/http;
 
-public isolated function initContext(http:Request request, http:RequestContext requestContext)
+public isolated function initContext(http:RequestContext requestContext, http:Request request)
 returns graphql:Context|error {
     graphql:Context context = new;
     check context.add("auth", "TOKEN");

--- a/examples/snowtooth/Dependencies.toml
+++ b/examples/snowtooth/Dependencies.toml
@@ -10,7 +10,6 @@ dependencies-toml-version = "2"
 org = "ballerina"
 name = "auth"
 version = "2.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -24,7 +23,6 @@ dependencies = [
 org = "ballerina"
 name = "cache"
 version = "3.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "task"},
@@ -35,7 +33,6 @@ dependencies = [
 org = "ballerina"
 name = "crypto"
 version = "2.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -45,7 +42,6 @@ dependencies = [
 org = "ballerina"
 name = "file"
 version = "1.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},
@@ -58,7 +54,6 @@ dependencies = [
 org = "ballerina"
 name = "graphql"
 version = "1.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "file"},
@@ -82,7 +77,6 @@ modules = [
 org = "ballerina"
 name = "http"
 version = "2.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -113,7 +107,6 @@ modules = [
 org = "ballerina"
 name = "io"
 version = "1.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -123,13 +116,11 @@ dependencies = [
 org = "ballerina"
 name = "jballerina.java"
 version = "0.0.0"
-transitive = true
 
 [[package]]
 org = "ballerina"
 name = "jwt"
 version = "2.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -145,7 +136,6 @@ dependencies = [
 org = "ballerina"
 name = "lang.__internal"
 version = "0.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -155,7 +145,6 @@ dependencies = [
 org = "ballerina"
 name = "lang.array"
 version = "0.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.__internal"}
@@ -165,7 +154,6 @@ dependencies = [
 org = "ballerina"
 name = "lang.decimal"
 version = "0.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -174,7 +162,6 @@ dependencies = [
 org = "ballerina"
 name = "lang.int"
 version = "0.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -183,13 +170,11 @@ dependencies = [
 org = "ballerina"
 name = "lang.object"
 version = "0.0.0"
-transitive = true
 
 [[package]]
 org = "ballerina"
 name = "lang.runtime"
 version = "0.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.array"},
@@ -200,7 +185,6 @@ dependencies = [
 org = "ballerina"
 name = "lang.string"
 version = "0.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -209,7 +193,6 @@ dependencies = [
 org = "ballerina"
 name = "lang.value"
 version = "0.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -218,7 +201,6 @@ dependencies = [
 org = "ballerina"
 name = "log"
 version = "2.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -229,7 +211,6 @@ dependencies = [
 org = "ballerina"
 name = "mime"
 version = "2.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -240,7 +221,6 @@ dependencies = [
 org = "ballerina"
 name = "oauth2"
 version = "2.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -253,7 +233,6 @@ dependencies = [
 org = "ballerina"
 name = "observe"
 version = "0.9.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -262,7 +241,6 @@ dependencies = [
 org = "ballerina"
 name = "os"
 version = "1.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -271,7 +249,6 @@ dependencies = [
 org = "ballerina"
 name = "regex"
 version = "1.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -280,7 +257,6 @@ dependencies = [
 org = "ballerina"
 name = "task"
 version = "2.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -291,7 +267,6 @@ org = "ballerina"
 name = "test"
 version = "0.0.0"
 scope = "testOnly"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -303,7 +278,6 @@ modules = [
 org = "ballerina"
 name = "time"
 version = "2.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -312,7 +286,6 @@ dependencies = [
 org = "ballerina"
 name = "url"
 version = "2.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -321,7 +294,6 @@ dependencies = [
 org = "ballerinai"
 name = "observe"
 version = "0.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "observe"}
@@ -334,7 +306,6 @@ modules = [
 org = "graphql"
 name = "snowtooth"
 version = "0.1.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "graphql"},
 	{org = "ballerina", name = "http"},


### PR DESCRIPTION
## Purpose
The context init function parameters should be ordered as follows as per the convension:

```
isolated function (http:RequestContext requestContext, http:equest request) returns graphql:Context|error {
}
```

Part of [#1906](https://github.com/ballerina-platform/ballerina-standard-library/issues/1906)

## Examples

## Checklist
- [x] Linked to an issue
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
