### PR TITLE
Increase Load Test Ramp-up Time

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -70,6 +70,7 @@ dependencies = [
 	{org = "ballerina", name = "lang.array"},
 	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "lang.value"},
+	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "mime"},
 	{org = "ballerina", name = "oauth2"},
 	{org = "ballerina", name = "regex"},
@@ -230,6 +231,9 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"},
 	{org = "ballerina", name = "observe"}
+]
+modules = [
+	{org = "ballerina", packageName = "log", moduleName = "log"}
 ]
 
 [[package]]

--- a/load-tests/snowtooth/scripts/run.sh
+++ b/load-tests/snowtooth/scripts/run.sh
@@ -19,4 +19,4 @@
 set -e
 source base-scenario.sh
 
-jmeter -n -t "${scriptsDir}/"snowtooth-test-plan.jmx -l "${resultsDir}/"original.jtl -Jusers=60 -Jduration=3600 -Jhost=bal.perf.test -Jport=80 -Jprotocol=http -Jpath=graphql ${payload_flags}
+jmeter -n -t "${scriptsDir}/"snowtooth-test-plan.jmx -l "${resultsDir}/"original.jtl -Jusers=60 -JrampUpPeriod=600 -Jduration=3600 -Jhost=bal.perf.test -Jport=80 -Jprotocol=http -Jpath=graphql ${payload_flags}


### PR DESCRIPTION
## Purpose
The load tests are failing due to an increase in requests suddenly. This PR will increase the ramp-up time of the load test, therefore the increase of requests will be reduced.

## Examples
N/A

## Checklist
- [ ] ~Linked to an issue~
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
