### PR TITLE
Add generic graphql client

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "graphql"
-version = "1.2.1"
+version = "1.2.2"
 authors = ["Ballerina"]
 keywords = ["gql", "network", "query", "service"]
 repository = "https://github.com/ballerina-platform/module-ballerina-graphql"
@@ -10,4 +10,4 @@ license = ["Apache-2.0"]
 distribution = "2201.0.1"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/graphql-native-1.2.1.jar"
+path = "../native/build/libs/graphql-native-1.2.2-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "graphql-compiler-plugin"
 class = "io.ballerina.stdlib.graphql.compiler.GraphqlCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/graphql-compiler-plugin-1.2.1.jar"
+path = "../compiler-plugin/build/libs/graphql-compiler-plugin-1.2.2-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -59,7 +59,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "file"},

--- a/ballerina/common_utils.bal
+++ b/ballerina/common_utils.bal
@@ -353,10 +353,12 @@ isolated function getInputObjectFieldFormPath((string|int)[] path, string name) 
     return name;
 }
 
-isolated function getGraphqlPayload(string query, map<anydata>? variables = ()) returns json {
+isolated function getGraphqlPayload(string query, map<anydata>? variables = (), string? operationName = ()) 
+                                    returns json {
     return {
         query: query,
-        variables: variables.toJson()
+        variables: variables.toJson(),
+        operationName: operationName
     };
 }
 

--- a/ballerina/errors.bal
+++ b/ballerina/errors.bal
@@ -22,3 +22,17 @@ public type AuthnError distinct Error;
 
 # Represents the authorization error type.
 public type AuthzError distinct Error;
+
+// GraphQL client related errors representation
+
+# Represents GraphQL client related generic errors.
+public type ClientError RequestError|ServerError;
+
+# Represents GraphQL client side or network level errors.
+public type RequestError distinct error<record {| anydata body?; |}>;
+
+# Represents GraphQL API response during GraphQL API server side errors.
+public type ServerError distinct error<record {| json? data?; ErrorDetail[] errors; map<json>? extensions?; |}>;
+
+# Represents a list of GraphQL API server side errors.
+type GraphQLErrorArray ErrorDetail[];

--- a/ballerina/errors.bal
+++ b/ballerina/errors.bal
@@ -34,5 +34,4 @@ public type RequestError distinct error<record {| anydata body?; |}>;
 # Represents GraphQL API response during GraphQL API server side errors.
 public type ServerError distinct error<record {| json? data?; ErrorDetail[] errors; map<json>? extensions?; |}>;
 
-# Represents a list of GraphQL API server side errors.
 type GraphQLErrorArray ErrorDetail[];

--- a/ballerina/graphql_client.bal
+++ b/ballerina/graphql_client.bal
@@ -1,0 +1,107 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/jballerina.java;
+import ballerina/http;
+ 
+# The [Ballerina](https://ballerina.io/) generic client for GraphQL(https://graphql.org/) APIs.
+public isolated client class Client {
+    final http:Client httpClient;
+
+    # Gets invoked to initialize the `connector`.
+    #
+    # + serviceUrl - URL of the target service
+    # + clientConfig - The configurations to be used when initializing the `connector`
+    # + return - An error at the failure of client initialization
+    public isolated function init(string serviceUrl, http:ClientConfiguration clientConfig = {})  returns ClientError? {
+        http:Client|http:ClientError httpClient = new (serviceUrl, clientConfig);
+        if httpClient is http:ClientError {
+             return error RequestError("GraphQL Client Error", httpClient);
+        }
+        self.httpClient = httpClient;
+    }
+
+    # Executes a GraphQL query and data binds the GraphQL response to a record with data and extensions 
+    # which is a subtype of GenericResponse. The errors of the GraphQL response are directed in the Ballerina error path.
+    #
+    # + query - The GraphQL query. For example `query countryByCode($code:ID!) {country(code:$code) {name}}`.
+    # + variables - The GraphQL variables. For example `{"code": "<variable_value>"}`.
+    # + headers - The GraphQL API headers to execute each query 
+    # + targetType - The payload, which is expected to be returned after data binding. For example 
+    #                `type CountryByCodeResponse record {| map<json?> __extensions?; record {| record{|string name;|}? country; |} data;`
+    # + return - The payload (if the `targetType` is configured) or a `graphql:ClientError` if failed to execute the query
+    remote isolated function executeWithType(string query, map<anydata>? variables = (), 
+                                             map<string|string[]>? headers = (), 
+                                             typedesc<GenericResponse|record{}|json> targetType = <>) 
+                                             returns targetType|ClientError = @java:Method {
+        'class: "io.ballerina.stdlib.graphql.runtime.client.QueryExecutor",
+        name: "executeWithType"
+    } external;
+
+    private isolated function processExecuteWithType(typedesc<GenericResponse|record{}|json> targetType, 
+                                                     string query, map<anydata>? variables, 
+                                                     map<string|string[]>? headers) 
+                                                     returns GenericResponse|record{}|json|ClientError {
+        http:Request request = new;
+        json graphqlPayload = getGraphqlPayload(query, variables);
+        request.setPayload(graphqlPayload);
+        json|http:ClientError httpResponse = self.httpClient->post("", request, headers = headers);
+
+        if httpResponse is http:ClientError {
+            check handleHttpClientErrorResponse(httpResponse);
+        } else {
+            map<json> responseMap = <map<json>> httpResponse;
+            if responseMap.hasKey("errors") {
+                check handleGraphqlErrorResponse(responseMap);
+            } else {
+                return check performDataBinding(targetType, responseMap);
+            }
+        }
+    }
+
+    # Executes a GraphQL query and data binds the GraphQL response to a record with data, extensions and errors 
+    # which is a subtype of GenericResponseWithErrors. The errors of the GraphQL response are directed in the Ballerina 
+    # target type data binding path.
+    #
+    # + query - The GraphQL query. For example `query countryByCode($code:ID!) {country(code:$code) {name}}`.
+    # + variables - The GraphQL variables. For example `{"code": "<variable_value>"}`.
+    # + headers - The GraphQL API headers to execute each query 
+    # + targetType - The payload (`GenericResponseWithErrors`), which is expected to be returned after data binding. For example 
+    #               `type CountryByCodeResponse record {| map<json?> __extensions?; record {| record{|string name;|}? country; |} data; ErrorDetail[] errors?; |};`
+    # + return - The payload (if the `targetType` is configured) or a `graphql:ClientError` if failed to execute the query
+    remote isolated function execute(string query, map<anydata>? variables = (), map<string|string[]>? headers = (), 
+                                     typedesc<GenericResponseWithErrors|record{}|json> targetType = <>) 
+                                     returns targetType|ClientError = @java:Method {
+        'class: "io.ballerina.stdlib.graphql.runtime.client.QueryExecutor",
+        name: "execute"
+    } external;
+
+    private isolated function processExecute(typedesc<GenericResponseWithErrors|record{}|json> targetType, 
+                                             string query, map<anydata>? variables, map<string|string[]>? headers) 
+                                             returns GenericResponseWithErrors|record{}|json|ClientError {
+        http:Request request = new;
+        json graphqlPayload = getGraphqlPayload(query, variables);
+        request.setPayload(graphqlPayload);
+        json|http:ClientError httpResponse = self.httpClient->post("", request, headers = headers);
+
+        if httpResponse is http:ClientError {
+            check handleHttpClientErrorResponse(httpResponse);
+        } else {
+            map<json> responseMap = <map<json>> httpResponse;
+            return check performDataBindingWithErrors(targetType, responseMap);
+        }
+    }
+}

--- a/ballerina/graphql_client.bal
+++ b/ballerina/graphql_client.bal
@@ -34,16 +34,19 @@ public isolated client class Client {
         self.httpClient = httpClient;
     }
 
-    # Executes a GraphQL query and data binds the GraphQL response to a record with data and extensions 
+    # Executes a GraphQL document and data binds the GraphQL response to a record with data and extensions 
     # which is a subtype of GenericResponse.
     #
-    # + document - The GraphQL query or mutation. For example `query countryByCode($code:ID!) {country(code:$code) {name}}`.
+    # + document - The GraphQL document. It can include queries & mutations. 
+    #              For example `query OperationName($code:ID!) {country(code:$code) {name}}`.
     # + variables - The GraphQL variables. For example `{"code": "<variable_value>"}`.
+    # + operationName - The GraphQL operation name. If a request has two or more operations, then each operation must have a name. 
+    #                   A request can only execute one operation, so you must also include the operation name to execute.
     # + headers - The GraphQL API headers to execute each query 
     # + targetType - The payload, which is expected to be returned after data binding. For example 
-    #                `type CountryByCodeResponse record {| map<json?> __extensions?; record {| record{|string name;|}? country; |} data;`
+    #                `type CountryByCodeResponse record {| map<json?> extensions?; record {| record{|string name;|}? country; |} data;`
     # + return - The GraphQL response or a `graphql:ClientError` if failed to execute the query
-    remote isolated function executeWithType(string document, map<anydata>? variables = (), 
+    remote isolated function executeWithType(string document, map<anydata>? variables = (), string? operationName = (),
                                              map<string|string[]>? headers = (), 
                                              typedesc<GenericResponse|record{}|json> targetType = <>) 
                                              returns targetType|ClientError = @java:Method {
@@ -52,35 +55,42 @@ public isolated client class Client {
     } external;
 
     private isolated function processExecuteWithType(typedesc<GenericResponse|record{}|json> targetType, 
-                                                     string document, map<anydata>? variables, 
+                                                     string document, map<anydata>? variables, string? operationName,
                                                      map<string|string[]>? headers) 
                                                      returns GenericResponse|record{}|json|ClientError {
         http:Request request = new;
-        json graphqlPayload = getGraphqlPayload(document, variables);
+        json graphqlPayload = getGraphqlPayload(document, variables, operationName);
         request.setPayload(graphqlPayload);
         json|http:ClientError httpResponse = self.httpClient->post("", request, headers = headers);
 
         if httpResponse is http:ClientError {
             return handleHttpClientErrorResponse(httpResponse);
         } 
-        GenericResponseWithErrors|record{}|json response = check performDataBinding(targetType, httpResponse);
-        map<json> responseMap = <map<json>> httpResponse;
+        map<json>|error responseMap = httpResponse.ensureType();
+        if responseMap is error {
+            return error RequestError("GraphQL Client Error", responseMap);
+        }
         if responseMap.hasKey("errors") {
             return handleGraphqlErrorResponse(responseMap);
-        } 
-        return response;
+        } else {
+            return check performDataBinding(targetType, httpResponse);
+        }
     }
 
-    # Executes a GraphQL query and data binds the GraphQL response to a record with data, extensions and errors 
+    # Executes a GraphQL document and data binds the GraphQL response to a record with data, extensions and errors 
     # which is a subtype of GenericResponseWithErrors.
     #
-    # + document - The GraphQL query or mutation. For example `query countryByCode($code:ID!) {country(code:$code) {name}}`.
+    # + document - The GraphQL document. It can include queries & mutations. 
+    #              For example `query countryByCode($code:ID!) {country(code:$code) {name}}`.
     # + variables - The GraphQL variables. For example `{"code": "<variable_value>"}`.
+    # + operationName - The GraphQL operation name. If a request has two or more operations, then each operation must have a name. 
+    #                   A request can only execute one operation, so you must also include the operation name to execute.
     # + headers - The GraphQL API headers to execute each query 
     # + targetType - The payload (`GenericResponseWithErrors`), which is expected to be returned after data binding. For example 
-    #               `type CountryByCodeResponse record {| map<json?> __extensions?; record {| record{|string name;|}? country; |} data; ErrorDetail[] errors?; |};`
+    #               `type CountryByCodeResponse record {| map<json?> extensions?; record {| record{|string name;|}? country; |} data; ErrorDetail[] errors?; |};`
     # + return - The GraphQL response or a `graphql:ClientError` if failed to execute the query
-    remote isolated function execute(string document, map<anydata>? variables = (), map<string|string[]>? headers = (), 
+    remote isolated function execute(string document, map<anydata>? variables = (), string? operationName = (), 
+                                     map<string|string[]>? headers = (), 
                                      typedesc<GenericResponseWithErrors|record{}|json> targetType = <>) 
                                      returns targetType|ClientError = @java:Method {
         'class: "io.ballerina.stdlib.graphql.runtime.client.QueryExecutor",
@@ -88,10 +98,11 @@ public isolated client class Client {
     } external;
 
     private isolated function processExecute(typedesc<GenericResponseWithErrors|record{}|json> targetType, 
-                                             string document, map<anydata>? variables, map<string|string[]>? headers) 
+                                             string document, map<anydata>? variables, string? operationName, 
+                                             map<string|string[]>? headers) 
                                              returns GenericResponseWithErrors|record{}|json|ClientError {
         http:Request request = new;
-        json graphqlPayload = getGraphqlPayload(document, variables);
+        json graphqlPayload = getGraphqlPayload(document, variables, operationName);
         request.setPayload(graphqlPayload);
         json|http:ClientError httpResponse = self.httpClient->post("", request, headers = headers);
 

--- a/ballerina/modules/parser/records.bal
+++ b/ballerina/modules/parser/records.bal
@@ -34,8 +34,10 @@ public type Location record {|
 # + message - The details of the error
 # + locations - The locations in the GraphQL document related to the error
 # + path - The GraphQL resource path of the error
+# + extensions - Additional information to errors
 public type ErrorDetail record {|
     string message;
     Location[] locations?;
     (int|string)[] path?;
+    map<anydata> extensions?;
 |};

--- a/ballerina/records.bal
+++ b/ballerina/records.bal
@@ -46,7 +46,7 @@ type Location record {|
     *parser:Location;
 |};
 
-type ErrorDetail record {|
+public type ErrorDetail record {|
     *parser:ErrorDetail;
 |};
 

--- a/ballerina/tests/client_test.bal
+++ b/ballerina/tests/client_test.bal
@@ -1,0 +1,306 @@
+// Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithTypeWithJson() returns error? {
+    string url = "http://localhost:9091/inputs";
+    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
+    string userName = "Roland";
+    map<anydata> variables = {"userName": userName};
+
+    Client graphqlClient = check new (url);
+    json actualPayload = check graphqlClient->executeWithType(query, variables);
+    json expectedPayload = {
+        "data": {
+            "greet": "Hello, Roland"
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithTypeWithOpenRecord() returns error? {
+    string url = "http://localhost:9091/inputs";
+    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
+    string userName = "Roland";
+    map<anydata> variables = {"userName": userName};
+
+    Client graphqlClient = check new (url);
+    record{} actualPayload = check graphqlClient->executeWithType(query, variables);
+    record{} expectedPayload = {
+        "data": {
+            "greet": "Hello, Roland"
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload.toJson(), expectedPayload.toJson());
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithTypeWithKnownRecord() returns error? {
+    string url = "http://localhost:9091/inputs";
+    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
+    string userName = "Roland";
+    map<anydata> variables = {"userName": userName};
+
+    Client graphqlClient = check new (url);
+    GreetingResponse actualPayload = check graphqlClient->executeWithType(query, variables);
+    GreetingResponse expectedPayload = {
+        data: {
+            greet: "Hello, Roland"
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload.toJson(), expectedPayload.toJson());
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithTypeWithGenericRecord() returns error? {
+    string url = "http://localhost:9091/inputs";
+    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
+    string userName = "Roland";
+    map<anydata> variables = {"userName": userName};
+
+    Client graphqlClient = check new (url);
+    GenericGreetingResponse actualPayload = check graphqlClient->executeWithType(query, variables);
+    GenericGreetingResponse expectedPayload = {
+        data: {
+            greet: "Hello, Roland"
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload.toJson(), expectedPayload.toJson());
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithJson() returns error? {
+    string url = "http://localhost:9091/inputs";
+    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
+    string userName = "Roland";
+    map<anydata> variables = {"userName": userName};
+
+    Client graphqlClient = check new (url);
+    json actualPayload = check graphqlClient->execute(query, variables);
+    json expectedPayload = {
+        "data": {
+            "greet": "Hello, Roland"
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithOpenRecord() returns error? {
+    string url = "http://localhost:9091/inputs";
+    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
+    string userName = "Roland";
+    map<anydata> variables = {"userName": userName};
+
+    Client graphqlClient = check new (url);
+    record{} actualPayload = check graphqlClient->execute(query, variables);
+    record{} expectedPayload = {
+        "data": {
+            "greet": "Hello, Roland"
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload.toJson(), expectedPayload.toJson());
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithKnownRecord() returns error? {
+    string url = "http://localhost:9091/inputs";
+    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
+    string userName = "Roland";
+    map<anydata> variables = {"userName": userName};
+
+    Client graphqlClient = check new (url);
+    GreetingResponseWithErrors actualPayload = check graphqlClient->execute(query, variables);
+    GreetingResponseWithErrors expectedPayload = {
+        data: {
+            greet: "Hello, Roland"
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload.toJson(), expectedPayload.toJson());
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithGenericRecord() returns error? {
+    string url = "http://localhost:9091/inputs";
+    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
+    string userName = "Roland";
+    map<anydata> variables = {"userName": userName};
+
+    Client graphqlClient = check new (url);
+    GenericGreetingResponseWithErrors actualPayload = check graphqlClient->execute(query, variables);
+    GenericGreetingResponseWithErrors expectedPayload = {
+        data: {
+            greet: "Hello, Roland"
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload.toJson(), expectedPayload.toJson());
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithTypeWithInvalidRequest() returns error? {
+    string url = "http://localhost:9091/inputs";
+    string query = string `query Greeting ($userName:String!){ gree (name: $userName) }`;
+    string userName = "Roland";
+    map<anydata> variables = {"userName": userName};
+
+    Client graphqlClient = check new (url);
+    json|ClientError actualPayload = graphqlClient->executeWithType(query, variables);
+    if actualPayload is ClientError {
+        if actualPayload is RequestError {
+            test:assertEquals(actualPayload.message(), "GraphQL Client Error");
+        }
+    }
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithInvalidRequest() returns error? {
+    string url = "http://localhost:9091/inputs";
+    string query = string `query Greeting ($userName:String!){ gree (name: $userName) }`;
+    string userName = "Roland";
+    map<anydata> variables = {"userName": userName};
+
+    Client graphqlClient = check new (url);
+    json|ClientError actualPayload = graphqlClient->execute(query, variables);
+    if actualPayload is ClientError {
+        if actualPayload is RequestError {
+            test:assertEquals(actualPayload.message(), "GraphQL Client Error");
+        }
+    }
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithTypeWithInvalidBindingType() returns error? {
+    string url = "http://localhost:9091/inputs";
+    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
+    string userName = "Roland";
+    map<anydata> variables = {"userName": userName};
+
+    Client graphqlClient = check new (url);
+    string|ClientError actualPayload = graphqlClient->executeWithType(query, variables);
+    if actualPayload is ClientError {
+        if actualPayload is RequestError {
+            test:assertEquals(actualPayload.message(), "GraphQL Client Error");
+        }
+    }
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithTypeWithMutation() returns error? {
+    string url = "http://localhost:9091/mutations";
+    string query = string `mutation { setName(name: "Heisenberg") { name } }`;
+
+    Client graphqlClient = check new (url);
+    SetNameResponse actualPayload = check graphqlClient->executeWithType(query);
+    SetNameResponse expectedPayload = {
+        data: {
+            setName: {
+                name: "Heisenberg"
+            }
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload.toJson(), expectedPayload.toJson());
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithMutation() returns error? {
+    string url = "http://localhost:9091/mutations";
+    string query = string `mutation { setName(name: "Heisenberg") { name } }`;
+
+    Client graphqlClient = check new (url);
+    SetNameResponseWithErrors actualPayload = check graphqlClient->execute(query);
+    SetNameResponseWithErrors expectedPayload = {
+        data: {
+            setName: {
+                name: "Heisenberg"
+            }
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload.toJson(), expectedPayload.toJson());
+}
+
+type GreetingResponse record {|
+    map<json?> extensions?;
+    record {|
+        string greet;
+    |} data;
+|};
+
+type GenericGreetingResponse record {|
+    map<json?> extensions?;
+    map<json?> data?;
+|};
+
+type GreetingResponseWithErrors record {|
+    map<json?> extensions?;
+    record {|
+        string greet;
+    |} data;
+    ErrorDetail[] errors?;
+|};
+
+type GenericGreetingResponseWithErrors record {|
+    map<json?> extensions?;
+    map<json?> data?;
+    ErrorDetail[] errors?;
+|};
+
+type SetNameResponse record {|
+    map<json?> extensions?;
+    record {|
+        record {|
+            string name;
+        |} setName;
+    |} data;
+|};
+
+type SetNameResponseWithErrors record {|
+    map<json?> extensions?;
+    record {|
+        record {|
+            string name;
+        |} setName;
+    |} data;
+    ErrorDetail[] errors?;
+|};

--- a/ballerina/tests/client_test.bal
+++ b/ballerina/tests/client_test.bal
@@ -95,6 +95,25 @@ isolated function testClientExecuteWithTypeWithGenericRecord() returns error? {
 @test:Config {
     groups: ["client"]
 }
+isolated function testClientExecuteWithTypeWithAnyDataGenericRecord() returns error? {
+    string url = "http://localhost:9091/inputs";
+    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
+    string userName = "Roland";
+    map<anydata> variables = {"userName": userName};
+
+    Client graphqlClient = check new (url);
+    GenericGreetingResponseWithAnyDataRecord actualPayload = check graphqlClient->executeWithType(query, variables);
+    GenericGreetingResponseWithAnyDataRecord expectedPayload = {
+        data: {
+            "greet": "Hello, Roland"
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload.toJson(), expectedPayload.toJson());
+}
+
+@test:Config {
+    groups: ["client"]
+}
 isolated function testClientExecuteWithJson() returns error? {
     string url = "http://localhost:9091/inputs";
     string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
@@ -163,6 +182,25 @@ isolated function testClientExecuteWithGenericRecord() returns error? {
     GenericGreetingResponseWithErrors expectedPayload = {
         data: {
             greet: "Hello, Roland"
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload.toJson(), expectedPayload.toJson());
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithAnyDataGenericRecord() returns error? {
+    string url = "http://localhost:9091/inputs";
+    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
+    string userName = "Roland";
+    map<anydata> variables = {"userName": userName};
+
+    Client graphqlClient = check new (url);
+    GenericGreetingResponseWithAnyDataRecordWithErrors actualPayload = check graphqlClient->execute(query, variables);
+    GenericGreetingResponseWithAnyDataRecordWithErrors expectedPayload = {
+        data: {
+            "greet": "Hello, Roland"
         }
     };
     assertJsonValuesWithOrder(actualPayload.toJson(), expectedPayload.toJson());
@@ -272,6 +310,11 @@ type GenericGreetingResponse record {|
     map<json?> data?;
 |};
 
+type GenericGreetingResponseWithAnyDataRecord record {|
+    map<json?> extensions?;
+    record {| anydata...; |} data?;
+|};
+
 type GreetingResponseWithErrors record {|
     map<json?> extensions?;
     record {|
@@ -283,6 +326,12 @@ type GreetingResponseWithErrors record {|
 type GenericGreetingResponseWithErrors record {|
     map<json?> extensions?;
     map<json?> data?;
+    ErrorDetail[] errors?;
+|};
+
+type GenericGreetingResponseWithAnyDataRecordWithErrors record {|
+    map<json?> extensions?;
+    record {| anydata...; |} data?;
     ErrorDetail[] errors?;
 |};
 

--- a/ballerina/tests/client_test.bal
+++ b/ballerina/tests/client_test.bal
@@ -179,24 +179,18 @@ isolated function testClientExecuteWithTypeWithInvalidRequest() returns error? {
 
     Client graphqlClient = check new (url);
     json|ClientError payload = graphqlClient->executeWithType(document, variables);
-    if payload is ClientError {
-        if payload is RequestError {
-            json actualPayload = payload.detail()?.body.toJson();
-            json expectedPayload = {
-                errors: [
-                    {
-                        message: "Cannot query field \"gree\" on type \"Query\".",
-                        locations: [{"line":1,"column":37}]
-                    }
-                ]
-            };
-            assertJsonValuesWithOrder(actualPayload, expectedPayload);
-        } else {
-            test:assertFail("Invalid error type");
-        }
-    } else {
-        test:assertFail("Json response received for an invalid request");
-    }
+    test:assertTrue(payload is RequestError);
+    RequestError err = <RequestError>payload;
+    json actualPayload = err.detail()?.body.toJson();
+    json expectedPayload = {
+        errors: [
+            {
+                message: "Cannot query field \"gree\" on type \"Query\".",
+                locations: [{"line":1,"column":37}]
+            }
+        ]
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
 }
 
 @test:Config {
@@ -210,24 +204,18 @@ isolated function testClientExecuteWithInvalidRequest() returns error? {
 
     Client graphqlClient = check new (url);
     json|ClientError payload = graphqlClient->execute(document, variables);
-    if payload is ClientError {
-        if payload is RequestError {
-            json actualPayload = payload.detail()?.body.toJson();
-            json expectedPayload = {
-                errors: [
-                    {
-                        message: "Cannot query field \"gree\" on type \"Query\".",
-                        locations: [{"line":1,"column":37}]
-                    }
-                ]
-            };
-            assertJsonValuesWithOrder(actualPayload, expectedPayload);
-        } else {
-            test:assertFail("Invalid error type");
-        }
-    } else {
-        test:assertFail("Json response received for an invalid request");
-    }
+    test:assertTrue(payload is RequestError);
+    RequestError err = <RequestError>payload;
+    json actualPayload = err.detail()?.body.toJson();
+    json expectedPayload = {
+        errors: [
+            {
+                message: "Cannot query field \"gree\" on type \"Query\".",
+                locations: [{"line":1,"column":37}]
+            }
+        ]
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
 }
 
 @test:Config {
@@ -240,16 +228,10 @@ isolated function testClientExecuteWithTypeWithInvalidBindingType() returns erro
     map<anydata> variables = {"userName": userName};
 
     Client graphqlClient = check new (url);
-    string|ClientError actualPayload = graphqlClient->executeWithType(document, variables);
-    if actualPayload is ClientError {
-        if actualPayload is RequestError {
-            test:assertEquals(actualPayload.message(), "GraphQL Client Error");
-        } else {
-            test:assertFail("Invalid error type");
-        }
-    } else {
-        test:assertFail("Response received for an invalid binding type request");
-    }
+    string|ClientError payload = graphqlClient->executeWithType(document, variables);
+    test:assertTrue(payload is RequestError);
+    RequestError actualPayload = <RequestError>payload;
+    test:assertEquals(actualPayload.message(), "GraphQL Client Error");
 }
 
 @test:Config {
@@ -261,30 +243,28 @@ isolated function testClientExecuteWithTypeWithPartialDataRequest() returns erro
 
     Client graphqlClient = check new (url);
     json|ClientError payload = graphqlClient->executeWithType(document);
-    if payload is ClientError {
-        if payload is ServerError {
-            json actualPayload = payload.detail().toJson();
-            json expectedPayload = {
-                data: {
-                    specialHolidays: ["TUESDAY", null, "THURSDAY"]
-                },
-                errors: [
+    test:assertTrue(payload is ServerError);
+    ServerError err = <ServerError>payload;
+    json actualPayload = err.detail().toJson();
+    json expectedPayload = {
+        data: {
+            specialHolidays: ["TUESDAY", null, "THURSDAY"]
+        },
+        errors: [
+            {
+                message: "Holiday!",
+                locations: [
                     {
-                        message: "Holiday!",
-                        locations: [
-                            {
-                                line: 1,
-                                column: 9
-                            }
-                        ],
-                        path: ["specialHolidays", 1]
+                        line: 1,
+                        column: 9
                     }
                 ],
-                extensions: null
-            };
-            assertJsonValuesWithOrder(actualPayload, expectedPayload);
-        }
-    }
+                path: ["specialHolidays", 1]
+            }
+        ],
+        extensions: null
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
 }
 
 @test:Config {
@@ -325,24 +305,18 @@ isolated function testClientExecuteWithTypeWithMultipleOperationsWithoutOperatio
 
     Client graphqlClient = check new (url);
     json|ClientError payload = graphqlClient->executeWithType(document);
-    if payload is ClientError {
-        if payload is RequestError {
-            json actualPayload = payload.detail()?.body.toJson();
-            json expectedPayload = {
-                errors: [
-                    {
-                        message: "Must provide operation name if query contains multiple operations.",
-                        locations: []
-                    }
-                ]
-            };
-            assertJsonValuesWithOrder(actualPayload, expectedPayload);
-        } else {
-            test:assertFail("Invalid error type");
-        }
-    } else {
-        test:assertFail("Json response received for a request with multiple operations without operation name");
-    }
+    test:assertTrue(payload is RequestError);
+    RequestError err = <RequestError>payload;
+    json actualPayload = err.detail()?.body.toJson();
+    json expectedPayload = {
+        errors: [
+            {
+                message: "Must provide operation name if query contains multiple operations.",
+                locations: []
+            }
+        ]
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
 }
 
 @test:Config {
@@ -354,24 +328,18 @@ isolated function testClientExecuteWithMultipleOperationsWithoutOperationNameInR
 
     Client graphqlClient = check new (url);
     json|ClientError payload = graphqlClient->execute(document);
-    if payload is ClientError {
-        if payload is RequestError {
-            json actualPayload = payload.detail()?.body.toJson();
-            json expectedPayload = {
-                errors: [
-                    {
-                        message: "Must provide operation name if query contains multiple operations.",
-                        locations: []
-                    }
-                ]
-            };
-            assertJsonValuesWithOrder(actualPayload, expectedPayload);
-        } else {
-            test:assertFail("Invalid error type");
-        }
-    } else {
-        test:assertFail("Json response received for a request with multiple operations without operation name");
-    }
+    test:assertTrue(payload is RequestError);
+    RequestError err = <RequestError>payload;
+    json actualPayload = err.detail()?.body.toJson();
+    json expectedPayload = {
+        errors: [
+            {
+                message: "Must provide operation name if query contains multiple operations.",
+                locations: []
+            }
+        ]
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
 }
 
 @test:Config {

--- a/ballerina/tests/client_test.bal
+++ b/ballerina/tests/client_test.bal
@@ -21,12 +21,12 @@ import ballerina/test;
 }
 isolated function testClientExecuteWithTypeWithJson() returns error? {
     string url = "http://localhost:9091/inputs";
-    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
+    string document = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
     string userName = "Roland";
     map<anydata> variables = {"userName": userName};
 
     Client graphqlClient = check new (url);
-    json actualPayload = check graphqlClient->executeWithType(query, variables);
+    json actualPayload = check graphqlClient->executeWithType(document, variables);
     json expectedPayload = {
         "data": {
             "greet": "Hello, Roland"
@@ -40,12 +40,12 @@ isolated function testClientExecuteWithTypeWithJson() returns error? {
 }
 isolated function testClientExecuteWithTypeWithOpenRecord() returns error? {
     string url = "http://localhost:9091/inputs";
-    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
+    string document = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
     string userName = "Roland";
     map<anydata> variables = {"userName": userName};
 
     Client graphqlClient = check new (url);
-    record{} actualPayload = check graphqlClient->executeWithType(query, variables);
+    record{} actualPayload = check graphqlClient->executeWithType(document, variables);
     record{} expectedPayload = {
         "data": {
             "greet": "Hello, Roland"
@@ -59,12 +59,12 @@ isolated function testClientExecuteWithTypeWithOpenRecord() returns error? {
 }
 isolated function testClientExecuteWithTypeWithKnownRecord() returns error? {
     string url = "http://localhost:9091/inputs";
-    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
+    string document = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
     string userName = "Roland";
     map<anydata> variables = {"userName": userName};
 
     Client graphqlClient = check new (url);
-    GreetingResponse actualPayload = check graphqlClient->executeWithType(query, variables);
+    GreetingResponse actualPayload = check graphqlClient->executeWithType(document, variables);
     GreetingResponse expectedPayload = {
         data: {
             greet: "Hello, Roland"
@@ -78,12 +78,12 @@ isolated function testClientExecuteWithTypeWithKnownRecord() returns error? {
 }
 isolated function testClientExecuteWithTypeWithGenericRecord() returns error? {
     string url = "http://localhost:9091/inputs";
-    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
+    string document = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
     string userName = "Roland";
     map<anydata> variables = {"userName": userName};
 
     Client graphqlClient = check new (url);
-    GenericGreetingResponse actualPayload = check graphqlClient->executeWithType(query, variables);
+    GenericGreetingResponse actualPayload = check graphqlClient->executeWithType(document, variables);
     GenericGreetingResponse expectedPayload = {
         data: {
             greet: "Hello, Roland"
@@ -95,33 +95,14 @@ isolated function testClientExecuteWithTypeWithGenericRecord() returns error? {
 @test:Config {
     groups: ["client"]
 }
-isolated function testClientExecuteWithTypeWithAnyDataGenericRecord() returns error? {
-    string url = "http://localhost:9091/inputs";
-    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
-    string userName = "Roland";
-    map<anydata> variables = {"userName": userName};
-
-    Client graphqlClient = check new (url);
-    GenericGreetingResponseWithAnyDataRecord actualPayload = check graphqlClient->executeWithType(query, variables);
-    GenericGreetingResponseWithAnyDataRecord expectedPayload = {
-        data: {
-            "greet": "Hello, Roland"
-        }
-    };
-    assertJsonValuesWithOrder(actualPayload.toJson(), expectedPayload.toJson());
-}
-
-@test:Config {
-    groups: ["client"]
-}
 isolated function testClientExecuteWithJson() returns error? {
     string url = "http://localhost:9091/inputs";
-    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
+    string document = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
     string userName = "Roland";
     map<anydata> variables = {"userName": userName};
 
     Client graphqlClient = check new (url);
-    json actualPayload = check graphqlClient->execute(query, variables);
+    json actualPayload = check graphqlClient->execute(document, variables);
     json expectedPayload = {
         "data": {
             "greet": "Hello, Roland"
@@ -135,12 +116,12 @@ isolated function testClientExecuteWithJson() returns error? {
 }
 isolated function testClientExecuteWithOpenRecord() returns error? {
     string url = "http://localhost:9091/inputs";
-    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
+    string document = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
     string userName = "Roland";
     map<anydata> variables = {"userName": userName};
 
     Client graphqlClient = check new (url);
-    record{} actualPayload = check graphqlClient->execute(query, variables);
+    record{} actualPayload = check graphqlClient->execute(document, variables);
     record{} expectedPayload = {
         "data": {
             "greet": "Hello, Roland"
@@ -154,12 +135,12 @@ isolated function testClientExecuteWithOpenRecord() returns error? {
 }
 isolated function testClientExecuteWithKnownRecord() returns error? {
     string url = "http://localhost:9091/inputs";
-    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
+    string document = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
     string userName = "Roland";
     map<anydata> variables = {"userName": userName};
 
     Client graphqlClient = check new (url);
-    GreetingResponseWithErrors actualPayload = check graphqlClient->execute(query, variables);
+    GreetingResponseWithErrors actualPayload = check graphqlClient->execute(document, variables);
     GreetingResponseWithErrors expectedPayload = {
         data: {
             greet: "Hello, Roland"
@@ -173,12 +154,12 @@ isolated function testClientExecuteWithKnownRecord() returns error? {
 }
 isolated function testClientExecuteWithGenericRecord() returns error? {
     string url = "http://localhost:9091/inputs";
-    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
+    string document = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
     string userName = "Roland";
     map<anydata> variables = {"userName": userName};
 
     Client graphqlClient = check new (url);
-    GenericGreetingResponseWithErrors actualPayload = check graphqlClient->execute(query, variables);
+    GenericGreetingResponseWithErrors actualPayload = check graphqlClient->execute(document, variables);
     GenericGreetingResponseWithErrors expectedPayload = {
         data: {
             greet: "Hello, Roland"
@@ -190,37 +171,31 @@ isolated function testClientExecuteWithGenericRecord() returns error? {
 @test:Config {
     groups: ["client"]
 }
-isolated function testClientExecuteWithAnyDataGenericRecord() returns error? {
-    string url = "http://localhost:9091/inputs";
-    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
-    string userName = "Roland";
-    map<anydata> variables = {"userName": userName};
-
-    Client graphqlClient = check new (url);
-    GenericGreetingResponseWithAnyDataRecordWithErrors actualPayload = check graphqlClient->execute(query, variables);
-    GenericGreetingResponseWithAnyDataRecordWithErrors expectedPayload = {
-        data: {
-            "greet": "Hello, Roland"
-        }
-    };
-    assertJsonValuesWithOrder(actualPayload.toJson(), expectedPayload.toJson());
-}
-
-@test:Config {
-    groups: ["client"]
-}
 isolated function testClientExecuteWithTypeWithInvalidRequest() returns error? {
     string url = "http://localhost:9091/inputs";
-    string query = string `query Greeting ($userName:String!){ gree (name: $userName) }`;
+    string document = string `query Greeting ($userName:String!){ gree (name: $userName) }`;
     string userName = "Roland";
     map<anydata> variables = {"userName": userName};
 
     Client graphqlClient = check new (url);
-    json|ClientError actualPayload = graphqlClient->executeWithType(query, variables);
-    if actualPayload is ClientError {
-        if actualPayload is RequestError {
-            test:assertEquals(actualPayload.message(), "GraphQL Client Error");
+    json|ClientError payload = graphqlClient->executeWithType(document, variables);
+    if payload is ClientError {
+        if payload is RequestError {
+            json actualPayload = payload.detail()?.body.toJson();
+            json expectedPayload = {
+                errors: [
+                    {
+                        message: "Cannot query field \"gree\" on type \"Query\".",
+                        locations: [{"line":1,"column":37}]
+                    }
+                ]
+            };
+            assertJsonValuesWithOrder(actualPayload, expectedPayload);
+        } else {
+            test:assertFail("Invalid error type");
         }
+    } else {
+        test:assertFail("Json response received for an invalid request");
     }
 }
 
@@ -229,16 +204,29 @@ isolated function testClientExecuteWithTypeWithInvalidRequest() returns error? {
 }
 isolated function testClientExecuteWithInvalidRequest() returns error? {
     string url = "http://localhost:9091/inputs";
-    string query = string `query Greeting ($userName:String!){ gree (name: $userName) }`;
+    string document = string `query Greeting ($userName:String!){ gree (name: $userName) }`;
     string userName = "Roland";
     map<anydata> variables = {"userName": userName};
 
     Client graphqlClient = check new (url);
-    json|ClientError actualPayload = graphqlClient->execute(query, variables);
-    if actualPayload is ClientError {
-        if actualPayload is RequestError {
-            test:assertEquals(actualPayload.message(), "GraphQL Client Error");
+    json|ClientError payload = graphqlClient->execute(document, variables);
+    if payload is ClientError {
+        if payload is RequestError {
+            json actualPayload = payload.detail()?.body.toJson();
+            json expectedPayload = {
+                errors: [
+                    {
+                        message: "Cannot query field \"gree\" on type \"Query\".",
+                        locations: [{"line":1,"column":37}]
+                    }
+                ]
+            };
+            assertJsonValuesWithOrder(actualPayload, expectedPayload);
+        } else {
+            test:assertFail("Invalid error type");
         }
+    } else {
+        test:assertFail("Json response received for an invalid request");
     }
 }
 
@@ -247,15 +235,54 @@ isolated function testClientExecuteWithInvalidRequest() returns error? {
 }
 isolated function testClientExecuteWithTypeWithInvalidBindingType() returns error? {
     string url = "http://localhost:9091/inputs";
-    string query = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
+    string document = string `query Greeting ($userName:String!){ greet (name: $userName) }`;
     string userName = "Roland";
     map<anydata> variables = {"userName": userName};
 
     Client graphqlClient = check new (url);
-    string|ClientError actualPayload = graphqlClient->executeWithType(query, variables);
+    string|ClientError actualPayload = graphqlClient->executeWithType(document, variables);
     if actualPayload is ClientError {
         if actualPayload is RequestError {
             test:assertEquals(actualPayload.message(), "GraphQL Client Error");
+        } else {
+            test:assertFail("Invalid error type");
+        }
+    } else {
+        test:assertFail("Response received for an invalid binding type request");
+    }
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithTypeWithPartialDataRequest() returns error? {
+    string url = "http://localhost:9095/special_types";
+    string document = string `query { specialHolidays }`;
+
+    Client graphqlClient = check new (url);
+    json|ClientError payload = graphqlClient->executeWithType(document);
+    if payload is ClientError {
+        if payload is ServerError {
+            json actualPayload = payload.detail().toJson();
+            json expectedPayload = {
+                data: {
+                    specialHolidays: ["TUESDAY", null, "THURSDAY"]
+                },
+                errors: [
+                    {
+                        message: "Holiday!",
+                        locations: [
+                            {
+                                line: 1,
+                                column: 9
+                            }
+                        ],
+                        path: ["specialHolidays", 1]
+                    }
+                ],
+                extensions: null
+            };
+            assertJsonValuesWithOrder(actualPayload, expectedPayload);
         }
     }
 }
@@ -263,12 +290,125 @@ isolated function testClientExecuteWithTypeWithInvalidBindingType() returns erro
 @test:Config {
     groups: ["client"]
 }
-isolated function testClientExecuteWithTypeWithMutation() returns error? {
-    string url = "http://localhost:9091/mutations";
-    string query = string `mutation { setName(name: "Heisenberg") { name } }`;
+isolated function testClientExecuteWithPartialDataRequest() returns error? {
+    string url = "http://localhost:9095/special_types";
+    string document = string `query { specialHolidays }`;
 
     Client graphqlClient = check new (url);
-    SetNameResponse actualPayload = check graphqlClient->executeWithType(query);
+    json actualPayload = check graphqlClient->execute(document);
+    json expectedPayload = {
+        errors: [
+            {
+                message: "Holiday!",
+                locations: [
+                    {
+                        line: 1,
+                        column: 9
+                    }
+                ],
+                path: ["specialHolidays", 1]
+            }
+        ],
+        data: {
+            specialHolidays: ["TUESDAY", null, "THURSDAY"]
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithTypeWithMultipleOperationsWithoutOperationNameInRequest() returns error? {
+    string url = "http://localhost:9091/validation";
+    string document = check getGraphQLDocumentFromFile("multiple_operations_without_operation_name_in_request.graphql");
+
+    Client graphqlClient = check new (url);
+    json|ClientError payload = graphqlClient->executeWithType(document);
+    if payload is ClientError {
+        if payload is RequestError {
+            json actualPayload = payload.detail()?.body.toJson();
+            json expectedPayload = {
+                errors: [
+                    {
+                        message: "Must provide operation name if query contains multiple operations.",
+                        locations: []
+                    }
+                ]
+            };
+            assertJsonValuesWithOrder(actualPayload, expectedPayload);
+        } else {
+            test:assertFail("Invalid error type");
+        }
+    } else {
+        test:assertFail("Json response received for a request with multiple operations without operation name");
+    }
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithMultipleOperationsWithoutOperationNameInRequest() returns error? {
+    string url = "http://localhost:9091/validation";
+    string document = check getGraphQLDocumentFromFile("multiple_operations_without_operation_name_in_request.graphql");
+
+    Client graphqlClient = check new (url);
+    json|ClientError payload = graphqlClient->execute(document);
+    if payload is ClientError {
+        if payload is RequestError {
+            json actualPayload = payload.detail()?.body.toJson();
+            json expectedPayload = {
+                errors: [
+                    {
+                        message: "Must provide operation name if query contains multiple operations.",
+                        locations: []
+                    }
+                ]
+            };
+            assertJsonValuesWithOrder(actualPayload, expectedPayload);
+        } else {
+            test:assertFail("Invalid error type");
+        }
+    } else {
+        test:assertFail("Json response received for a request with multiple operations without operation name");
+    }
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithTypeWithMultipleOperationsWithOperationNameInRequest() returns error? {
+    string url = "http://localhost:9091/validation";
+    string document = check getGraphQLDocumentFromFile("multiple_operations_without_operation_name_in_request.graphql");
+
+    Client graphqlClient = check new (url);
+    json actualPayload = check graphqlClient->executeWithType(document, operationName = "getName");
+    json expectedPayload = {"data":{"name":"James Moriarty"}};
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithMultipleOperationsWithOperationNameInRequest() returns error? {
+    string url = "http://localhost:9091/validation";
+    string document = check getGraphQLDocumentFromFile("multiple_operations_without_operation_name_in_request.graphql");
+
+    Client graphqlClient = check new (url);
+    json actualPayload = check graphqlClient->execute(document, operationName = "getName");
+    json expectedPayload = {"data":{"name":"James Moriarty"}};
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithTypeWithMutation() returns error? {
+    string url = "http://localhost:9091/mutations";
+    string document = string `mutation { setName(name: "Heisenberg") { name } }`;
+
+    Client graphqlClient = check new (url);
+    SetNameResponse actualPayload = check graphqlClient->executeWithType(document);
     SetNameResponse expectedPayload = {
         data: {
             setName: {
@@ -284,15 +424,291 @@ isolated function testClientExecuteWithTypeWithMutation() returns error? {
 }
 isolated function testClientExecuteWithMutation() returns error? {
     string url = "http://localhost:9091/mutations";
-    string query = string `mutation { setName(name: "Heisenberg") { name } }`;
+    string document = string `mutation { setName(name: "Heisenberg") { name } }`;
 
     Client graphqlClient = check new (url);
-    SetNameResponseWithErrors actualPayload = check graphqlClient->execute(query);
+    SetNameResponseWithErrors actualPayload = check graphqlClient->execute(document);
     SetNameResponseWithErrors expectedPayload = {
         data: {
             setName: {
                 name: "Heisenberg"
             }
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload.toJson(), expectedPayload.toJson());
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithTypeWithAlias() returns error? {
+    string url = "http://localhost:9091/duplicates";
+    string document = check getGraphQLDocumentFromFile("alias.graphql");
+
+    Client graphqlClient = check new (url);
+    json actualPayload = check graphqlClient->executeWithType(document);
+    json expectedPayload = {
+        data: {
+            sherlock: {
+                name: "Sherlock Holmes",
+                address: {
+                    city: "London"
+                }
+            }
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithAlias() returns error? {
+    string url = "http://localhost:9091/duplicates";
+    string document = check getGraphQLDocumentFromFile("alias.graphql");
+
+    Client graphqlClient = check new (url);
+    json actualPayload = check graphqlClient->execute(document);
+    json expectedPayload = {
+        data: {
+            sherlock: {
+                name: "Sherlock Holmes",
+                address: {
+                    city: "London"
+                }
+            }
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithTypeWithEnum() returns error? {
+    string url = "http://localhost:9095/special_types";
+    string document = "query { time { weekday } }";
+    
+    Client graphqlClient = check new (url);
+    json actualPayload = check graphqlClient->executeWithType(document);
+    json expectedPayload = {
+        data: {
+            time: {
+                weekday: "MONDAY"
+            }
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithEnum() returns error? {
+    string url = "http://localhost:9095/special_types";
+    string document = "query { time { weekday } }";
+    
+    Client graphqlClient = check new (url);
+    json actualPayload = check graphqlClient->execute(document);
+    json expectedPayload = {
+        data: {
+            time: {
+                weekday: "MONDAY"
+            }
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithTypeWithFragmentsOnRecordObjects() returns error? {
+    string url = "http://localhost:9091/records";
+    string document = check getGraphQLDocumentFromFile("fragments_on_record_objects.graphql");
+    
+    Client graphqlClient = check new (url);
+    json actualPayload = check graphqlClient->executeWithType(document);
+    json expectedPayload = check getJsonContentFromFile("fragments_on_record_objects.json");
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithFragmentsOnRecordObjects() returns error? {
+    string url = "http://localhost:9091/records";
+    string document = check getGraphQLDocumentFromFile("fragments_on_record_objects.graphql");
+    
+    Client graphqlClient = check new (url);
+    json actualPayload = check graphqlClient->execute(document);
+    json expectedPayload = check getJsonContentFromFile("fragments_on_record_objects.json");
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithTypeWithNestedFragments() returns error? {
+    string url = "http://localhost:9091/records";
+    string document = check getGraphQLDocumentFromFile("nested_fragments.graphql");
+
+    Client graphqlClient = check new (url);
+    json actualPayload = check graphqlClient->executeWithType(document);
+    json expectedPayload = check getJsonContentFromFile("nested_fragments.json");
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithNestedFragments() returns error? {
+    string url = "http://localhost:9091/records";
+    string document = check getGraphQLDocumentFromFile("nested_fragments.graphql");
+
+    Client graphqlClient = check new (url);
+    json actualPayload = check graphqlClient->execute(document);
+    json expectedPayload = check getJsonContentFromFile("nested_fragments.json");
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithTypeWithInlineFragment() returns error? {
+    string url = "http://localhost:9091/records";
+    string document = check getGraphQLDocumentFromFile("inline_fragment.graphql");
+
+    Client graphqlClient = check new (url);
+    json actualPayload = check graphqlClient->executeWithType(document);
+    json expectedPayload = check getJsonContentFromFile("inline_fragment.json");
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithInlineFragment() returns error? {
+    string url = "http://localhost:9091/records";
+    string document = check getGraphQLDocumentFromFile("inline_fragment.graphql");
+
+    Client graphqlClient = check new (url);
+    json actualPayload = check graphqlClient->execute(document);
+    json expectedPayload = check getJsonContentFromFile("inline_fragment.json");
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithTypeWithBallerinaRecordAsGraphqlObject() returns error? {
+    string url = "http://localhost:9091/records";
+    string document = "query getPerson { detective { name, address { street } } }";
+    
+    Client graphqlClient = check new (url);
+    PersonResponse actualPayload = check graphqlClient->executeWithType(document);
+    PersonResponse expectedPayload = {
+        data: {
+            detective: {
+                name: "Sherlock Holmes",
+                address: {
+                    street: "Baker Street"
+                }
+            }
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload.toJson(), expectedPayload.toJson());
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithBallerinaRecordAsGraphqlObject() returns error? {
+    string url = "http://localhost:9091/records";
+    string document = "query getPerson { detective { name, address { street } } }";
+    
+    Client graphqlClient = check new (url);
+    PersonResponseWithErrors actualPayload = check graphqlClient->execute(document);
+    PersonResponseWithErrors expectedPayload = {
+        data: {
+            detective: {
+                name: "Sherlock Holmes",
+                address: {
+                    street: "Baker Street"
+                }
+            }
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload.toJson(), expectedPayload.toJson());
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithTypeWithRecordTypeArrays() returns error? {
+    string document = "{ people { name address { city } } }";
+    string url = "http://localhost:9091/records";
+    
+    Client graphqlClient = check new (url);
+    PeopleResponse actualPayload = check graphqlClient->executeWithType(document);
+    PeopleResponse expectedPayload = {
+        data: {
+            people: [
+                {
+                    name: "Sherlock Holmes",
+                    address: {
+                        city: "London"
+                    }
+                },
+                {
+                    name: "Walter White",
+                    address: {
+                        city: "Albuquerque"
+                    }
+                },
+                {
+                    name: "Tom Marvolo Riddle",
+                    address: {
+                        city: "Hogwarts"
+                    }
+                }
+            ]
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload.toJson(), expectedPayload.toJson());
+}
+
+@test:Config {
+    groups: ["client"]
+}
+isolated function testClientExecuteWithRecordTypeArrays() returns error? {
+    string document = "{ people { name address { city } } }";
+    string url = "http://localhost:9091/records";
+    
+    Client graphqlClient = check new (url);
+    PeopleResponseWithErrors actualPayload = check graphqlClient->executeWithType(document);
+    PeopleResponseWithErrors expectedPayload = {
+        data: {
+            people: [
+                {
+                    name: "Sherlock Holmes",
+                    address: {
+                        city: "London"
+                    }
+                },
+                {
+                    name: "Walter White",
+                    address: {
+                        city: "Albuquerque"
+                    }
+                },
+                {
+                    name: "Tom Marvolo Riddle",
+                    address: {
+                        city: "Hogwarts"
+                    }
+                }
+            ]
         }
     };
     assertJsonValuesWithOrder(actualPayload.toJson(), expectedPayload.toJson());
@@ -310,11 +726,6 @@ type GenericGreetingResponse record {|
     map<json?> data?;
 |};
 
-type GenericGreetingResponseWithAnyDataRecord record {|
-    map<json?> extensions?;
-    record {| anydata...; |} data?;
-|};
-
 type GreetingResponseWithErrors record {|
     map<json?> extensions?;
     record {|
@@ -326,12 +737,6 @@ type GreetingResponseWithErrors record {|
 type GenericGreetingResponseWithErrors record {|
     map<json?> extensions?;
     map<json?> data?;
-    ErrorDetail[] errors?;
-|};
-
-type GenericGreetingResponseWithAnyDataRecordWithErrors record {|
-    map<json?> extensions?;
-    record {| anydata...; |} data?;
     ErrorDetail[] errors?;
 |};
 
@@ -352,4 +757,52 @@ type SetNameResponseWithErrors record {|
         |} setName;
     |} data;
     ErrorDetail[] errors?;
+|};
+
+type PersonResponse record {|
+    map<json?> extensions?;
+    PersonDataResponse data;
+|};
+
+type PersonResponseWithErrors record {|
+    map<json?> extensions?;
+    PersonDataResponse data;
+    ErrorDetail[] errors?;
+|};
+
+type PersonDataResponse record {|
+    DetectiveResponse detective;
+|};
+
+type DetectiveResponse record {|
+    string name;
+    AddressResponse address;
+|};
+
+type AddressResponse record {|
+    string street;
+|};
+
+type PeopleResponse record {|
+    map<json?> extensions?;
+    PeopleDataResponse data;
+|};
+
+type PeopleResponseWithErrors record {|
+    map<json?> extensions?;
+    PeopleDataResponse data;
+    ErrorDetail[] errors?;
+|};
+
+type PeopleDataResponse record {|
+    PersonInfoResponse[] people;
+|};
+
+type PersonInfoResponse record {|
+    string name;
+    AddressInfoResponse address;
+|};
+
+type AddressInfoResponse record {|
+    string city;
 |};

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -56,3 +56,25 @@ public type CorsConfig record {|
 isolated service class HttpService {
     *http:Service;
 }
+
+// GraphQL client related data binding types representation
+
+# Represents the target type binding record with data and extensions of a GraphQL response for `executeWithType` method.
+#
+# + extensions -  Meta information of the GraphQL API call
+# + data -  Data information of the GraphQL API call
+public type GenericResponse record {|
+   map<json?> extensions?;
+   record {| anydata...; |}|map<json?> data?;
+|};
+
+# Represents the target type binding record with data, extensions and errors of a GraphQL response for `execute` method.
+#
+# + extensions - Meta information of the GraphQL API call  
+# + data - Data information of the GraphQL API call
+# + errors - Error information of the GraphQL API call
+public type GenericResponseWithErrors record {|
+   map<json?> extensions?;
+   record {| anydata...; |}|map<json?> data?;
+   ErrorDetail[] errors?;
+|};

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -61,8 +61,8 @@ isolated service class HttpService {
 
 # Represents the target type binding record with data and extensions of a GraphQL response for `executeWithType` method.
 #
-# + extensions -  Meta information of the GraphQL API call
-# + data -  Data information of the GraphQL API call
+# + extensions -  Meta information on protocol extensions from the GraphQL server
+# + data -  The requested data from the GraphQL server
 public type GenericResponse record {|
    map<json?> extensions?;
    record {| anydata...; |}|map<json?> data?;
@@ -70,9 +70,9 @@ public type GenericResponse record {|
 
 # Represents the target type binding record with data, extensions and errors of a GraphQL response for `execute` method.
 #
-# + extensions - Meta information of the GraphQL API call  
-# + data - Data information of the GraphQL API call
-# + errors - Error information of the GraphQL API call
+# + extensions - Meta information on protocol extensions from the GraphQL server
+# + data - The requested data from the GraphQL server
+# + errors - The errors occurred (if present) while processing the GraphQL request.
 public type GenericResponseWithErrors record {|
    map<json?> extensions?;
    record {| anydata...; |}|map<json?> data?;

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/client/QueryExecutor.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/client/QueryExecutor.java
@@ -35,30 +35,35 @@ public class QueryExecutor {
     /**
     * Executes the GraphQL document when the corresponding Ballerina remote operation is invoked.
     */
-    public static Object execute(Environment env, BObject client, BString document, Object variables, Object headers,
-                                 BTypedesc targetType) {
-        return invokeClientMethod(env, client, document, variables, headers, targetType, "processExecute");
+    public static Object execute(Environment env, BObject client, BString document, Object variables,
+                                 Object operationName, Object headers, BTypedesc targetType) {
+        return invokeClientMethod(env, client, document, variables, operationName, headers, targetType,
+                "processExecute");
     }
 
     /**
     * Executes the GraphQL document when the corresponding Ballerina remote operation is invoked.
     */
-    public static Object executeWithType(Environment env, BObject client, BString document, Object variables, 
-                                         Object headers, BTypedesc targetType) {
-        return invokeClientMethod(env, client, document, variables, headers, targetType, "processExecuteWithType");
+    public static Object executeWithType(Environment env, BObject client, BString document, Object variables,
+                                         Object operationName, Object headers, BTypedesc targetType) {
+        return invokeClientMethod(env, client, document, variables, operationName, headers, targetType,
+                "processExecuteWithType");
     }
 
-    private static Object invokeClientMethod(Environment env, BObject client, BString document, Object variables, 
-                                             Object headers, BTypedesc targetType, String methodName) {
-        Object[] paramFeed = new Object[8];
+    private static Object invokeClientMethod(Environment env, BObject client, BString document, Object variables,
+                                             Object operationName, Object headers, BTypedesc targetType,
+                                             String methodName) {
+        Object[] paramFeed = new Object[10];
         paramFeed[0] = targetType;
         paramFeed[1] = true;
         paramFeed[2] = document;
         paramFeed[3] = true;
         paramFeed[4] = variables;
         paramFeed[5] = true;
-        paramFeed[6] = headers;
+        paramFeed[6] = operationName;
         paramFeed[7] = true;
+        paramFeed[8] = headers;
+        paramFeed[9] = true;
         return invokeClientMethod(env, client, methodName, paramFeed);
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/client/QueryExecutor.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/client/QueryExecutor.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.graphql.runtime.client;
+
+import io.ballerina.runtime.api.Environment;
+import io.ballerina.runtime.api.Future;
+import io.ballerina.runtime.api.PredefinedTypes;
+import io.ballerina.runtime.api.async.Callback;
+import io.ballerina.runtime.api.values.BError;
+import io.ballerina.runtime.api.values.BObject;
+import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
+
+/**
+ * This class is used to execute a GraphQL query using the Ballerina GraphQL client.
+ */
+public class QueryExecutor {
+
+    /**
+    * Executes the GraphQL query when the corresponding Ballerina remote operation is invoked.
+    */
+    public static Object execute(Environment env, BObject client, BString query, Object variables, Object headers,
+                                 BTypedesc targetType) {
+        return invokeClientMethod(env, client, query, variables, headers, targetType, "processExecute");
+    }
+
+    /**
+    * Executes the GraphQL query when the corresponding Ballerina remote operation is invoked.
+    */
+    public static Object executeWithType(Environment env, BObject client, BString query, Object variables, 
+                                         Object headers, BTypedesc targetType) {
+        return invokeClientMethod(env, client, query, variables, headers, targetType, "processExecuteWithType");
+    }
+
+    private static Object invokeClientMethod(Environment env, BObject client, BString query, Object variables, 
+                                             Object headers, BTypedesc targetType, String methodName) {
+        Object[] paramFeed = new Object[8];
+        paramFeed[0] = targetType;
+        paramFeed[1] = true;
+        paramFeed[2] = query;
+        paramFeed[3] = true;
+        paramFeed[4] = variables;
+        paramFeed[5] = true;
+        paramFeed[6] = headers;
+        paramFeed[7] = true;
+        return invokeClientMethod(env, client, methodName, paramFeed);
+    }
+
+    private static Object invokeClientMethod(Environment env, BObject client, String methodName, Object[] paramFeed) {
+        Future balFuture = env.markAsync();
+
+        if (client.getType().isIsolated() && client.getType().isIsolated(methodName)) {
+            env.getRuntime().invokeMethodAsyncConcurrently(client, methodName,
+                    null, null, new Callback() {
+                @Override
+                public void notifySuccess(Object result) {
+                    balFuture.complete(result);
+                }
+
+                @Override
+                public void notifyFailure(BError bError) {
+                    balFuture.complete(bError);
+                }
+            }, null, PredefinedTypes.TYPE_NULL, paramFeed);
+        } else {
+            env.getRuntime().invokeMethodAsyncSequentially(client, methodName,
+                    null, null, new Callback() {
+                @Override
+                public void notifySuccess(Object result) {
+                    balFuture.complete(result);
+                }
+
+                @Override
+                public void notifyFailure(BError bError) {
+                    balFuture.complete(bError);
+                }
+            }, null, PredefinedTypes.TYPE_NULL, paramFeed);
+        }
+        return null;
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/client/QueryExecutor.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/client/QueryExecutor.java
@@ -28,32 +28,32 @@ import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.api.values.BTypedesc;
 
 /**
- * This class is used to execute a GraphQL query using the Ballerina GraphQL client.
+ * This class is used to execute a GraphQL document using the Ballerina GraphQL client.
  */
 public class QueryExecutor {
 
     /**
-    * Executes the GraphQL query when the corresponding Ballerina remote operation is invoked.
+    * Executes the GraphQL document when the corresponding Ballerina remote operation is invoked.
     */
-    public static Object execute(Environment env, BObject client, BString query, Object variables, Object headers,
+    public static Object execute(Environment env, BObject client, BString document, Object variables, Object headers,
                                  BTypedesc targetType) {
-        return invokeClientMethod(env, client, query, variables, headers, targetType, "processExecute");
+        return invokeClientMethod(env, client, document, variables, headers, targetType, "processExecute");
     }
 
     /**
-    * Executes the GraphQL query when the corresponding Ballerina remote operation is invoked.
+    * Executes the GraphQL document when the corresponding Ballerina remote operation is invoked.
     */
-    public static Object executeWithType(Environment env, BObject client, BString query, Object variables, 
+    public static Object executeWithType(Environment env, BObject client, BString document, Object variables, 
                                          Object headers, BTypedesc targetType) {
-        return invokeClientMethod(env, client, query, variables, headers, targetType, "processExecuteWithType");
+        return invokeClientMethod(env, client, document, variables, headers, targetType, "processExecuteWithType");
     }
 
-    private static Object invokeClientMethod(Environment env, BObject client, BString query, Object variables, 
+    private static Object invokeClientMethod(Environment env, BObject client, BString document, Object variables, 
                                              Object headers, BTypedesc targetType, String methodName) {
         Object[] paramFeed = new Object[8];
         paramFeed[0] = targetType;
         paramFeed[1] = true;
-        paramFeed[2] = query;
+        paramFeed[2] = document;
         paramFeed[3] = true;
         paramFeed[4] = variables;
         paramFeed[5] = true;


### PR DESCRIPTION
## Purpose

Add the generic GraphQL client implementation.

The client supports 2 remote operations.
- executeWithType (Executes a GraphQL query and data binds the GraphQL response to a record with data and extensions. The errors of the GraphQL response are directed in the Ballerina error path.)
  For example
  ```
  type GenericResponse record {|
      map<json?> extensions?;
      record {| anydata...; |}|map<json?> data?;
  |};
  ```
- execute (Executes a GraphQL query and data binds the GraphQL response to a record with data, extensions and errors. The errors of the GraphQL response are directed in the Ballerina target type data binding path.)
  For example
  ```
  type GraphQLGenericResponse record {|
      map<json?> extensions?;
      record {| anydata...; |}|map<json?> data?;
      GraphQLError[] errors?;
  |};
  ```

Fixes: https://github.com/ballerina-platform/graphql-tools/issues/28

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
