### PR TITLE
Fix Escape Character Issues

### DIFF
--- a/ballerina-tests/tests/04_input_parameters.bal
+++ b/ballerina-tests/tests/04_input_parameters.bal
@@ -267,3 +267,18 @@ isolated function testOptionalEnumArgumentWithValue() returns error? {
     };
     assertJsonValuesWithOrder(actualPayload, expectedPayload);
 }
+
+@test:Config {
+    groups: ["inputs", "escape_characters"]
+}
+isolated function testInputsWithEscapeCharacters() returns error? {
+    string url = "http://localhost:9091/inputs";
+    string document = string`{ version(version: "1.0.0") }`;
+    json actualPayload = check getJsonPayloadFromService(url, document);
+    json expectedPayload = {
+        data: {
+            'version: "1.0.0"
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}

--- a/ballerina-tests/tests/04_input_parameters.bal
+++ b/ballerina-tests/tests/04_input_parameters.bal
@@ -273,11 +273,26 @@ isolated function testOptionalEnumArgumentWithValue() returns error? {
 }
 isolated function testInputsWithEscapeCharacters() returns error? {
     string url = "http://localhost:9091/inputs";
-    string document = string`{ version(version: "1.0.0") }`;
+    string document = string`{ type(version: "1.0.0") }`;
     json actualPayload = check getJsonPayloadFromService(url, document);
     json expectedPayload = {
         data: {
-            'version: "1.0.0"
+            'type: "1.0.0"
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["inputs", "escape_characters"]
+}
+isolated function testInputsWithUnicodeCharacters() returns error? {
+    string url = "http://localhost:9091/inputs";
+    string document = string`{ version(name: "SwanLake") }`;
+    json actualPayload = check getJsonPayloadFromService(url, document);
+    json expectedPayload = {
+        data: {
+            'version: "SwanLake"
         }
     };
     assertJsonValuesWithOrder(actualPayload, expectedPayload);

--- a/ballerina-tests/tests/04_input_parameters.bal
+++ b/ballerina-tests/tests/04_input_parameters.bal
@@ -273,7 +273,7 @@ isolated function testOptionalEnumArgumentWithValue() returns error? {
 }
 isolated function testInputsWithEscapeCharacters() returns error? {
     string url = "http://localhost:9091/inputs";
-    string document = string`{ type(version: "1.0.0") }`;
+    string document = string `{ type(version: "1.0.0") }`;
     json actualPayload = check getJsonPayloadFromService(url, document);
     json expectedPayload = {
         data: {
@@ -288,7 +288,7 @@ isolated function testInputsWithEscapeCharacters() returns error? {
 }
 isolated function testInputsWithUnicodeCharacters() returns error? {
     string url = "http://localhost:9091/inputs";
-    string document = string`{ version(name: "SwanLake") }`;
+    string document = string `{ version(name: "SwanLake") }`;
     json actualPayload = check getJsonPayloadFromService(url, document);
     json expectedPayload = {
         data: {

--- a/ballerina-tests/tests/records.bal
+++ b/ballerina-tests/tests/records.bal
@@ -207,16 +207,16 @@ public type Shape record {
 # Represents an instrument
 #
 # + name - Name of the instrument
-# + instrumentType - The type of the musical instrument
+# + type - The type of the musical instrument
 public type Instrument readonly & record {
     string name;
-    InstrumentType instrumentType;
+    InstrumentType 'type;
 };
 
 # Represents the types of musical instruments.
 public enum InstrumentType {
     # Instruments with strings
-    STRINGS,
+    STRINGS = "Strings Instruments",
     # Instruments with wooden pipes
     WOODWIND,
     # Instruments with keyboards

--- a/ballerina-tests/tests/resources/expected_results/deprecated_fields_filtering.json
+++ b/ballerina-tests/tests/resources/expected_results/deprecated_fields_filtering.json
@@ -49,7 +49,7 @@
                                         "deprecationReason": null
                                     },
                                     {
-                                        "name": "instrumentType",
+                                        "name": "type",
                                         "isDeprecated": false,
                                         "deprecationReason": null
                                     }

--- a/ballerina-tests/tests/resources/expected_results/deprecated_fields_filtering_with_variables.json
+++ b/ballerina-tests/tests/resources/expected_results/deprecated_fields_filtering_with_variables.json
@@ -49,7 +49,7 @@
                                         "deprecationReason": null
                                     },
                                     {
-                                        "name": "instrumentType",
+                                        "name": "type",
                                         "isDeprecated": false,
                                         "deprecationReason": null
                                     }

--- a/ballerina-tests/tests/resources/expected_results/deprecated_fields_introspection.json
+++ b/ballerina-tests/tests/resources/expected_results/deprecated_fields_introspection.json
@@ -65,7 +65,7 @@
                                         "deprecationReason": null
                                     },
                                     {
-                                        "name": "instrumentType",
+                                        "name": "type",
                                         "isDeprecated": false,
                                         "deprecationReason": null
                                     }
@@ -87,7 +87,7 @@
                                         "deprecationReason": null
                                     },
                                     {
-                                        "name": "instrumentType",
+                                        "name": "type",
                                         "isDeprecated": false,
                                         "deprecationReason": null
                                     }

--- a/ballerina-tests/tests/resources/expected_results/deprecated_fields_introspection_with_variables.json
+++ b/ballerina-tests/tests/resources/expected_results/deprecated_fields_introspection_with_variables.json
@@ -65,7 +65,7 @@
                                         "deprecationReason": null
                                     },
                                     {
-                                        "name": "instrumentType",
+                                        "name": "type",
                                         "isDeprecated": false,
                                         "deprecationReason": null
                                     }
@@ -87,7 +87,7 @@
                                         "deprecationReason": null
                                     },
                                     {
-                                        "name": "instrumentType",
+                                        "name": "type",
                                         "isDeprecated": false,
                                         "deprecationReason": null
                                     }

--- a/ballerina-tests/tests/resources/expected_results/documentation.json
+++ b/ballerina-tests/tests/resources/expected_results/documentation.json
@@ -40,7 +40,7 @@
                                         "description": "Name of the instrument"
                                     },
                                     {
-                                        "name": "instrumentType",
+                                        "name": "type",
                                         "description": "The type of the musical instrument"
                                     }
                                 ]

--- a/ballerina-tests/tests/test_services.bal
+++ b/ballerina-tests/tests/test_services.bal
@@ -262,6 +262,10 @@ service /inputs on basicListener {
     isolated resource function get sendEmail(string message) returns string {
         return message;
     }
+
+    isolated resource function get 'version(string 'version) returns string {
+        return 'version;
+    }
 }
 
 service /decimal_inputs on basicListener {
@@ -1318,7 +1322,7 @@ service /documentation on basicListener {
     isolated resource function get instrument() returns Instrument {
         return {
             name: "Guitar",
-            instrumentType: STRINGS
+            'type: STRINGS
         };
     }
 
@@ -1362,22 +1366,22 @@ service /deprecation on wrappedListener {
     # Creates a new instrument.
     #
     # + name - Name of the instrument
-    # + instrumentType - Type of the instrument
+    # + 'type - Type of the instrument
     # + return - The newly created instrument
     # # Deprecated
     # Use the `addInstrument` field instead of this.
     @deprecated
-    remote function newInstrument(string name, InstrumentType instrumentType) returns Instrument {
-        return {name: name, instrumentType: instrumentType};
+    remote function newInstrument(string name, InstrumentType 'type) returns Instrument {
+        return {name: name, 'type: 'type};
     }
 
     # Adds a new instrument to the database.
     #
     # + name - Name of the instrument
-    # + instrumentType - Type of the instrument
+    # + 'type - Type of the instrument
     # + return - The newly added instrument
-    remote function addInstrument(string name, InstrumentType instrumentType) returns Instrument {
-        return {name: name, instrumentType: instrumentType};
+    remote function addInstrument(string name, InstrumentType 'type) returns Instrument {
+        return {name: name, 'type: 'type};
     }
 
     # Subscribes to the new instruments.

--- a/ballerina-tests/tests/test_services.bal
+++ b/ballerina-tests/tests/test_services.bal
@@ -263,8 +263,12 @@ service /inputs on basicListener {
         return message;
     }
 
-    isolated resource function get 'version(string 'version) returns string {
+    isolated resource function get 'type(string 'version) returns string {
         return 'version;
+    }
+
+    isolated resource function get \u{0076}ersion(string name) returns string {
+        return name;
     }
 }
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [[#2898] Support Deprecation Support in GraphQL Services](https://github.com/ballerina-platform/ballerina-standard-library/issues/2898)
 - [[#2001] Support GraphQL Interceptors for Query and Mutation operations](https://github.com/ballerina-platform/ballerina-standard-library/issues/2001)
 
+### Fixed
+- [[#3069] Fix Enums with String Values Return String Value for Enum Name](https://github.com/ballerina-platform/ballerina-standard-library/issues/3069)
+- [[#3067] Fix Single Quote Character Included in Field and Argument Names](https://github.com/ballerina-platform/ballerina-standard-library/issues/3067)
+
 ## [1.3.2] - 2022-07-11
 
 ### Fixed

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/generator_tests/02_record_types/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/generator_tests/02_record_types/service.bal
@@ -32,10 +32,12 @@ type Person record {
 # + number - The number of the address
 # + street - The street of the address
 # + city - The city of the address
+# + 'type - The type of the address
 type Address record {
     int number;
     string street;
     string city;
+    string 'type;
 };
 
 isolated service on new graphql:Listener(9000) {
@@ -47,7 +49,8 @@ isolated service on new graphql:Listener(9000) {
             address: {
                 number: 308,
                 street: "Negra Arroyo Lane",
-                city: "Albequerque"
+                city: "Albequerque",
+                'type: "Personal"
             }
         };
     }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/generator_tests/08_input_scalar_types/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/generator_tests/08_input_scalar_types/service.bal
@@ -17,8 +17,8 @@
 import ballerina/graphql;
 
 isolated service on new graphql:Listener(9000) {
-    isolated resource function get toString(int value) returns string {
-        return value.toString();
+    isolated resource function get toString(int 'version) returns string {
+        return 'version.toString();
     }
 
     isolated resource function get bonus(decimal salary) returns decimal {

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/generator/GeneratorUtils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/generator/GeneratorUtils.java
@@ -26,6 +26,8 @@ import io.ballerina.stdlib.graphql.compiler.schema.types.TypeKind;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Utility methods for Ballerina GraphQL schema generator.
@@ -33,6 +35,9 @@ import java.util.List;
 public class GeneratorUtils {
     private GeneratorUtils() {
     }
+
+    private static final String UNICODE_REGEX = "\\\\(\\\\*)u\\{([a-fA-F0-9]+)\\}";
+    public static final Pattern UNICODE_PATTERN = Pattern.compile(UNICODE_REGEX);
 
     public static final String UNION_TYPE_NAME_DELIMITER = "_";
 
@@ -93,14 +98,50 @@ public class GeneratorUtils {
         return documentable.documentation().get().deprecatedDescription().get();
     }
 
-    public static String removeEscapeCharacter(String value) {
-        if (value == null) {
+    public static String removeEscapeCharacter(String identifier) {
+        if (identifier == null) {
             return null;
         }
+
+        Matcher matcher = UNICODE_PATTERN.matcher(identifier);
+        StringBuffer buffer = new StringBuffer(identifier.length());
+        while (matcher.find()) {
+            String leadingSlashes = matcher.group(1);
+            if (isEscapedNumericEscape(leadingSlashes)) {
+                // e.g. \\u{61}, \\\\u{61}
+                continue;
+            }
+
+            int codePoint = Integer.parseInt(matcher.group(2), 16);
+            char[] chars = Character.toChars(codePoint);
+            String ch = String.valueOf(chars);
+
+            if (ch.equals("\\")) {
+                // Ballerina string unescaping is done in two stages.
+                // 1. unicode code point unescaping (doing separately as [2] does not support code points > 0xFFFF)
+                // 2. java unescaping
+                // Replacing unicode code point of backslash at [1] would compromise [2]. Therefore, special case it.
+                matcher.appendReplacement(buffer, Matcher.quoteReplacement(leadingSlashes + "\\u005C"));
+            } else {
+                matcher.appendReplacement(buffer, Matcher.quoteReplacement(leadingSlashes + ch));
+            }
+        }
+        matcher.appendTail(buffer);
+        String value = String.valueOf(buffer);
+
         if (value.startsWith("'")) {
             return value.substring(1);
         }
         return value;
+    }
+
+    private static boolean isEscapedNumericEscape(String leadingSlashes) {
+        return !isEven(leadingSlashes.length());
+    }
+
+    private static boolean isEven(int n) {
+        // (n & 1) is 0 when n is even.
+        return (n & 1) == 0;
     }
 
     public static Type getWrapperType(Type type, TypeKind typeKind) {

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/generator/GeneratorUtils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/generator/GeneratorUtils.java
@@ -93,6 +93,16 @@ public class GeneratorUtils {
         return documentable.documentation().get().deprecatedDescription().get();
     }
 
+    public static String removeEscapeCharacter(String value) {
+        if (value == null) {
+            return null;
+        }
+        if (value.startsWith("'")) {
+            return value.substring(1);
+        }
+        return value;
+    }
+
     public static Type getWrapperType(Type type, TypeKind typeKind) {
         return new Type(typeKind, type);
     }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/generator/GeneratorUtils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/generator/GeneratorUtils.java
@@ -37,7 +37,9 @@ public class GeneratorUtils {
     }
 
     private static final String UNICODE_REGEX = "\\\\(\\\\*)u\\{([a-fA-F0-9]+)\\}";
-    public static final Pattern UNICODE_PATTERN = Pattern.compile(UNICODE_REGEX);
+    private static final Pattern UNICODE_PATTERN = Pattern.compile(UNICODE_REGEX);
+
+    private static final String SINGLE_QUOTE_CHARACTER = "'";
 
     public static final String UNION_TYPE_NAME_DELIMITER = "_";
 
@@ -129,7 +131,7 @@ public class GeneratorUtils {
         matcher.appendTail(buffer);
         String value = String.valueOf(buffer);
 
-        if (value.startsWith("'")) {
+        if (value.startsWith(SINGLE_QUOTE_CHARACTER)) {
             return value.substring(1);
         }
         return value;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/generator/SchemaGenerator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/generator/SchemaGenerator.java
@@ -72,6 +72,7 @@ import static io.ballerina.stdlib.graphql.compiler.schema.generator.GeneratorUti
 import static io.ballerina.stdlib.graphql.compiler.schema.generator.GeneratorUtils.getDescription;
 import static io.ballerina.stdlib.graphql.compiler.schema.generator.GeneratorUtils.getTypeName;
 import static io.ballerina.stdlib.graphql.compiler.schema.generator.GeneratorUtils.getWrapperType;
+import static io.ballerina.stdlib.graphql.compiler.schema.generator.GeneratorUtils.removeEscapeCharacter;
 import static io.ballerina.stdlib.graphql.compiler.service.validator.ValidatorUtils.RESOURCE_FUNCTION_GET;
 
 /**
@@ -337,7 +338,10 @@ public class SchemaGenerator {
                          RecordTypeSymbol recordTypeSymbol) {
         Type objectType = addType(name, TypeKind.OBJECT, description);
         for (RecordFieldSymbol recordFieldSymbol : recordTypeSymbol.fieldDescriptors().values()) {
-            String fieldDescription = fieldMap.get(recordFieldSymbol.getName().orElse(""));
+            if (recordFieldSymbol.getName().isEmpty()) {
+                continue;
+            }
+            String fieldDescription = fieldMap.get(removeEscapeCharacter(recordFieldSymbol.getName().get()));
             objectType.addField(getField(recordFieldSymbol, fieldDescription));
         }
         return objectType;
@@ -518,11 +522,11 @@ public class SchemaGenerator {
     }
 
     private void addEnumValueToType(Type type, ConstantSymbol enumMember) {
-        if (enumMember.resolvedValue().isEmpty()) {
+        if (enumMember.getName().isEmpty()) {
             return;
         }
         String memberDescription = getDescription(enumMember);
-        String name = enumMember.resolvedValue().get().replaceAll("\"", "");
+        String name = enumMember.getName().get();
         boolean isDeprecated = enumMember.deprecated();
         String deprecationReason = getDeprecationReason(enumMember);
         EnumValue enumValue = new EnumValue(name, memberDescription, isDeprecated, deprecationReason);

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/types/Directive.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/types/Directive.java
@@ -22,6 +22,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import static io.ballerina.stdlib.graphql.compiler.schema.generator.GeneratorUtils.removeEscapeCharacter;
+
 /**
  * Represents the {@code __Directive} in GraphQL schema.
  */
@@ -37,7 +39,7 @@ public class Directive implements Serializable {
     }
 
     public Directive(String name, String description, List<DirectiveLocation> locations) {
-        this.name = name;
+        this.name = removeEscapeCharacter(name);
         this.description = description;
         this.locations = locations;
         this.args = new ArrayList<>();

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/types/EnumValue.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/types/EnumValue.java
@@ -20,6 +20,8 @@ package io.ballerina.stdlib.graphql.compiler.schema.types;
 
 import java.io.Serializable;
 
+import static io.ballerina.stdlib.graphql.compiler.schema.generator.GeneratorUtils.removeEscapeCharacter;
+
 /**
  * Represents the {@code __EnumValue} type in GraphQL schema.
  */
@@ -35,7 +37,7 @@ public class EnumValue implements Serializable {
     }
 
     public EnumValue(String name, String description, boolean isDeprecated, String deprecationReason) {
-        this.name = name;
+        this.name = removeEscapeCharacter(name);
         this.description = description;
         this.isDeprecated = isDeprecated;
         this.deprecationReason = deprecationReason;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/types/Field.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/types/Field.java
@@ -22,6 +22,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import static io.ballerina.stdlib.graphql.compiler.schema.generator.GeneratorUtils.removeEscapeCharacter;
+
 /**
  * Represents the {@code __Field} in GraphQL schema.
  */
@@ -47,7 +49,7 @@ public class Field implements Serializable {
     }
 
     public Field(String name, String description, Type type, boolean isDeprecated, String deprecationReason) {
-        this.name = name;
+        this.name = removeEscapeCharacter(name);
         this.description = description;
         this.type = type;
         this.isDeprecated = isDeprecated;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/types/InputValue.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/types/InputValue.java
@@ -20,6 +20,8 @@ package io.ballerina.stdlib.graphql.compiler.schema.types;
 
 import java.io.Serializable;
 
+import static io.ballerina.stdlib.graphql.compiler.schema.generator.GeneratorUtils.removeEscapeCharacter;
+
 /**
  * Represents the {@code __InputValue} in GraphQL schema.
  */
@@ -31,7 +33,7 @@ public class InputValue implements Serializable {
     private final String defaultValue;
 
     public InputValue(String name, Type type, String description, String defaultValue) {
-        this.name = name;
+        this.name = removeEscapeCharacter(name);
         this.description = description;
         this.type = type;
         this.defaultValue = defaultValue;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/types/Type.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/types/Type.java
@@ -25,6 +25,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.ballerina.stdlib.graphql.compiler.schema.generator.GeneratorUtils.removeEscapeCharacter;
+
 /**
  * Represents the {@code __Type} type in GraphQL schema.
  */
@@ -72,7 +74,7 @@ public class Type implements Serializable {
     }
 
     private Type(String name, TypeKind kind, String description, Type ofType) {
-        this.name = name;
+        this.name = removeEscapeCharacter(name);
         this.kind = kind;
         this.description = description;
         this.fields = kind == TypeKind.OBJECT || kind == TypeKind.INTERFACE ? new LinkedHashMap<>() : null;

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -472,6 +472,30 @@ service on new graphql:Listener(9090) {
 
 This will generate the documentation for all the fields of the `Query` type including the field descriptions of the `Person` type.
 
+**Note:** When a field or an argument name contains unicode characters or any other escape characters, they are unescaped when generating the schema.   
+
+###### Example: Escaping Characters
+```ballerina
+service on new graphql:Listener(4000) {
+    resource function get 'type(string 'version) returns string {
+        return "";
+    }
+    
+    resource function get name(string \u{0076}ersion) returns string {
+        return "";
+    }
+}
+```
+
+The above code will generate the following schema:
+
+```graphql
+type Query {
+    type(version: String!): String!
+    name(version: String!): String!
+}
+```
+
 ## 4. Types
 
 GraphQL type system is represented using a hierarchical structure. Type is the fundamental unit of any GraphQL schema.


### PR DESCRIPTION
## Purpose

When a field name, argument name, or type name has escape characters, the generated schema causes problems. This PR will fix those issues.

Fixes: [#3069](https://github.com/ballerina-platform/ballerina-standard-library/issues/3069)
Fixes: [#3067](https://github.com/ballerina-platform/ballerina-standard-library/issues/3067)

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
