### PR TITLE
Fix not Allowing `null` Values as Arguments

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -35,7 +35,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.2.1"
+version = "2.2.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -115,7 +115,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.2.1"
+version = "1.2.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -315,7 +315,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.2.1"
+version = "2.2.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -35,7 +35,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -115,7 +115,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -315,7 +315,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/tests/26_nullable_values.bal
+++ b/ballerina/tests/26_nullable_values.bal
@@ -244,8 +244,7 @@ isolated function testNullValueInListTypeInputWithVaraibles() returns error? {
 }
 
 @test:Config {
-    groups: ["inputs", "variables", "nullable"],
-    enable: false // TODO: Disabled due to https://github.com/ballerina-platform/ballerina-standard-library/issues/2712
+    groups: ["inputs", "variables", "nullable"]
 }
 isolated function testNullValueForNullableInputObjectWithVariableValue() returns error? {
     string url = "http://localhost:9091/null_values";
@@ -257,7 +256,7 @@ isolated function testNullValueForNullableInputObjectWithVariableValue() returns
     json expectedPayload = {
         data: {
             book: {
-                name: "The Art of Electronics"
+                name: "Algorithms to Live By"
             }
         }
     };
@@ -265,8 +264,7 @@ isolated function testNullValueForNullableInputObjectWithVariableValue() returns
 }
 
 @test:Config {
-    groups: ["list", "variables", "inputs"],
-    enable: false // TODO: Disabled due to https://github.com/ballerina-platform/ballerina-standard-library/issues/2712
+    groups: ["list", "variables", "inputs"]
 }
 isolated function testNullValueForNullableListTypeInputWithVaraibles() returns error? {
     string document = string`query ($words: [String]){ concat(words: $words) }`;

--- a/ballerina/tests/33_nullable_inputs.bal
+++ b/ballerina/tests/33_nullable_inputs.bal
@@ -1,0 +1,107 @@
+// Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+@test:Config {
+    groups: ["inputs", "input_objects", "nullable_inputs"]
+}
+isolated function testNullInputForNullableRecord() returns error? {
+    string url = "http://localhost:9091/nullable_inputs";
+    string document = "{ city(address: null) }";
+    json actualPayload = check getJsonPayloadFromService(url, document);
+    json expectedPayload = {
+        data: {
+            city: null
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["inputs", "input_objects", "nullable_inputs"]
+}
+isolated function testNonNullInputForNullableRecord() returns error? {
+    string url = "http://localhost:9091/nullable_inputs";
+    string document = check getGraphQLDocumentFromFile("non_null_input_for_nullable_record.graphql");
+    json actualPayload = check getJsonPayloadFromService(url, document);
+    json expectedPayload = {
+        data: {
+            city: "Albequerque"
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["inputs", "input_objects", "nullable_inputs", "list"]
+}
+isolated function testNullInputForNullableList() returns error? {
+    string url = "http://localhost:9091/nullable_inputs";
+    string document = "{ cities(addresses: null) }";
+    json actualPayload = check getJsonPayloadFromService(url, document);
+    json expectedPayload = {
+        data: {
+            cities: null
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["inputs", "input_objects", "nullable_inputs", "list"]
+}
+isolated function testNonNullInputForNullableList() returns error? {
+    string url = "http://localhost:9091/nullable_inputs";
+    string document = check getGraphQLDocumentFromFile("non_null_input_for_nullable_list.graphql");
+    json actualPayload = check getJsonPayloadFromService(url, document);
+    json expectedPayload = {
+        data: {
+            cities: ["Albequerque", "Hogwarts"]
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["inputs", "input_objects", "nullable_inputs", "list"]
+}
+isolated function testNullInputForNullableRecordField() returns error? {
+    string url = "http://localhost:9091/nullable_inputs";
+    string document = check getGraphQLDocumentFromFile("null_input_for_nullable_record_field.graphql");
+    json actualPayload = check getJsonPayloadFromService(url, document);
+    json expectedPayload = {
+        data: {
+            accountNumber: 123456
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["inputs", "input_objects", "nullable_inputs", "list"]
+}
+isolated function testNonNullInputForNullableRecordField() returns error? {
+    string url = "http://localhost:9091/nullable_inputs";
+    string document = check getGraphQLDocumentFromFile("non_null_input_for_nullable_record_field.graphql");
+    json actualPayload = check getJsonPayloadFromService(url, document);
+    json expectedPayload = {
+        data: {
+            accountNumber: 123456
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}

--- a/ballerina/tests/records.bal
+++ b/ballerina/tests/records.bal
@@ -16,6 +16,11 @@
 
 type Information Address|Person;
 
+type Account record {
+    int number;
+    Contact? contact;
+};
+
 type Pet record {
     string name;
     string ownerName;

--- a/ballerina/tests/resources/documents/non_null_input_for_nullable_list.graphql
+++ b/ballerina/tests/resources/documents/non_null_input_for_nullable_list.graphql
@@ -1,0 +1,8 @@
+{
+    cities(
+        addresses: [
+            { number: "308", street: "Negra Arroyo Lane", city: "Albequerque" },
+            { number: "Unknown", street: "Unknown", city: "Hogwarts" }
+        ]
+    )
+}

--- a/ballerina/tests/resources/documents/non_null_input_for_nullable_record.graphql
+++ b/ballerina/tests/resources/documents/non_null_input_for_nullable_record.graphql
@@ -1,0 +1,9 @@
+{
+    city(
+        address: {
+            number: "308"
+            street: "Negra Arroyo Lane"
+            city: "Albequerque"
+        }
+    )
+}

--- a/ballerina/tests/resources/documents/non_null_input_for_nullable_record_field.graphql
+++ b/ballerina/tests/resources/documents/non_null_input_for_nullable_record_field.graphql
@@ -1,0 +1,5 @@
+{
+    accountNumber(
+        account: { number: 123456, contact: { number: "07123456789"} }
+    )
+}

--- a/ballerina/tests/resources/documents/null_input_for_nullable_record_field.graphql
+++ b/ballerina/tests/resources/documents/null_input_for_nullable_record_field.graphql
@@ -1,0 +1,5 @@
+{
+    accountNumber(
+        account: { number: 123456, contact: null }
+    )
+}

--- a/ballerina/tests/test_services.bal
+++ b/ballerina/tests/test_services.bal
@@ -1122,3 +1122,23 @@ service /intersection_types on basicListener {
         return pet.ownerName;
     }
 }
+
+service /nullable_inputs on basicListener {
+    resource function get city(Address? address) returns string? {
+        if address is Address {
+            return address.city;
+        }
+        return;
+    }
+
+    resource function get cities(Address[]? addresses) returns string[]? {
+        if addresses is Address[] {
+            return addresses.map(address => address.city);
+        }
+        return;
+    }
+
+    resource function get accountNumber(Account account) returns int {
+        return account.number;
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/ArgumentHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/ArgumentHandler.java
@@ -152,6 +152,8 @@ public class ArgumentHandler {
     private Object getUnionTypeArgument(BObject argumentNode, UnionType unionType) {
         if (isEnum(unionType)) {
             return getScalarArgumentValue(argumentNode);
+        } else if (unionType.isNilable() && argumentNode.get(VALUE_FIELD) == null) {
+            return null;
         }
         Type effectiveType = getEffectiveType(unionType);
         return getArgumentValue(argumentNode, effectiveType);

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/ArgumentHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/ArgumentHandler.java
@@ -152,8 +152,12 @@ public class ArgumentHandler {
     private Object getUnionTypeArgument(BObject argumentNode, UnionType unionType) {
         if (isEnum(unionType)) {
             return getScalarArgumentValue(argumentNode);
-        } else if (unionType.isNilable() && argumentNode.get(VALUE_FIELD) == null) {
-            return null;
+        } else if (unionType.isNilable()) {
+            if (argumentNode.getBooleanValue(VARIABLE_DEFINITION) && argumentNode.get(VARIABLE_VALUE_FIELD) == null) {
+                return null;
+            } else if (!argumentNode.getBooleanValue(VARIABLE_DEFINITION) && argumentNode.get(VALUE_FIELD) == null) {
+                return null;
+            }
         }
         Type effectiveType = getEffectiveType(unionType);
         return getArgumentValue(argumentNode, effectiveType);


### PR DESCRIPTION
## Purpose
$Subject

This bug was introduced with #605. Therefore, no released versions are affected by the bug. Therefore, the changelog is not updated. 

Fixes: [#2712](https://github.com/ballerina-platform/ballerina-standard-library/issues/2712)

## Examples
N/A

## Checklist
- [x] Linked to an issue
- [ ] ~Updated the changelog~
- [x] Added tests
