### PR TITLE
Deprecate `context.add` Function and Introduce `context.set` Function

### DIFF
--- a/ballerina/context.bal
+++ b/ballerina/context.bal
@@ -17,6 +17,7 @@
 import ballerina/http;
 import ballerina/lang.value;
 
+# The GraphQL context object used to pass the meta information between resolvers.
 public isolated class Context {
     private final map<value:Cloneable|isolated object {}> attributes;
 
@@ -24,6 +25,29 @@ public isolated class Context {
         self.attributes = {};
     }
 
+    # Sets a given value for a given key in the GraphQL context.
+    #
+    # + key - The key for the value to be set
+    # + value - Value to be set
+    public isolated function set(string 'key, value:Cloneable|isolated object {} value) {
+        lock {
+            if value is value:Cloneable {
+                self.attributes['key] = value.clone();
+            } else {
+                self.attributes['key] = value;
+            }
+        }
+    }
+
+    # Adds a value to the GraphQL context.
+    #
+    # + key - The key for the value to be set
+    # + value - The value to be set
+    # + return - A `graphql:Error` if the key already exists in the context, nil otherwise
+    #
+    # # Deprecated
+    # This function is deprecated and will be removed in a future release. Please use `set` method instead.
+    @deprecated
     public isolated function add(string 'key, value:Cloneable|isolated object {} value) returns Error? {
         lock {
             if self.attributes.hasKey('key) {
@@ -36,6 +60,10 @@ public isolated class Context {
         }
     }
 
+    # Retrieves a value using the given key from the GraphQL context.
+    #
+    # + key - The key corresponding to the required value
+    # + return - The value if the key is present in the context, a `graphql:Error` otherwise
     public isolated function get(string 'key) returns value:Cloneable|isolated object {}|Error {
         lock {
             if self.attributes.hasKey('key) {
@@ -46,10 +74,14 @@ public isolated class Context {
                     return value;
                 }
             }
+            return error Error(string`Attribute with the key "${'key}" not found in the context`);
         }
-        return error Error(string`Attribute with the key "${'key}" not found in the context`);
     }
 
+    # Removes a value using the given key from the GraphQL context.
+    #
+    # + key - The key corresponding to the value to be removed
+    # + return - The value if the key is present in the context, a `graphql:Error` otherwise
     public isolated function remove(string 'key) returns value:Cloneable|isolated object {}|Error {
         lock {
             if self.attributes.hasKey('key) {
@@ -60,8 +92,8 @@ public isolated class Context {
                     return value;
                 }
             }
+            return error Error(string`Attribute with the key "${'key}" not found in the context`);
         }
-        return error Error(string`Attribute with the key "${'key}" not found in the context`);
     }
 }
 

--- a/ballerina/tests/27_context.bal
+++ b/ballerina/tests/27_context.bal
@@ -176,6 +176,22 @@ function testSettingAttributeTwice() returns error? {
 @test:Config {
     groups: ["context"]
 }
+function testSettingObjectValues() returns error? {
+    ContextInit contextInit =
+        isolated function (http:RequestContext requestContext, http:Request request) returns Context|error {
+            Context context = new;
+            context.set("HierarchicalServiceObject", new HierarchicalName());
+            return context;
+        };
+    http:Request request = new;
+    http:RequestContext requestContext = new;
+    Context context = check contextInit(requestContext, request);
+    test:assertTrue((check context.get("HierarchicalServiceObject")) is HierarchicalName);
+}
+
+@test:Config {
+    groups: ["context"]
+}
 isolated function testContextWithHttpHeaderValues() returns error? {
     string url = "http://localhost:9092/context";
     string document = "{ profile { name } }";

--- a/ballerina/tests/27_context.bal
+++ b/ballerina/tests/27_context.bal
@@ -135,6 +135,47 @@ function testAddingDuplicateAttribute() returns error? {
 @test:Config {
     groups: ["context"]
 }
+function testSettingAttribute() returns error? {
+    ContextInit contextInit =
+        isolated function (http:RequestContext requestContext, http:Request request) returns Context|error {
+            Context context = new;
+            context.set("String", "Ballerina");
+            return context;
+        };
+    http:Request request = new;
+    http:RequestContext requestContext = new;
+    Context context = check contextInit(requestContext, request);
+    var value = check context.get("String");
+    test:assertTrue(value is string);
+    test:assertEquals(<string>value, "Ballerina");
+}
+
+@test:Config {
+    groups: ["context"]
+}
+function testSettingAttributeTwice() returns error? {
+    ContextInit contextInit =
+        isolated function (http:RequestContext requestContext, http:Request request) returns Context|error {
+            Context context = new;
+            context.set("String", "Ballerina");
+            return context;
+        };
+    http:Request request = new;
+    http:RequestContext requestContext = new;
+    Context context = check contextInit(requestContext, request);
+    var value = check context.get("String");
+    test:assertTrue(value is string);
+    test:assertEquals(<string>value, "Ballerina");
+
+    context.set("String", "GraphQL");
+    value = check context.get("String");
+    test:assertTrue(value is string);
+    test:assertEquals(<string>value, "GraphQL");
+}
+
+@test:Config {
+    groups: ["context"]
+}
 isolated function testContextWithHttpHeaderValues() returns error? {
     string url = "http://localhost:9092/context";
     string document = "{ profile { name } }";

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - [[#1837] Add Input Value List Support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1837)
 
+### Changed
+- [[#2476] Deprecating the `context.add` function and introducing the `context.set` function](https://github.com/ballerina-platform/ballerina-standard-library/issues/2476)
+
 ### Fixed
 - [[#2437] Pass `http:RequestContext` object to the `graphql:Context` Init Function](https://github.com/ballerina-platform/ballerina-standard-library/issues/2437)
 - [[#2465] Disallow path parameters in GraphQL resource functions](https://github.com/ballerina-platform/ballerina-standard-library/issues/2465)


### PR DESCRIPTION
## Purpose

Fixes: [#2476](https://github.com/ballerina-platform/ballerina-standard-library/issues/2476)

## Examples
N/A

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
