### PR TITLE
Update Retrieving the Intersection Type Names from Records

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -9,7 +9,7 @@ dependencies-toml-version = "2"
 [[package]]
 org = "ballerina"
 name = "auth"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -25,7 +25,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "task"},
@@ -35,7 +35,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -44,7 +44,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},
@@ -83,7 +83,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -113,7 +113,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -133,7 +133,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -225,7 +225,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -236,7 +236,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -246,7 +246,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -269,7 +269,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -277,7 +277,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "regex"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -288,7 +288,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -309,7 +309,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -317,7 +317,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/examples/snowtooth/Dependencies.toml
+++ b/examples/snowtooth/Dependencies.toml
@@ -9,7 +9,7 @@ dependencies-toml-version = "2"
 [[package]]
 org = "ballerina"
 name = "auth"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -22,7 +22,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "task"},
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},
@@ -76,7 +76,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -106,7 +106,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -120,7 +120,7 @@ version = "0.0.0"
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -200,7 +200,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -211,7 +211,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -221,7 +221,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -241,7 +241,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -249,7 +249,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "regex"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -278,7 +278,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/EngineUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/EngineUtils.java
@@ -154,22 +154,6 @@ public class EngineUtils {
         return tag == INT_TAG || tag == FLOAT_TAG || tag == BOOLEAN_TAG || tag == STRING_TAG;
     }
 
-    // Temporary fix until https://github.com/ballerina-platform/ballerina-lang/issues/30728 is fixed
-    static String getNameFromRecordTypeMap(BMap<BString, Object> record) {
-        String name = record.getType().getName();
-        if (name.contains("&")) {
-            String[] intersectionMemberTypeNames = name.split("&");
-            for (String intersectionTypeName : intersectionMemberTypeNames) {
-                intersectionTypeName = intersectionTypeName.strip();
-                if (!intersectionTypeName.equals("readonly")) {
-                    String[] typeNameSegments = intersectionTypeName.split(":");
-                    return typeNameSegments[typeNameSegments.length - 1].strip();
-                }
-            }
-        }
-        return name;
-    }
-
     static boolean isPathsMatching(ResourceMethodType resourceMethod, List<String> paths) {
         String[] resourcePath = resourceMethod.getResourcePath();
         if (resourcePath.length != paths.size()) {

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/ResponseGenerator.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/ResponseGenerator.java
@@ -47,9 +47,9 @@ import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.TYPENAME_FI
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.copyAndUpdateResourcePathsList;
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.createDataRecord;
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.getErrorDetailRecord;
-import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.getNameFromRecordTypeMap;
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.isScalarType;
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.updatePathSegments;
+import static io.ballerina.stdlib.graphql.runtime.schema.Utils.getTypeNameFromType;
 
 /**
  * Used to generate the response for a GraphQL request in Ballerina.
@@ -122,7 +122,7 @@ public class ResponseGenerator {
             BObject subNode = (BObject) selections.get(i);
             BString typeName = StringUtils.fromString(subNode.getType().getName());
             if (FRAGMENT_NODE.equals(typeName)) {
-                if (subNode.getStringValue(ON_TYPE_FIELD).getValue().equals(getNameFromRecordTypeMap(record))) {
+                if (subNode.getStringValue(ON_TYPE_FIELD).getValue().equals(getTypeNameFromType(record.getType()))) {
                     processFragmentNodes(executionContext, subNode, record, subData, pathSegments);
                 }
             } else {

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/Utils.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/schema/Utils.java
@@ -24,7 +24,9 @@ import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.flags.SymbolFlags;
 import io.ballerina.runtime.api.types.ArrayType;
 import io.ballerina.runtime.api.types.Field;
+import io.ballerina.runtime.api.types.IntersectionType;
 import io.ballerina.runtime.api.types.MapType;
+import io.ballerina.runtime.api.types.RecordType;
 import io.ballerina.runtime.api.types.TableType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.types.UnionType;
@@ -34,6 +36,7 @@ import io.ballerina.runtime.api.values.BString;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static io.ballerina.stdlib.graphql.runtime.engine.EngineUtils.BOOLEAN;
@@ -91,6 +94,8 @@ public class Utils {
             return getTypeNameFromType(((TableType) type).getConstrainedType());
         } else if (tag == TypeTags.UNION_TAG) {
             return getUnionTypeName((UnionType) type);
+        } else if (tag == TypeTags.RECORD_TYPE_TAG) {
+            return getRecordTypeName((RecordType) type);
         }
         return type.getName();
     }
@@ -120,5 +125,17 @@ public class Utils {
         return unionType.getName().isBlank() ?
                 memberTypes.stream().map(Type::getName).collect(Collectors.joining(UNION_TYPE_NAME_DELIMITER)) :
                 unionType.getName();
+    }
+
+    private static String getRecordTypeName(RecordType recordType) {
+        Optional<IntersectionType> intersectionType = recordType.getIntersectionType();
+        if (intersectionType.isPresent()) {
+            for (Type constituentType : intersectionType.get().getConstituentTypes()) {
+                if (constituentType.getTag() != TypeTags.READONLY_TAG) {
+                    return  constituentType.getName();
+                }
+            }
+        }
+        return recordType.getName();
     }
 }


### PR DESCRIPTION
## Purpose
Currently, when a record type is an intersection type, the type name of that record is retrieved using string manipulation. This was because there was no API to retrieve the type name from an intersection type. With https://github.com/ballerina-platform/ballerina-lang/issues/32215, we can improv this. 

Fixes: [1649](https://github.com/ballerina-platform/ballerina-standard-library/issues/1649)

## Examples
N/A

## Checklist
- [x] Linked to an issue
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
