### PR TITLE
Add SDL Schema File Generation

### DIFF
--- a/ballerina/annotations.bal
+++ b/ballerina/annotations.bal
@@ -23,6 +23,7 @@
 # + graphiql - GraphiQL client configurations
 # + schemaString - The generated schema. This is auto-generated at the compile-time
 # + interceptors - GraphQL service level interceptors
+# + schemaFileGenEnabled - Whether enable or disable the SDL schema file generation
 public type GraphqlServiceConfig record {|
     int maxQueryDepth?;
     ListenerAuthConfig[] auth?;
@@ -31,6 +32,7 @@ public type GraphqlServiceConfig record {|
     Graphiql graphiql = {};
     readonly string schemaString = "";
     readonly readonly & Interceptor[] interceptors = [];
+    boolean schemaFileGenEnabled = true;
 |};
 
 # The annotation to configure a GraphQL service.

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/ServiceAnalysisTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/ServiceAnalysisTask.java
@@ -72,11 +72,11 @@ public class ServiceAnalysisTask implements AnalysisTask<SyntaxNodeAnalysisConte
         }
         DocumentId documentId = context.documentId();
         Schema schema = generateSchema(interfaceFinder, symbol);
-        Project project = context.currentPackage().project();
         addToModifierContextMap(documentId, node, schema);
 
         boolean generateSDLFileEnabled = getSchemaGenerationAnnotValue(node);
         if (generateSDLFileEnabled) {
+            Project project = context.currentPackage().project();
             SDLFileGenerator sdlFileGenerator = new SDLFileGenerator(schema, symbol, project);
             sdlFileGenerator.generate();
         }
@@ -102,19 +102,19 @@ public class ServiceAnalysisTask implements AnalysisTask<SyntaxNodeAnalysisConte
         if (node.metadata().isPresent()) {
             MetadataNode metadataNode = node.metadata().get();
             for (AnnotationNode annotationNode : metadataNode.annotations()) {
-                return Boolean.parseBoolean(getAnnotationValue(annotationNode));
+                if (annotationNode.annotValue().isPresent()) {
+                    return Boolean.parseBoolean(getAnnotationValue(annotationNode));
+                }
             }
         }
         return true;
     }
 
     private String getAnnotationValue(AnnotationNode annotationNode) {
-        if (annotationNode.annotValue().isPresent()) {
-            for (MappingFieldNode field : annotationNode.annotValue().get().fields()) {
-                if (field.toString().contains(SCHEMA_GEN_CONFIG_IDENTIFIER)) {
-                    String[] annotStrings = field.toString().split(":");
-                    return annotStrings[annotStrings.length - 1].trim();
-                }
+        for (MappingFieldNode field : annotationNode.annotValue().get().fields()) {
+            if (field.toString().contains(SCHEMA_GEN_CONFIG_IDENTIFIER)) {
+                String[] annotStrings = field.toString().split(":");
+                return annotStrings[annotStrings.length - 1].trim();
             }
         }
         return String.valueOf(true);

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/Utils.java
@@ -55,6 +55,7 @@ public final class Utils {
     public static final String CONTEXT_IDENTIFIER = "Context";
     public static final String FILE_UPLOAD_IDENTIFIER = "Upload";
     public static final String SERVICE_CONFIG_IDENTIFIER = "ServiceConfig";
+    public static final String SCHEMA_GEN_CONFIG_IDENTIFIER = "schemaFileGenEnabled";
 
     public static boolean isGraphqlModuleSymbol(Symbol symbol) {
         if (symbol.getModule().isEmpty()) {

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/generator/SDLFileGenerator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/generator/SDLFileGenerator.java
@@ -52,7 +52,7 @@ public class SDLFileGenerator {
     private static final String FIELD_BLOCK_FORMAT = "{%n%s%n}";
     private static final String ARGS_FORMAT = "(%s)";
     private static final String DESC_FORMAT = "%s%n";
-    private static final String DEPRECATE_FORMAT = "%s(reason: %s)";
+    private static final String DEPRECATE_FORMAT = "%s(reason: \"%s\")";
     private static final String COMMENT_FORMAT = "%s# %s";
     private static final String IMPLEMENT_FORMAT = " implements %s";
     private static final String POSSIBLE_TYPE_FORMAT = " = %s";

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/generator/SDLFileGenerator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/schema/generator/SDLFileGenerator.java
@@ -1,0 +1,392 @@
+package io.ballerina.stdlib.graphql.compiler.schema.generator;
+
+import io.ballerina.compiler.api.symbols.ServiceDeclarationSymbol;
+import io.ballerina.projects.Project;
+import io.ballerina.projects.ProjectKind;
+import io.ballerina.stdlib.graphql.compiler.schema.types.DefaultDirective;
+import io.ballerina.stdlib.graphql.compiler.schema.types.Directive;
+import io.ballerina.stdlib.graphql.compiler.schema.types.DirectiveLocation;
+import io.ballerina.stdlib.graphql.compiler.schema.types.EnumValue;
+import io.ballerina.stdlib.graphql.compiler.schema.types.Field;
+import io.ballerina.stdlib.graphql.compiler.schema.types.InputValue;
+import io.ballerina.stdlib.graphql.compiler.schema.types.IntrospectionType;
+import io.ballerina.stdlib.graphql.compiler.schema.types.ScalarType;
+import io.ballerina.stdlib.graphql.compiler.schema.types.Schema;
+import io.ballerina.stdlib.graphql.compiler.schema.types.Type;
+import io.ballerina.stdlib.graphql.compiler.schema.types.TypeKind;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static io.ballerina.projects.util.ProjectConstants.USER_DIR;
+
+/**
+ * Generate the SDL schema file for a given Ballerina GraphQL Service.
+ */
+public class SDLFileGenerator {
+
+    private final Schema schema;
+    private final ServiceDeclarationSymbol serviceDeclarationSymbol;
+    private final Project project;
+    private final PrintStream stdError = System.err;
+
+    //String formats for SDL schema
+    private static final String SDL_SCHEMA_NAME_FORMAT = "schema_%d.graphql";
+    private static final String SCHEMA_FORMAT = "%s%s%s%n%n%s";
+    private static final String ROOT_TYPE_FORMAT = "schema {%n%s%n}";
+    private static final String DIRECTIVE_TYPE_FORMAT = "%sdirective @%s%s on %s";
+    private static final String INTERFACE_TYPE_FORMAT = "%sinterface %s%s %s";
+    private static final String UNION_TYPE_FORMAT = "%sunion %s%s";
+    private static final String SCALAR_TYPE_FORMAT = "%sscalar %s";
+    private static final String OBJECT_TYPE_FORMAT = "%stype %s%s %s";
+    private static final String ENUM_TYPE_FORMAT = "%senum %s %s";
+    private static final String INPUT_TYPE_FORMAT = "input %s %s";
+    private static final String FIELD_FORMAT = "%s  %s%s: %s%s";
+    private static final String FIELD_BLOCK_FORMAT = "{%n%s%n}";
+    private static final String ARGS_FORMAT = "(%s)";
+    private static final String DESC_FORMAT = "%s%n";
+    private static final String DEPRECATE_FORMAT = "%s(reason: %s)";
+    private static final String COMMENT_FORMAT = "%s# %s";
+    private static final String IMPLEMENT_FORMAT = " implements %s";
+    private static final String POSSIBLE_TYPE_FORMAT = " = %s";
+    private static final String INPUT_FIELD_FORMAT = "  %s: %s";
+    private static final String ARGS_TYPE_FORMAT = "%s = %s";
+    private static final String ARGS_VALUE_FORMAT = "%s: %s";
+    private static final String ENUM_VALUE_FORMAT = "  %s%s";
+    private static final String NON_NULL_FORMAT = "%s!";
+    private static final String LIST_FORMAT = "[%s]";
+    private static final String QUERY_FORMAT = "  query: %s";
+    private static final String MUTATION_FORMAT = "  mutation: %s";
+    private static final String SUBSCRIPTION_FORMAT = "  subscription: %s";
+    private static final String DEPRECATE = " @deprecated";
+
+    //Schema delimiters
+    private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+    private static final String INDENTATION = "  ";
+    private static final String EMPTY_STRING = "";
+    private static final String COMMA_SIGN = ", ";
+    private static final String AND_SIGN = " & ";
+    private static final String PIPE_SIGN = "|";
+
+    public SDLFileGenerator(Schema schema, ServiceDeclarationSymbol symbol, Project project) {
+        this.schema = schema;
+        this.serviceDeclarationSymbol = symbol;
+        this.project = project;
+    }
+
+    public void generate() {
+        String schema = getSDLSchemaString();
+        writeFile(schema);
+    }
+
+    private String getSDLSchemaString() {
+        String rootType = createRootType();
+        String directives = getDirectives();
+        String types = getTypes();
+        return getFormattedString(SCHEMA_FORMAT, createDescription(this.schema.getDescription()), rootType, directives,
+                                  types);
+    }
+
+    private String createRootType() {
+        List<String> rootOperations = new ArrayList<>();
+        Type query = this.schema.getQueryType();
+        if (query != null) {
+            rootOperations.add(getFormattedString(QUERY_FORMAT, query.getName()));
+        }
+
+        Type mutation = this.schema.getMutationType();
+        if (mutation != null) {
+            rootOperations.add(getFormattedString(MUTATION_FORMAT, mutation.getName()));
+        }
+
+        Type subscription = this.schema.getSubscriptionType();
+        if (subscription != null) {
+            rootOperations.add(getFormattedString(SUBSCRIPTION_FORMAT, subscription.getName()));
+        }
+        return getFormattedString(ROOT_TYPE_FORMAT, String.join(LINE_SEPARATOR, rootOperations));
+    }
+
+    private String getDirectives() {
+        List<String> directives = new ArrayList<>();
+        for (Directive directive : this.schema.getDirectives()) {
+            if (!isDefaultDirective(directive)) {
+                directives.add(createDirective(directive));
+            }
+        }
+        String formatedDirectives = String.join(LINE_SEPARATOR + LINE_SEPARATOR, directives);
+        if (directives.isEmpty()) {
+            return formatedDirectives;
+        }
+        return LINE_SEPARATOR + LINE_SEPARATOR + formatedDirectives;
+    }
+
+    private String getTypes() {
+        List<String> types = new ArrayList<>();
+        for (Map.Entry<String, Type> entry : this.schema.getTypes().entrySet()) {
+            if (!isIntrospectionType(entry.getValue()) && !isBuiltInScalarType(entry.getValue())) {
+                types.add(createType(entry.getValue()));
+            }
+        }
+        return String.join(LINE_SEPARATOR + LINE_SEPARATOR, types);
+    }
+
+    private String createDirective(Directive directive) {
+        return getFormattedString(DIRECTIVE_TYPE_FORMAT, createDescription(directive.getDescription()),
+                                  directive.getName(), createArgs(directive.getArgs()),
+                                  createDirectiveLocation(directive.getLocations()));
+    }
+
+    private String createType(Type type) {
+        if (type.getKind().equals(TypeKind.SCALAR)) {
+            return createScalarType(type);
+        }
+        if (type.getKind().equals(TypeKind.OBJECT)) {
+            return createObjectType(type);
+        }
+        if (type.getKind().equals(TypeKind.INTERFACE)) {
+            return createInterfaceType(type);
+        }
+        if (type.getKind().equals(TypeKind.UNION)) {
+            return createUnionType(type);
+        }
+        if (type.getKind().equals(TypeKind.ENUM)) {
+            return createEnumType(type);
+        }
+        if (type.getKind().equals(TypeKind.INPUT_OBJECT)) {
+            return createInputObjectType(type);
+        }
+        return EMPTY_STRING;
+    }
+
+    private String createScalarType(Type type) {
+        return getFormattedString(SCALAR_TYPE_FORMAT, createDescription(type.getDescription()), type.getName());
+    }
+
+    private String createObjectType(Type type) {
+        return getFormattedString(OBJECT_TYPE_FORMAT, createDescription(type.getDescription()), type.getName(),
+                                  createInterfaceImplements(type), createFields(type));
+    }
+
+    private String createInterfaceType(Type type) {
+        return getFormattedString(INTERFACE_TYPE_FORMAT, createDescription(type.getDescription()), type.getName(),
+                                  createInterfaceImplements(type), createFields(type));
+    }
+
+    private String createUnionType(Type type) {
+        return getFormattedString(UNION_TYPE_FORMAT, createDescription(type.getDescription()), type.getName(),
+                                  createPossibleTypes(type));
+    }
+
+    private String createInputObjectType(Type type) {
+        return getFormattedString(INPUT_TYPE_FORMAT, type.getName(), createInputValues(type));
+    }
+
+    private String createEnumType(Type type) {
+        return getFormattedString(ENUM_TYPE_FORMAT, createDescription(type.getDescription()), type.getName(),
+                                  createEnumValues(type));
+    }
+
+    private String createDescription(String description) {
+        if (description == null || description.isEmpty()) {
+            return EMPTY_STRING;
+        } else {
+            List<String> subStrings = new ArrayList<>();
+            for (String subString : description.split(LINE_SEPARATOR)) {
+                subStrings.add(getFormattedString(COMMENT_FORMAT, EMPTY_STRING, subString));
+            }
+            return getFormattedString(DESC_FORMAT, String.join(LINE_SEPARATOR, subStrings));
+        }
+    }
+
+    private String createFields(Type type) {
+        List<String> fields = new ArrayList<>();
+        for (Field field : type.getFields()) {
+            fields.add(getFormattedString(FIELD_FORMAT, createFieldDescription(field.getDescription()), field.getName(),
+                                          createArgs(field.getArgs()), createFieldType(field.getType()),
+                                          createDeprecate(field)));
+        }
+        return getFormattedString(FIELD_BLOCK_FORMAT, String.join(LINE_SEPARATOR, fields));
+    }
+
+    private String createEnumValues(Type type) {
+        List<String> enumValues = new ArrayList<>();
+        for (EnumValue enumValue : type.getEnumValues()) {
+            enumValues.add(getFormattedString(ENUM_VALUE_FORMAT, enumValue.getName(), createDeprecate(enumValue)));
+        }
+        return getFormattedString(FIELD_BLOCK_FORMAT, String.join(LINE_SEPARATOR, enumValues));
+    }
+
+    private String createInputValues(Type type) {
+        List<String> inputFields = new ArrayList<>();
+        for (InputValue inputField : type.getInputFields()) {
+            inputFields.add(getFormattedString(INPUT_FIELD_FORMAT, inputField.getName(), createArgType(inputField)));
+        }
+        return getFormattedString(FIELD_BLOCK_FORMAT, String.join(LINE_SEPARATOR, inputFields));
+    }
+
+    private String createPossibleTypes(Type type) {
+        List<String> possibleTypes = new ArrayList<>();
+        for (Type possibleType : type.getPossibleTypes()) {
+            possibleTypes.add(possibleType.getName());
+        }
+        return getFormattedString(POSSIBLE_TYPE_FORMAT, String.join(PIPE_SIGN, possibleTypes));
+    }
+
+    private String createArgs(List<InputValue> inputValues) {
+        List<String> args = new ArrayList<>();
+        if (inputValues.isEmpty()) {
+            return EMPTY_STRING;
+        }
+        for (InputValue arg : inputValues) {
+            args.add(getFormattedString(ARGS_VALUE_FORMAT, arg.getName(), createArgType(arg)));
+        }
+        return getFormattedString(ARGS_FORMAT, String.join(COMMA_SIGN, args));
+    }
+
+    private String createFieldType(Type type) {
+        if (type.getKind().equals(TypeKind.NON_NULL)) {
+            return getFormattedString(NON_NULL_FORMAT, createFieldType(type.getOfType()));
+        } else if (type.getKind().equals(TypeKind.LIST)) {
+            return getFormattedString(LIST_FORMAT, createFieldType(type.getOfType()));
+        } else {
+            return type.getName();
+        }
+    }
+
+    private String createArgType(InputValue arg) {
+        if (arg.getDefaultValue() == null) {
+            return createFieldType(arg.getType());
+        } else {
+            return getFormattedString(ARGS_TYPE_FORMAT, createFieldType(arg.getType()), arg.getDefaultValue());
+        }
+    }
+
+    private String createInterfaceImplements(Type type) {
+        List<String> interfaces = new ArrayList<>();
+        if (type.getInterfaces().isEmpty()) {
+            return EMPTY_STRING;
+        }
+        for (Type interfaceType : type.getInterfaces()) {
+            interfaces.add(interfaceType.getName());
+        }
+        return getFormattedString(IMPLEMENT_FORMAT, String.join(AND_SIGN, interfaces));
+    }
+
+    private String createFieldDescription(String description) {
+        if (description == null || description.isEmpty()) {
+            return EMPTY_STRING;
+        } else {
+            List<String> subStrings = new ArrayList<>();
+            for (String subString : description.split(LINE_SEPARATOR)) {
+                subStrings.add(getFormattedString(COMMENT_FORMAT, INDENTATION, subString));
+            }
+            return getFormattedString(DESC_FORMAT, String.join(LINE_SEPARATOR, subStrings));
+        }
+    }
+
+    private String createDirectiveLocation(List<DirectiveLocation> location) {
+        List<String> locations = new ArrayList<>();
+        for (DirectiveLocation directiveLocation : location) {
+            locations.add(directiveLocation.name());
+        }
+        return String.join(PIPE_SIGN, locations);
+    }
+
+    private String createDeprecate(EnumValue enumValue) {
+        if (enumValue.isDeprecated()) {
+            if (enumValue.getDeprecationReason() != null) {
+                return getFormattedString(DEPRECATE_FORMAT, DEPRECATE, enumValue.getDeprecationReason());
+            }
+            return DEPRECATE;
+        }
+        return EMPTY_STRING;
+    }
+
+    private String createDeprecate(Field field) {
+        if (field.isDeprecated()) {
+            if (field.getDeprecationReason() != null) {
+                return getFormattedString(DEPRECATE_FORMAT, DEPRECATE, field.getDeprecationReason());
+            }
+            return DEPRECATE;
+        }
+        return EMPTY_STRING;
+    }
+
+    private Boolean isIntrospectionType(Type type) {
+        for (IntrospectionType value : IntrospectionType.values()) {
+            if (value.getName().equals(type.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Boolean isBuiltInScalarType(Type type) {
+        for (ScalarType value : ScalarType.values()) {
+            if (value.getName().equals(type.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Boolean isDefaultDirective(Directive directive) {
+        for (DefaultDirective value : DefaultDirective.values()) {
+            if (value.getName().equals(directive.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String getFormattedString(String format, String... args) {
+        return String.format(format, (Object[]) args);
+    }
+
+    private void writeFile(String content) {
+        Path filePath = Paths.get(getTargetPath(), getSchemaFileName()).toAbsolutePath();
+        try {
+            createFileIfNotExists(filePath);
+            Files.write(filePath, Collections.singleton(content));
+        } catch (IOException e) {
+            this.stdError.println("WARNING! SDL schema file generation failed. " + e.getMessage());
+        }
+    }
+
+    private String getTargetPath() {
+        if (this.project.kind().equals(ProjectKind.SINGLE_FILE_PROJECT)) {
+            return System.getProperty(USER_DIR);
+        } else {
+            return this.project.targetDir().toString();
+        }
+    }
+
+    private String getSchemaFileName() {
+        return String.format(SDL_SCHEMA_NAME_FORMAT, this.serviceDeclarationSymbol.hashCode());
+    }
+
+    private static void createFileIfNotExists(Path filePath) throws IOException {
+        Path parentDir = filePath.getParent();
+        if (parentDir != null && !parentDir.toFile().exists()) {
+            try {
+                Files.createDirectories(parentDir);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        if (!filePath.toFile().exists()) {
+            try {
+                Files.createFile(filePath);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -92,6 +92,7 @@ The conforming implementation of the specification is released and included in t
         * 9.1.4 [CORS Configurations](#914-cors-configurations)
         * 9.1.5 [GraphiQL Configurations](#915-graphiql-configurations)
         * 9.1.6 [Service Level Interceptors](#916-service-level-interceptors)
+        * 9.1.7 [Schema File Generation](#917-schema-file-generation)
 10. [Interceptors](#10-interceptors)
     * 10.1 [Interceptor Service Object](#101-interceptor-service-object)
     * 10.2 [GraphQL Field Object](#102-graphql-field-object)
@@ -1326,6 +1327,23 @@ service on new graphql:Listener(4000) {
     // ...
 }
 ```
+
+#### 9.1.7 Schema File Generation
+
+The `schemaFileGenEnabled` field is used to enable or disable the GraphQL SDL schema file generation. If this is enabled, the Ballerina GraphQL package generates the schema file in GraphQL Schema Definition Language(SDL). By default, the `schemaFileGenEnabled` field has been set to `true`.
+
+###### Example: Disable Schema File Generation
+
+```ballerina
+@graphql:ServiceConfig {
+    schemaFileGenEnabled: false
+}
+service on new graphql:Listener(4000) {
+    // ...
+}
+```
+
+>**NOTE:** For the Ballerina projects, it will create the schema in the `target` directory and for the single bal files, it will create the schema in bal file's directory.
 
 ## 10. Interceptors
 The GraphQL interceptors can be used to execute a custom code before and after the resolver function gets invoked.


### PR DESCRIPTION
## Purpose

Fixes: [#3205](https://github.com/ballerina-platform/ballerina-standard-library/issues/3205)

## Examples
The `schemaFileGenEnabled` field in GraphQL [service config](https://github.com/ballerina-platform/module-ballerina-graphql/blob/master/docs/spec/spec.md#91-service-configuration) can be used to enable or disable the GraphQL SDL schema file generation. For the Ballerina projects, it will create the schema in the `target` directory and for the single `bal` files, it will create the schema in `bal` file's directory. By default, the `schemaFileGenEnabled` field has been set to `true`.

**Schema File Generation Configs**
```ballerina
@graphql:ServiceConfig {
    schemaFileGenEnabled: false
}
```
Sample schema generated for GraphQL [starwars](https://github.com/ballerina-platform/module-ballerina-graphql/tree/master/examples/starwars) example:
```graphql
# This is an implementation of Starwars example in Ballerina. The Starwars schema and resolvers are based on popular Star Wars characters. This sample implementation can be used to learn the Ballerina GraphQL package functionalities.
# In this implementation, it supports both query and mutation operations. Subscriptions are not included in this exaple due to the limitation coming from the Ballerina GraphQL package. Support for Subscriptions are planned in near future releases.
schema {
  query: Query
  mutation: Mutation
}

type Query {
  # Fetch the hero of the Star Wars
  hero(episode: Episode): Character!
  # Returns reviews of the Star Wars
  reviews(episode: Episode!): [Review]!
  # Returns characters by id, or null if character is not found
  characters(idList: [String!]!): [Character]!
  # Returns a droid by id, or null if droid is not found
  droid(id: String!): Droid
  # Returns a human by id, or null if human is not found
  human(id: String!): Human
  # Returns a starship by id, or null if starship is not found
  starship(id: String!): Starship
  # Returns search results by text, or null if search item is not found
  search(text: String!): [SearchResult!]
}

# A mechanical character from the Star Wars universe
interface Character {
  # The unique identifier of the character
  id: String!
  # The name of the character
  name: String!
  # The episodes this character appears in
  appearsIn: [Episode!]!
  friends: [Character!]!
}

# An autonomous mechanical character in the Star Wars universe
type Droid implements Character {
  # The unique identifier of the droid
  id: String!
  # The name of the droid
  name: String!
  # This droid's friends, or an empty list if they have none
  friends: [Character!]!
  # The episodes this droid appears in
  appearsIn: [Episode!]!
  # This droid's primary function
  primaryFunction: String
}

enum Episode {
  JEDI
  EMPIRE
  NEWHOPE
}

# A humanoid creature from the Star Wars universe
type Human implements Character {
  # The unique identifier of the human
  id: String!
  # The name of the human
  name: String!
  # The home planet of the human, or null if unknown
  homePlanet: String
  # Height in meters, or null if unknown
  height: Float
  # Mass in kilograms, or null if unknown
  mass: Int
  # This human's friends, or an empty list if they have none
  friends: [Character!]!
  # The episodes this human appears in
  appearsIn: [Episode!]!
  # A list of starships this person has piloted, or an empty list if none
  starships: [Starship!]!
}

# A ship from the Star Wars universe
type Starship {
  # The unique identifier of the starship
  id: String!
  # The name of the starship
  name: String!
  # The length of the starship, or null if unknown
  length: Float
  # Cordinates of the starship, or null if unknown
  cordinates: [[Float!]!]
}

type Review {
  episode: Episode
  stars: Int!
  commentary: String
}

# auto-generated union type from Ballerina
union SearchResult = Human|Droid|Starship

type Mutation {
  # Add new reviews and return the review values
  createReview(episode: Episode!, reviewInput: ReviewInput!): [Review!]!
}

input ReviewInput {
  stars: Int!
  commentary: String!
}
```

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [x] Updated the spec
