### PR TITLE
Update Gradle Clean Task to Remove Dependencies.toml from the Examples

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 clean {
     examples.forEach { example ->
         delete "${projectDir}/${example}/target"
+        delete "${projectDir}/${example}/Dependencies.toml"
     }
 }
 


### PR DESCRIPTION
## Purpose

When the minor (or the major) version is bumped, the examples fail to build locally, due to the `Dependencies.toml` file not updating the GraphQL version. This is not affecting the GitHub workflow builds because we do not commit the Dependencies.toml file for the examples. But this is a pain for the local development environment. Therefore, the clean task is updated to delete the Dependencies.toml file.

## Examples

## Checklist
- [ ] ~Linked to an issue~
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
- [ ] ~Updated the spec~
