### PR TITLE
Fix service detaching logic in listener

### DIFF
--- a/ballerina/listener.bal
+++ b/ballerina/listener.bal
@@ -19,7 +19,6 @@ import ballerina/http;
 # Represents a Graphql listener endpoint.
 public class Listener {
     private http:Listener httpListener;
-    private HttpService? httpService;
 
     # Invoked during the initialization of a `graphql:Listener`. Either an `http:Listner` or a port number must be
     # provided to initialize the listener.
@@ -39,7 +38,6 @@ public class Listener {
         } else {
             self.httpListener = listenTo;
         }
-        self.httpService = ();
     }
 
     # Attaches the provided service to the Listener.
@@ -57,11 +55,12 @@ public class Listener {
         attachServiceToEngine(s, engine);
 
         HttpService httpService = new(engine, serviceConfig);
+        attachHttpServiceToGraphqlService(s, httpService);
+
         error? result = self.httpListener.attach(httpService, name);
         if (result is error) {
             return error Error("Error occurred while attaching the service", result);
         }
-        self.httpService = httpService;
     }
 
     # Detaches the provided service from the Listener.
@@ -69,8 +68,9 @@ public class Listener {
     # + s - The service to be detached from the listener
     # + return - A `graphql:Error` if an error occurred during the service detaching process or else `()`
     public isolated function detach(Service s) returns Error? {
-        if (self.httpService is HttpService) {
-            error? result = self.httpListener.detach(<HttpService>self.httpService);
+        HttpService? httpService = getHttpServiceFromGraphqlService(s);
+        if (httpService is HttpService) {
+            error? result = self.httpListener.detach(httpService);
             if (result is error) {
                 return error Error("Error occurred while detaching the service", result);
             }

--- a/ballerina/listener.bal
+++ b/ballerina/listener.bal
@@ -58,7 +58,7 @@ public class Listener {
         attachHttpServiceToGraphqlService(s, httpService);
 
         error? result = self.httpListener.attach(httpService, name);
-        if (result is error) {
+        if result is error {
             return error Error("Error occurred while attaching the service", result);
         }
     }
@@ -69,7 +69,7 @@ public class Listener {
     # + return - A `graphql:Error` if an error occurred during the service detaching process or else `()`
     public isolated function detach(Service s) returns Error? {
         HttpService? httpService = getHttpServiceFromGraphqlService(s);
-        if (httpService is HttpService) {
+        if httpService is HttpService {
             error? result = self.httpListener.detach(httpService);
             if (result is error) {
                 return error Error("Error occurred while detaching the service", result);
@@ -82,7 +82,7 @@ public class Listener {
     # + return - A `graphql:Error`, if an error occurred during the service starting process, otherwise nil
     public isolated function 'start() returns Error? {
         error? result = self.httpListener.'start();
-        if (result is error) {
+        if result is error {
             return error Error("Error occurred while starting the service", result);
         }
     }
@@ -92,7 +92,7 @@ public class Listener {
     # + return - A `graphql:Error`, if an error occurred during the service stopping process, otherwise nil
     public isolated function gracefulStop() returns Error? {
         error? result = self.httpListener.gracefulStop();
-        if (result is error) {
+        if result is error {
             return error Error("Error occurred while stopping the service", result);
         }
     }
@@ -102,7 +102,7 @@ public class Listener {
     # + return - A `graphql:Error` if an error occurred during the service stopping process or else `()`
     public isolated function immediateStop() returns Error? {
         error? result = self.httpListener.immediateStop();
-        if (result is error) {
+        if result is error {
             return error Error("Error occurred while stopping the service", result);
         }
     }

--- a/ballerina/listener_utils.bal
+++ b/ballerina/listener_utils.bal
@@ -15,6 +15,7 @@
 // under the License.
 
 import ballerina/http;
+import ballerina/jballerina.java;
 
 import graphql.parser;
 
@@ -100,3 +101,12 @@ isolated function addDefaultDirectives(__Schema schema) {
         schema.directives.push(directive);
     }
 }
+
+isolated function attachHttpServiceToGraphqlService(Service s, HttpService httpService) = @java:Method {
+    'class: "io.ballerina.stdlib.graphql.runtime.engine.ListenerUtils"
+} external;
+
+isolated function getHttpServiceFromGraphqlService(Service s) returns HttpService? =
+@java:Method {
+    'class: "io.ballerina.stdlib.graphql.runtime.engine.ListenerUtils"
+} external;

--- a/ballerina/tests/01_listener_test.bal
+++ b/ballerina/tests/01_listener_test.bal
@@ -20,10 +20,10 @@ import ballerina/test;
     groups: ["listener", "attach_detach"]
 }
 function testDetachAndAttach() returns error? {
-    check wrappedListener.attach(simpleService, "graphql");
-    check wrappedListener.detach(simpleService);
-    check wrappedListener.attach(simpleService, "graphql");
-    error? attachResult = trap wrappedListener.attach(simpleService, "graphql");
+    check wrappedListener.attach(simpleService1, "graphql");
+    check wrappedListener.detach(simpleService1);
+    check wrappedListener.attach(simpleService1, "graphql");
+    error? attachResult = trap wrappedListener.attach(simpleService1, "graphql");
     test:assertTrue(attachResult is Error);
     Error err = <Error>attachResult;
     string expectedErrorMessage = "Error occurred while attaching the service";
@@ -34,6 +34,34 @@ function testDetachAndAttach() returns error? {
     error causingError = <error>cause;
     string expectedCausingErrorMessage = string`Service registration failed: two services have the same basePath : '/graphql'`;
     test:assertEquals(causingError.message(), expectedCausingErrorMessage);
+    check wrappedListener.detach(simpleService1);
+}
+
+@test:Config {
+    groups: ["listener", "attach_detach"],
+    dependsOn: [testDetachAndAttach]
+}
+function testAttachAndDetachMultipleServices() returns error? {
+    string document = "{ name }";
+    check wrappedListener.attach(simpleService1, "endpoint_1");
+    check wrappedListener.attach(simpleService2, "endpoint_2");
+
+    string url1 = "http://localhost:9090/endpoint_1";
+    string url2 = "http://localhost:9090/endpoint_2";
+    json result1 = check getJsonPayloadFromService(url1, document);
+    json result2 = check getJsonPayloadFromService(url2, document);
+
+    json expectedResult = { data: { name: "Walter White" } };
+
+    assertJsonValuesWithOrder(result1, expectedResult);
+    assertJsonValuesWithOrder(result2, expectedResult);
+
+    // Detach first service
+    check wrappedListener.detach(simpleService1);
+    string errorMessage = check getTextPayloadFromBadService(url1, document);
+    json newResult2 = check getJsonPayloadFromService(url2, document);
+    test:assertEquals("no matching service found for path : /endpoint_1", errorMessage);
+    assertJsonValuesWithOrder(newResult2, expectedResult);
 }
 
 @test:Config {

--- a/ballerina/tests/test_services.bal
+++ b/ballerina/tests/test_services.bal
@@ -17,7 +17,17 @@
 import ballerina/http;
 import ballerina/lang.runtime;
 
-Service simpleService = service object {
+Service simpleService1 = service object {
+    isolated resource function get name() returns string {
+        return "Walter White";
+    }
+
+    isolated resource function get id() returns int {
+        return 1;
+    }
+};
+
+Service simpleService2 = service object {
     isolated resource function get name() returns string {
         return "Walter White";
     }

--- a/ballerina/tests/utils.bal
+++ b/ballerina/tests/utils.bal
@@ -48,6 +48,14 @@ returns json|error {
     return response.getJsonPayload();
 }
 
+isolated function getTextPayloadFromBadService(string url, string document, json? variables = {}, string? operationName = ())
+returns string|error {
+    http:Client httpClient = check new(url);
+    http:Response response = check httpClient->post("/", { query: document, operationName: operationName, variables: variables});
+    assertResponseForBadRequest(response);
+    return response.getTextPayload();
+}
+
 isolated function assertResponseAndGetPayload(string url, string document, json? variables = {},
 string? operationName = (), int statusCode = http:STATUS_OK) returns json|error {
     http:Client httpClient = check new(url);
@@ -64,8 +72,10 @@ isolated function getTextPayloadFromBadRequest(string url, http:Request request)
 }
 
 isolated function assertResponseForBadRequest(http:Response response) {
-    test:assertEquals(response.statusCode, http:STATUS_BAD_REQUEST);
-    test:assertEquals(response.reasonPhrase, "Bad Request");
+    int statusCode = response.statusCode;
+    if statusCode != http:STATUS_BAD_REQUEST && statusCode != http:STATUS_NOT_FOUND {
+        test:assertFail(string`Invalid status code received: ${statusCode}`);
+    }
 }
 
 isolated function assertJsonValuesWithOrder(json actualPayload, json expectedPayload) {

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [[#2041] Fix Invalid Type Inferring for List Element Types](https://github.com/ballerina-platform/ballerina-standard-library/issues/2041)
 - [[#2042] Fix NON_NULL Fields Returning null Value](https://github.com/ballerina-platform/ballerina-standard-library/issues/2042)
 - [[#2018] Fix Ignoring Parser Invalidation of Variable Usages in Variable Definitions](https://github.com/ballerina-platform/ballerina-standard-library/issues/2018)
+- [[#2356] Fix Service Detach Function Always Detaching the Latest Attached Service](https://github.com/ballerina-platform/ballerina-standard-library/issues/2356)
 
 ## [1.0.0] - 2021-10-09
 

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/ListenerUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/ListenerUtils.java
@@ -23,7 +23,7 @@ import io.ballerina.runtime.api.values.BObject;
 /**
  * External utility methods used in Ballerina GraphQL listener.
  */
-public class ListenerUtils {
+public final class ListenerUtils {
     private static final String HTTP_SERVICE = "graphql.http.service";
 
     private ListenerUtils() {}

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/ListenerUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/ListenerUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.graphql.runtime.engine;
+
+import io.ballerina.runtime.api.values.BObject;
+
+/**
+ * External utility methods used in Ballerina GraphQL listener.
+ */
+public class ListenerUtils {
+    private static final String HTTP_SERVICE = "graphql.http.service";
+
+    public static void attachHttpServiceToGraphqlService(BObject graphqlService, BObject httpService) {
+        graphqlService.addNativeData(HTTP_SERVICE, httpService);
+    }
+
+    public static Object getHttpServiceFromGraphqlService(BObject graphqlService) {
+        Object httpService = graphqlService.getNativeData(HTTP_SERVICE);
+        if (httpService instanceof BObject) {
+            return httpService;
+        }
+        return null;
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/ListenerUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/ListenerUtils.java
@@ -26,6 +26,8 @@ import io.ballerina.runtime.api.values.BObject;
 public class ListenerUtils {
     private static final String HTTP_SERVICE = "graphql.http.service";
 
+    private ListenerUtils() {}
+
     public static void attachHttpServiceToGraphqlService(BObject graphqlService, BObject httpService) {
         graphqlService.addNativeData(HTTP_SERVICE, httpService);
     }


### PR DESCRIPTION
## Purpose
Previously, when the `detach` function of the GraphQL listener is called, no matter which service is passed to detach, the latest attached HTTP service is being detached from the underlying HTTP listener. This causes unexpected results.
This PR will fix this issue, by keeping track the HTTP service related to a particular GraphQL service. 

Fixes: [#2356](https://github.com/ballerina-platform/ballerina-standard-library/issues/2356)

## Examples
N/A

## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [X] Added tests
