### PR TITLE
Refactor Compiler Plugin Code and Invalidate Path Parameters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - [[#2437] Pass `http:RequestContext` object to the `graphql:Context` Init Function](https://github.com/ballerina-platform/ballerina-standard-library/issues/2437)
+- [[#2465] Disallow path parameters in GraphQL resource functions](https://github.com/ballerina-platform/ballerina-standard-library/issues/2465)
 
 ## [1.0.1] - 2021-11-19
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/CompilerPluginTest.java
@@ -20,12 +20,11 @@ package io.ballerina.stdlib.graphql.compiler;
 
 import io.ballerina.projects.DiagnosticResult;
 import io.ballerina.projects.Package;
-import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.ProjectEnvironmentBuilder;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.environment.Environment;
 import io.ballerina.projects.environment.EnvironmentBuilder;
-import io.ballerina.stdlib.graphql.compiler.Utils.CompilationError;
+import io.ballerina.stdlib.graphql.compiler.validator.errors.CompilationError;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 import org.testng.Assert;
@@ -47,121 +46,106 @@ public class CompilerPluginTest {
 
     @Test
     public void testValidResourceReturnTypes() {
-        Package currentPackage = loadPackage("valid_service_1");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "valid_service_1";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 0);
     }
 
     @Test
     public void testValidResourceInputTypes() {
-        Package currentPackage = loadPackage("valid_service_2");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "valid_service_2";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 0);
     }
 
     @Test
     public void testValidServiceConfigurationAnnotation() {
-        Package currentPackage = loadPackage("valid_service_3");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "valid_service_3";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 0);
     }
 
     @Test
     public void testResourceReturningEnum() {
-        Package currentPackage = loadPackage("valid_service_4");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "valid_service_4";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 0);
     }
 
     @Test
     public void testEnumAsResourceInputParameter() {
-        Package currentPackage = loadPackage("valid_service_5");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "valid_service_5";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 0);
     }
 
     @Test
     public void testValidListenerConfigurations() {
-        Package currentPackage = loadPackage("valid_service_6");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "valid_service_6";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 0);
     }
 
     @Test
     public void testOptionalInputParametersInResources() {
-        Package currentPackage = loadPackage("valid_service_7");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "valid_service_7";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 0);
     }
 
     @Test
     public void testReturningDistinctServiceObjects() {
-        Package currentPackage = loadPackage("valid_service_8");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "valid_service_8";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 0);
     }
 
     @Test
     public void testReturningServiceTypesRecursively() {
-        Package currentPackage = loadPackage("valid_service_9");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "valid_service_9";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 0);
     }
 
     @Test
     public void testFieldsInServiceObject() {
-        Package currentPackage = loadPackage("valid_service_10");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "valid_service_10";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 0);
     }
 
     @Test
     public void testInputObjectTypeInputParameter() {
-        Package currentPackage = loadPackage("valid_service_11");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "valid_service_11";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 0);
     }
 
     @Test
     public void testGraphQLContextAsFirstParameter() {
-        Package currentPackage = loadPackage("valid_service_12");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "valid_service_12";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 0);
     }
 
     @Test
     public void testGraphQLContextInsideReturningServices() {
-        Package currentPackage = loadPackage("valid_service_13");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "valid_service_13";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 0);
     }
 
     @Test
     public void testGraphQLListTypeInputParametersInResources() {
-        Package currentPackage = loadPackage("valid_service_14");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "valid_service_14";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 0);
     }
 
     @Test
     public void testMultipleListenersOnSameService() {
-        Package currentPackage = loadPackage("invalid_service_1");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_1";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 1);
         Diagnostic diagnostic = diagnosticResult.errors().iterator().next();
         assertError(diagnostic, CompilationError.INVALID_MULTIPLE_LISTENERS, 19, 1);
@@ -169,9 +153,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testMissingResourceFunctionInService() {
-        Package currentPackage = loadPackage("invalid_service_2");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_2";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 1);
         Diagnostic diagnostic = diagnosticResult.errors().iterator().next();
         assertError(diagnostic, CompilationError.MISSING_RESOURCE_FUNCTIONS, 19, 1);
@@ -179,9 +162,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testInvalidResourceAccessor() {
-        Package currentPackage = loadPackage("invalid_service_3");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_3";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 1);
         Diagnostic diagnostic = diagnosticResult.errors().iterator().next();
         assertError(diagnostic, CompilationError.INVALID_RESOURCE_FUNCTION_ACCESSOR, 20, 23);
@@ -189,9 +171,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testInvalidResourceReturnTypes() {
-        Package currentPackage = loadPackage("invalid_service_4");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_4";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 8);
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
 
@@ -222,9 +203,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testInvalidResourceInputParameterTypes() {
-        Package currentPackage = loadPackage("invalid_service_5");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_5";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 7);
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
 
@@ -252,9 +232,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testReturningOnlyErrorOrNil() {
-        Package currentPackage = loadPackage("invalid_service_6");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_6";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 1);
         Diagnostic diagnostic = diagnosticResult.errors().iterator().next();
         assertError(diagnostic, CompilationError.INVALID_RETURN_TYPE_ERROR_OR_NIL, 20, 5);
@@ -262,9 +241,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testReturningOnlyNil() {
-        Package currentPackage = loadPackage("invalid_service_7");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_7";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 1);
         Diagnostic diagnostic = diagnosticResult.errors().iterator().next();
         assertError(diagnostic, CompilationError.INVALID_RETURN_TYPE_NIL, 20, 5);
@@ -272,9 +250,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testReturningOnlyError() {
-        Package currentPackage = loadPackage("invalid_service_8");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_8";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 1);
         Diagnostic diagnostic = diagnosticResult.errors().iterator().next();
         assertError(diagnostic, CompilationError.INVALID_RETURN_TYPE_ERROR, 20, 5);
@@ -282,9 +259,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testListenerInitParameters() {
-        Package currentPackage = loadPackage("invalid_service_9");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_9";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 2);
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
 
@@ -297,9 +273,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testInvalidInputParameterUnions() {
-        Package currentPackage = loadPackage("invalid_service_10");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_10";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 4);
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
 
@@ -318,9 +293,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testInvalidResourceReturnTypeUnions() {
-        Package currentPackage = loadPackage("invalid_service_11");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_11";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 3);
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
 
@@ -336,9 +310,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testInvalidAccessorsInServicesReturningFromResources() {
-        Package currentPackage = loadPackage("invalid_service_12");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_12";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 2);
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
 
@@ -351,9 +324,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testInvalidReturnTypesInServicesReturningFromResources() {
-        Package currentPackage = loadPackage("invalid_service_13");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_13";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 2);
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
 
@@ -366,9 +338,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testInvalidInputParametersInServicesReturningFromResources() {
-        Package currentPackage = loadPackage("invalid_service_14");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_14";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 2);
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
 
@@ -381,9 +352,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testInvalidListenerInitParameters() {
-        Package currentPackage = loadPackage("invalid_service_15");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_15";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 1);
         Diagnostic diagnostic = diagnosticResult.errors().iterator().next();
         assertError(diagnostic, CompilationError.INVALID_LISTENER_INIT, 22, 57);
@@ -391,9 +361,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testInvalidResourcePath() {
-        Package currentPackage = loadPackage("invalid_service_16");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_16";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 7);
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
 
@@ -421,9 +390,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testInvalidReturnTypeAny() {
-        Package currentPackage = loadPackage("invalid_service_17");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_17";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 2);
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
 
@@ -436,9 +404,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testServiceWithOnlyRemoteMethods() {
-        Package currentPackage = loadPackage("invalid_service_18");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_18";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 1);
         Diagnostic diagnostic = diagnosticResult.errors().iterator().next();
         assertError(diagnostic, CompilationError.MISSING_RESOURCE_FUNCTIONS, 19, 1);
@@ -446,9 +413,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testRemoteMethodWithInvalidReturnType() {
-        Package currentPackage = loadPackage("invalid_service_19");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_19";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 1);
         Diagnostic diagnostic = diagnosticResult.errors().iterator().next();
         assertError(diagnostic, CompilationError.INVALID_RETURN_TYPE, 23, 5);
@@ -456,9 +422,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testRemoteMethodInsideReturningServiceObject() {
-        Package currentPackage = loadPackage("invalid_service_20");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_20";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 1);
         Diagnostic diagnostic = diagnosticResult.errors().iterator().next();
         assertError(diagnostic, CompilationError.INVALID_FUNCTION, 36, 21);
@@ -466,9 +431,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testMissingResourceMethodFromReturningServiceClass() {
-        Package currentPackage = loadPackage("invalid_service_21");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_21";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 1);
         Diagnostic diagnostic = diagnosticResult.errors().iterator().next();
         assertError(diagnostic, CompilationError.MISSING_RESOURCE_FUNCTIONS, 25, 15);
@@ -476,9 +440,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testInvalidInputObjects() {
-        Package currentPackage = loadPackage("invalid_service_22");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_22";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 9);
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
         Diagnostic diagnostic = diagnosticIterator.next();
@@ -511,9 +474,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testGraphQLContextAsAnotherParameter() {
-        Package currentPackage = loadPackage("invalid_service_23");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_23";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 2);
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
         Diagnostic diagnostic = diagnosticIterator.next();
@@ -525,9 +487,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testInvalidContextObject() {
-        Package currentPackage = loadPackage("invalid_service_24");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_24";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 2);
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
         Diagnostic diagnostic = diagnosticIterator.next();
@@ -539,9 +500,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testInvalidRecordFieldType() {
-        Package currentPackage = loadPackage("invalid_service_25");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_25";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 1);
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
         Diagnostic diagnostic = diagnosticIterator.next();
@@ -550,9 +510,8 @@ public class CompilerPluginTest {
 
     @Test
     public void testInvalidListTypeInputs() {
-        Package currentPackage = loadPackage("invalid_service_26");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        String packagePath = "invalid_service_26";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 5);
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
         Diagnostic diagnostic = diagnosticIterator.next();
@@ -569,6 +528,26 @@ public class CompilerPluginTest {
 
         diagnostic = diagnosticIterator.next();
         assertError(diagnostic, CompilationError.INVALID_RESOURCE_INPUT_OBJECT_PARAM, 88, 52);
+    }
+
+    @Test
+    public void testInvalidResourcePaths() {
+        String packagePath = "invalid_service_27";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
+        Assert.assertEquals(diagnosticResult.errorCount(), 3);
+        Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
+        Diagnostic diagnostic = diagnosticIterator.next();
+        assertError(diagnostic, CompilationError.INVALID_PATH_PARAMETERS, 20, 5);
+
+        diagnostic = diagnosticIterator.next();
+        assertError(diagnostic, CompilationError.INVALID_PATH_PARAMETERS, 24, 5);
+
+        diagnostic = diagnosticIterator.next();
+        assertError(diagnostic, CompilationError.MISSING_RESOURCE_NAME, 28, 5);
+    }
+
+    private DiagnosticResult getDiagnosticResult(String packagePath) {
+        return loadPackage(packagePath).getCompilation().diagnosticResult();
     }
 
     private Package loadPackage(String path) {

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_27/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_27/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "graphql_test"
+name = "invalid_service_27"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_27/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_27/service.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/graphql;
+
+service / on new graphql:Listener(4000) {
+    resource function get profile/[string id]/name() returns string {
+        return "Walter White";
+    }
+
+    resource function get profile/[string ...ids]() returns string {
+        return "Jesse Pinkman";
+    }
+
+    resource function get .() returns int {
+        return 767;
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/Utils.java
@@ -29,18 +29,13 @@ import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
-import io.ballerina.tools.diagnostics.Diagnostic;
-import io.ballerina.tools.diagnostics.DiagnosticFactory;
-import io.ballerina.tools.diagnostics.DiagnosticInfo;
-import io.ballerina.tools.diagnostics.DiagnosticSeverity;
-import io.ballerina.tools.diagnostics.Location;
 
 import java.util.Optional;
 
 /**
  * Util class for the compiler plugin.
  */
-public class Utils {
+public final class Utils {
 
     private Utils() {
     }
@@ -50,71 +45,8 @@ public class Utils {
     public static final String PACKAGE_ORG = "ballerina";
 
     // resource function constants
-    public static final String RESOURCE_FUNCTION_GET = "get";
     public static final String LISTENER_IDENTIFIER = "Listener";
-    public static final String DOUBLE_UNDERSCORES = "__";
     public static final String CONTEXT_IDENTIFIER = "Context";
-
-    /**
-     * Compilation errors.
-     */
-    enum CompilationError {
-        INVALID_FUNCTION("Remote methods are not allowed inside the service classes returned from GraphQL resources",
-                         "GRAPHQL_101", DiagnosticSeverity.ERROR),
-        INVALID_RETURN_TYPE("Invalid GraphQL field Type", "GRAPHQL_102", DiagnosticSeverity.ERROR),
-        INVALID_RESOURCE_INPUT_PARAM("Invalid input parameter type for GraphQL resource/remote function", "GRAPHQL_103",
-                                     DiagnosticSeverity.ERROR),
-        INVALID_RETURN_TYPE_NIL("A GraphQL field must have a return type", "GRAPHQL_104", DiagnosticSeverity.ERROR),
-        INVALID_RETURN_TYPE_ERROR_OR_NIL("A GraphQL field must have a return data type", "GRAPHQL_105",
-                                         DiagnosticSeverity.ERROR),
-        INVALID_RESOURCE_FUNCTION_ACCESSOR(
-                "Only \"" + RESOURCE_FUNCTION_GET + "\" accessor is allowed for GraphQL resource function",
-                "GRAPHQL_106", DiagnosticSeverity.ERROR),
-        INVALID_MULTIPLE_LISTENERS("A GraphQL service cannot be attached to multiple listeners", "GRAPHQL_107",
-                                   DiagnosticSeverity.ERROR),
-        INVALID_RETURN_TYPE_ERROR("A GraphQL field must have a return data type", "GRAPHQL_108",
-                                  DiagnosticSeverity.ERROR),
-        INVALID_LISTENER_INIT("http:Listener and graphql:ListenerConfiguration are mutually exclusive", "GRAPHQL_109",
-                              DiagnosticSeverity.ERROR),
-        INVALID_RETURN_TYPE_MULTIPLE_SERVICES("GraphQL union type cannot consist non-distinct services", "GRAPHQL_110",
-                                              DiagnosticSeverity.ERROR),
-        INVALID_FIELD_NAME("A GraphQL field name must not begin with \"" + DOUBLE_UNDERSCORES +
-                                   "\", which is reserved by GraphQL introspection", "GRAPHQL_111",
-                           DiagnosticSeverity.ERROR),
-        INVALID_RETURN_TYPE_ANY(
-                "A GraphQL field cannot have \"any\" or \"anydata\" as the type, instead use specific types",
-                "GRAPHQL_112", DiagnosticSeverity.ERROR),
-        MISSING_RESOURCE_FUNCTIONS("A GraphQL service must have at least one resource function", "GRAPHQL_113",
-                                   DiagnosticSeverity.ERROR),
-        INVALID_RETURN_TYPE_INPUT_OBJECT("A GraphQL field type cannot be an input type", "GRAPHQL_113",
-                                         DiagnosticSeverity.ERROR),
-        INVALID_RESOURCE_INPUT_OBJECT_PARAM("A GraphQL field cannot use an output type as an input type", "GRAPHQL_114",
-                                            DiagnosticSeverity.ERROR),
-        INVALID_LOCATION_FOR_CONTEXT_PARAMETER("The graphql:Context should be the first parameter", "GRAPHQL_115",
-                                               DiagnosticSeverity.ERROR);
-
-        private final String error;
-        private final String errorCode;
-        private final DiagnosticSeverity diagnosticSeverity;
-
-        CompilationError(String error, String errorCode, DiagnosticSeverity diagnosticSeverity) {
-            this.error = error;
-            this.errorCode = errorCode;
-            this.diagnosticSeverity = diagnosticSeverity;
-        }
-
-        String getError() {
-            return error;
-        }
-
-        String getErrorCode() {
-            return errorCode;
-        }
-
-        DiagnosticSeverity getDiagnosticSeverity() {
-            return this.diagnosticSeverity;
-        }
-    }
 
     public static boolean validateModuleId(ModuleSymbol moduleSymbol) {
         String moduleName = moduleSymbol.id().moduleName();
@@ -139,14 +71,6 @@ public class Utils {
         return methodSymbol.qualifiers().contains(Qualifier.REMOTE);
     }
 
-    public static void updateContext(SyntaxNodeAnalysisContext context, CompilationError errorCode,
-                                     Location location) {
-        DiagnosticInfo diagnosticInfo = new DiagnosticInfo(
-                errorCode.getErrorCode(), errorCode.getError(), errorCode.getDiagnosticSeverity());
-        Diagnostic diagnostic = DiagnosticFactory.createDiagnostic(diagnosticInfo, location);
-        context.reportDiagnostic(diagnostic);
-    }
-
     public static boolean isGraphqlListener(TypeSymbol listenerType) {
         if (listenerType.typeKind() == TypeDescKind.UNION) {
             return ((UnionTypeSymbol) listenerType).memberTypeDescriptors().stream()
@@ -168,16 +92,5 @@ public class Utils {
             return moduleOpt.isPresent() && validateModuleId(moduleOpt.get());
         }
         return false;
-    }
-
-    public static boolean isInvalidFieldName(String fieldName) {
-        return fieldName.startsWith(DOUBLE_UNDERSCORES) || fieldName.contains("/" + DOUBLE_UNDERSCORES);
-    }
-
-    static Location getLocation(Symbol typeSymbol, Location alternateLocation) {
-        if (typeSymbol.getLocation().isPresent()) {
-            return typeSymbol.getLocation().get();
-        }
-        return alternateLocation;
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/validator/FunctionValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/validator/FunctionValidator.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package io.ballerina.stdlib.graphql.compiler;
+package io.ballerina.stdlib.graphql.compiler.validator;
 
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
@@ -35,12 +35,17 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.api.symbols.resourcepath.PathSegmentList;
+import io.ballerina.compiler.api.symbols.resourcepath.ResourcePath;
+import io.ballerina.compiler.api.symbols.resourcepath.util.PathSegment;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeList;
 import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.graphql.compiler.Utils;
+import io.ballerina.stdlib.graphql.compiler.validator.errors.CompilationError;
 import io.ballerina.tools.diagnostics.Location;
 
 import java.util.ArrayList;
@@ -52,13 +57,13 @@ import java.util.Optional;
 import java.util.Set;
 
 import static io.ballerina.stdlib.graphql.compiler.Utils.CONTEXT_IDENTIFIER;
-import static io.ballerina.stdlib.graphql.compiler.Utils.CompilationError;
 import static io.ballerina.stdlib.graphql.compiler.Utils.PACKAGE_ORG;
 import static io.ballerina.stdlib.graphql.compiler.Utils.PACKAGE_PREFIX;
-import static io.ballerina.stdlib.graphql.compiler.Utils.RESOURCE_FUNCTION_GET;
-import static io.ballerina.stdlib.graphql.compiler.Utils.getLocation;
 import static io.ballerina.stdlib.graphql.compiler.Utils.getMethodSymbol;
-import static io.ballerina.stdlib.graphql.compiler.Utils.updateContext;
+import static io.ballerina.stdlib.graphql.compiler.validator.ValidatorUtils.RESOURCE_FUNCTION_GET;
+import static io.ballerina.stdlib.graphql.compiler.validator.ValidatorUtils.getLocation;
+import static io.ballerina.stdlib.graphql.compiler.validator.ValidatorUtils.isInvalidFieldName;
+import static io.ballerina.stdlib.graphql.compiler.validator.ValidatorUtils.updateContext;
 
 /**
  * Validate functions in Ballerina GraphQL services.
@@ -137,9 +142,26 @@ public class FunctionValidator {
     private void validateResourcePath(MethodSymbol methodSymbol, Location location, SyntaxNodeAnalysisContext context) {
         if (methodSymbol.kind() == SymbolKind.RESOURCE_METHOD) {
             ResourceMethodSymbol resourceMethodSymbol = (ResourceMethodSymbol) methodSymbol;
-            if (Utils.isInvalidFieldName(resourceMethodSymbol.resourcePath().signature())) {
-                updateContext(context, CompilationError.INVALID_FIELD_NAME, location);
+            validateResourcePath(resourceMethodSymbol, location, context);
+        }
+    }
+
+    private void validateResourcePath(ResourceMethodSymbol resourceMethodSymbol, Location location,
+                                      SyntaxNodeAnalysisContext context) {
+        ResourcePath resourcePath = resourceMethodSymbol.resourcePath();
+        if (resourcePath.kind() == ResourcePath.Kind.PATH_SEGMENT_LIST) {
+            PathSegmentList pathSegmentList = (PathSegmentList) resourcePath;
+            for (PathSegment pathSegment : pathSegmentList.list()) {
+                if (pathSegment.pathSegmentKind() == PathSegment.Kind.NAMED_SEGMENT) {
+                    if (isInvalidFieldName(pathSegment.signature())) {
+                        updateContext(context, CompilationError.INVALID_FIELD_NAME, location);
+                    }
+                } else {
+                    updateContext(context, CompilationError.INVALID_PATH_PARAMETERS, location);
+                }
             }
+        } else {
+            updateContext(context, CompilationError.MISSING_RESOURCE_NAME, location);
         }
     }
 
@@ -453,7 +475,7 @@ public class FunctionValidator {
                 Location fieldLocation = getLocation(recordField, location);
                 validateReturnType(recordField.typeDescriptor(), fieldLocation, context);
             } else {
-                if (Utils.isInvalidFieldName(recordField.getName().orElse(""))) {
+                if (isInvalidFieldName(recordField.getName().orElse(""))) {
                     Location fieldLocation = getLocation(recordField, location);
                     updateContext(context, CompilationError.INVALID_FIELD_NAME, fieldLocation);
                 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/validator/ListenerValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/validator/ListenerValidator.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package io.ballerina.stdlib.graphql.compiler;
+package io.ballerina.stdlib.graphql.compiler.validator;
 
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
@@ -32,11 +32,13 @@ import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
 import io.ballerina.projects.plugins.AnalysisTask;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.graphql.compiler.Utils;
+import io.ballerina.stdlib.graphql.compiler.validator.errors.CompilationError;
 
 import java.util.Optional;
 
-import static io.ballerina.stdlib.graphql.compiler.Utils.CompilationError;
 import static io.ballerina.stdlib.graphql.compiler.Utils.isGraphqlListener;
+import static io.ballerina.stdlib.graphql.compiler.validator.ValidatorUtils.updateContext;
 
 /**
  * Validates Ballerina GraphQL Listener Initializations.
@@ -86,7 +88,7 @@ public class ListenerValidator implements AnalysisTask<SyntaxNodeAnalysisContext
             FunctionArgumentNode secondArg = functionArgs.get(1);
             SyntaxKind firstArgSyntaxKind = firstArg.expression().kind();
             if (firstArgSyntaxKind != SyntaxKind.NUMERIC_LITERAL) {
-                Utils.updateContext(context, CompilationError.INVALID_LISTENER_INIT, secondArg.location());
+                updateContext(context, CompilationError.INVALID_LISTENER_INIT, secondArg.location());
             }
         }
     }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/validator/ServiceAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/validator/ServiceAnalyzer.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package io.ballerina.stdlib.graphql.compiler;
+package io.ballerina.stdlib.graphql.compiler.validator;
 
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.plugins.CodeAnalysisContext;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/validator/ServiceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/validator/ServiceValidator.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package io.ballerina.stdlib.graphql.compiler;
+package io.ballerina.stdlib.graphql.compiler.validator;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
@@ -28,14 +28,15 @@ import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
 import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
 import io.ballerina.projects.plugins.AnalysisTask;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.graphql.compiler.validator.errors.CompilationError;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 
 import java.util.List;
 import java.util.Optional;
 
-import static io.ballerina.stdlib.graphql.compiler.Utils.CompilationError;
 import static io.ballerina.stdlib.graphql.compiler.Utils.validateModuleId;
+import static io.ballerina.stdlib.graphql.compiler.validator.ValidatorUtils.updateContext;
 
 /**
  * Validates a Ballerina GraphQL Service.
@@ -70,8 +71,7 @@ public class ServiceValidator implements AnalysisTask<SyntaxNodeAnalysisContext>
             ServiceDeclarationSymbol serviceDeclarationSymbol = (ServiceDeclarationSymbol) symbol.get();
             List<TypeSymbol> listeners = serviceDeclarationSymbol.listenerTypes();
             if (listeners.size() > 1 && hasGraphqlListener(listeners)) {
-                Utils.updateContext(context, CompilationError.INVALID_MULTIPLE_LISTENERS,
-                                    serviceDeclarationNode.location());
+                updateContext(context, CompilationError.INVALID_MULTIPLE_LISTENERS, serviceDeclarationNode.location());
             } else {
                 if (listeners.get(0).typeKind() == TypeDescKind.UNION) {
                     UnionTypeSymbol unionTypeSymbol = (UnionTypeSymbol) listeners.get(0);

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/validator/ValidatorUtils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/validator/ValidatorUtils.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.graphql.compiler.validator;
+
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.graphql.compiler.validator.errors.CompilationError;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticFactory;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
+import io.ballerina.tools.diagnostics.Location;
+
+/**
+ * Utility functions for the Ballerina GraphQL compiler validations.
+ */
+public final class ValidatorUtils {
+    private ValidatorUtils() {}
+
+    public static final String DOUBLE_UNDERSCORES = "__";
+    public static final String RESOURCE_FUNCTION_GET = "get";
+
+    public static void updateContext(SyntaxNodeAnalysisContext context, CompilationError errorCode,
+                                     Location location) {
+        DiagnosticInfo diagnosticInfo = new DiagnosticInfo(
+                errorCode.getErrorCode(), errorCode.getError(), errorCode.getDiagnosticSeverity());
+        Diagnostic diagnostic = DiagnosticFactory.createDiagnostic(diagnosticInfo, location);
+        context.reportDiagnostic(diagnostic);
+    }
+
+    static Location getLocation(Symbol typeSymbol, Location alternateLocation) {
+        if (typeSymbol.getLocation().isPresent()) {
+            return typeSymbol.getLocation().get();
+        }
+        return alternateLocation;
+    }
+
+    public static boolean isInvalidFieldName(String fieldName) {
+        return fieldName.startsWith(DOUBLE_UNDERSCORES);
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/validator/errors/CompilationError.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/validator/errors/CompilationError.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.graphql.compiler.validator.errors;
+
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+/**
+ * Compilation errors in the Ballerina GraphQL package.
+ */
+public enum CompilationError {
+    INVALID_FUNCTION(ErrorMessage.ERROR_101, ErrorCode.GRAPHQL_101, DiagnosticSeverity.ERROR),
+    INVALID_RETURN_TYPE(ErrorMessage.ERROR_102, ErrorCode.GRAPHQL_102, DiagnosticSeverity.ERROR),
+    INVALID_RESOURCE_INPUT_PARAM(ErrorMessage.ERROR_103, ErrorCode.GRAPHQL_103, DiagnosticSeverity.ERROR),
+    INVALID_RETURN_TYPE_NIL(ErrorMessage.ERROR_104, ErrorCode.GRAPHQL_104, DiagnosticSeverity.ERROR),
+    INVALID_RETURN_TYPE_ERROR_OR_NIL(ErrorMessage.ERROR_105, ErrorCode.GRAPHQL_105, DiagnosticSeverity.ERROR),
+    INVALID_RESOURCE_FUNCTION_ACCESSOR(ErrorMessage.ERROR_106, ErrorCode.GRAPHQL_106, DiagnosticSeverity.ERROR),
+    INVALID_MULTIPLE_LISTENERS(ErrorMessage.ERROR_107, ErrorCode.GRAPHQL_107, DiagnosticSeverity.ERROR),
+    INVALID_RETURN_TYPE_ERROR(ErrorMessage.ERROR_108, ErrorCode.GRAPHQL_108, DiagnosticSeverity.ERROR),
+    INVALID_LISTENER_INIT(ErrorMessage.ERROR_109, ErrorCode.GRAPHQL_109, DiagnosticSeverity.ERROR),
+    INVALID_RETURN_TYPE_MULTIPLE_SERVICES(ErrorMessage.ERROR_110, ErrorCode.GRAPHQL_110, DiagnosticSeverity.ERROR),
+    INVALID_FIELD_NAME(ErrorMessage.ERROR_111, ErrorCode.GRAPHQL_111, DiagnosticSeverity.ERROR),
+    INVALID_RETURN_TYPE_ANY(ErrorMessage.ERROR_112, ErrorCode.GRAPHQL_112, DiagnosticSeverity.ERROR),
+    MISSING_RESOURCE_FUNCTIONS(ErrorMessage.ERROR_113, ErrorCode.GRAPHQL_113, DiagnosticSeverity.ERROR),
+    INVALID_RETURN_TYPE_INPUT_OBJECT(ErrorMessage.ERROR_114, ErrorCode.GRAPHQL_114, DiagnosticSeverity.ERROR),
+    INVALID_RESOURCE_INPUT_OBJECT_PARAM(ErrorMessage.ERROR_115, ErrorCode.GRAPHQL_115, DiagnosticSeverity.ERROR),
+    INVALID_LOCATION_FOR_CONTEXT_PARAMETER(ErrorMessage.ERROR_116, ErrorCode.GRAPHQL_116, DiagnosticSeverity.ERROR),
+    INVALID_PATH_PARAMETERS(ErrorMessage.ERROR_117, ErrorCode.GRAPHQL_117, DiagnosticSeverity.ERROR),
+    MISSING_RESOURCE_NAME(ErrorMessage.ERROR_118, ErrorCode.GRAPHQL_118, DiagnosticSeverity.ERROR);
+
+    private final String error;
+    private final String errorCode;
+    private final DiagnosticSeverity diagnosticSeverity;
+
+    CompilationError(ErrorMessage message, ErrorCode errorCode, DiagnosticSeverity diagnosticSeverity) {
+        this.error = message.getMessage();
+        this.errorCode = errorCode.name();
+        this.diagnosticSeverity = diagnosticSeverity;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public DiagnosticSeverity getDiagnosticSeverity() {
+        return this.diagnosticSeverity;
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/validator/errors/ErrorCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/validator/errors/ErrorCode.java
@@ -16,18 +16,28 @@
  * under the License.
  */
 
-package io.ballerina.stdlib.graphql.compiler;
-
-import io.ballerina.projects.plugins.CompilerPlugin;
-import io.ballerina.projects.plugins.CompilerPluginContext;
-import io.ballerina.stdlib.graphql.compiler.validator.ServiceAnalyzer;
+package io.ballerina.stdlib.graphql.compiler.validator.errors;
 
 /**
- * This is the compiler plugin for Ballerina GraphQL package.
+ * Compilation error codes used in Ballerina GraphQL package compiler plugin.
  */
-public class GraphqlCompilerPlugin extends CompilerPlugin {
-    @Override
-    public void init(CompilerPluginContext compilerPluginContext) {
-        compilerPluginContext.addCodeAnalyzer(new ServiceAnalyzer());
-    }
+public enum ErrorCode {
+    GRAPHQL_101,
+    GRAPHQL_102,
+    GRAPHQL_103,
+    GRAPHQL_104,
+    GRAPHQL_105,
+    GRAPHQL_106,
+    GRAPHQL_107,
+    GRAPHQL_108,
+    GRAPHQL_109,
+    GRAPHQL_110,
+    GRAPHQL_111,
+    GRAPHQL_112,
+    GRAPHQL_113,
+    GRAPHQL_114,
+    GRAPHQL_115,
+    GRAPHQL_116,
+    GRAPHQL_117,
+    GRAPHQL_118
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/validator/errors/ErrorMessage.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/validator/errors/ErrorMessage.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.graphql.compiler.validator.errors;
+
+import static io.ballerina.stdlib.graphql.compiler.validator.ValidatorUtils.DOUBLE_UNDERSCORES;
+import static io.ballerina.stdlib.graphql.compiler.validator.ValidatorUtils.RESOURCE_FUNCTION_GET;
+
+/**
+ * Compilation error messages used in Ballerina GraphQL package compiler plugin.
+ */
+public enum ErrorMessage {
+    ERROR_101("Remote methods are not allowed inside the service classes returned from GraphQL resources"),
+    ERROR_102("Invalid GraphQL field Type: `{0}`"),
+    ERROR_103("Invalid input parameter type for GraphQL resource/remote function"),
+    ERROR_104("A GraphQL field must have a return type"),
+    ERROR_105("A GraphQL field must have a return data type"),
+    ERROR_106("Only \"" + RESOURCE_FUNCTION_GET + "\" accessor is allowed for GraphQL resource function"),
+    ERROR_107("A GraphQL service cannot be attached to multiple listeners"),
+    ERROR_108("A GraphQL field must have a return data type"),
+    ERROR_109("http:Listener and graphql:ListenerConfiguration are mutually exclusive"),
+    ERROR_110("GraphQL union type cannot consist non-distinct services"),
+    ERROR_111("A GraphQL field name must not begin with \"" + DOUBLE_UNDERSCORES +
+                      "\", which is reserved by GraphQL introspection"),
+    ERROR_112("A GraphQL field cannot have \"any\" or \"anydata\" as the type, instead use specific types"),
+    ERROR_113("A GraphQL service must have at least one resource function"),
+    ERROR_114("The record type `{0}` is used as a GraphQL input type, cannot be used as an output type"),
+    ERROR_115("A GraphQL field cannot use an output type as an input type"),
+    ERROR_116("The graphql:Context should be the first parameter"),
+    ERROR_117("Path parameters not allowed in GraphQL resources"),
+    ERROR_118("A GraphQL resource must have a name");
+
+    private final String message;
+
+    ErrorMessage(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+}


### PR DESCRIPTION
## Purpose
- Refactoring the compiler plugin code to match with the compile-time schema generation task. 
- Disallow the path parameters and resource functions without resource path (dotted resources).

Fixes: [#2465](https://github.com/ballerina-platform/ballerina-standard-library/issues/2465)

## Examples
The following resource functions inside a GraphQL service will cause compilation errors.

Example 1 - Path Parameters:

```ballerina
resource function get profile/[string id]/name() returns string {
    return "Walter White";
}
```

Example 2 - Path rest parameters:

```ballerina
resource function get profile/[string ...ids] returns string {
    return "Walter White";
}
```

__Example 3 - Dotted resource paths:__

```ballerina
resource function get .() returns int {
    return 767;
}
```


## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
