### PR TITLE
Replace Slack References with Discord and Bump Versions to Prepare for 2201.3.0 Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1068,5 +1068,5 @@ All the contributors are encouraged to read the [Ballerina Code of Conduct](http
 
 * For more information go to the [`graphql` library](https://lib.ballerina.io/ballerina/graphql/latest).
 * For example demonstrations of the usage, go to [Ballerina By Examples](https://ballerina.io/learn/by-example/).
-* Chat live with us via our [Slack channel](https://ballerina.io/community/slack/).
+* Chat live with us via our [Discord server](https://discord.gg/ballerinalang).
 * Post all technical questions on Stack Overflow with the [#ballerina](https://stackoverflow.com/questions/tagged/ballerina) tag.

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -9,7 +9,7 @@ dependencies-toml-version = "2"
 [[package]]
 org = "ballerina"
 name = "auth"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -22,7 +22,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -33,7 +33,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "constraint"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.2.3"
+version = "2.3.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -111,7 +111,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -142,7 +142,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -159,7 +159,7 @@ version = "0.0.0"
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -212,6 +212,14 @@ version = "0.0.0"
 
 [[package]]
 org = "ballerina"
+name = "lang.regexp"
+version = "0.0.0"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.runtime"
 version = "0.0.0"
 dependencies = [
@@ -226,7 +234,8 @@ org = "ballerina"
 name = "lang.string"
 version = "0.0.0"
 dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.regexp"}
 ]
 
 [[package]]
@@ -243,7 +252,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -254,7 +263,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -267,7 +276,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -287,7 +296,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"}
@@ -296,7 +305,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "regex"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.string"}
@@ -308,7 +317,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.2.3"
+version = "2.3.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -329,7 +338,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -337,7 +346,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -348,7 +357,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "websocket"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["gql", "network", "query", "service"]
 repository = "https://github.com/ballerina-platform/module-ballerina-graphql"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.2.0"
+distribution = "2201.3.0"
 
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -9,7 +9,7 @@ dependencies-toml-version = "2"
 [[package]]
 org = "ballerina"
 name = "auth"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -25,7 +25,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -36,7 +36,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "constraint"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -44,7 +44,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.2.3"
+version = "2.3.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -53,7 +53,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -94,7 +94,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -125,7 +125,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -145,7 +145,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -204,6 +204,14 @@ version = "0.0.0"
 
 [[package]]
 org = "ballerina"
+name = "lang.regexp"
+version = "0.0.0"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.runtime"
 version = "0.0.0"
 dependencies = [
@@ -215,7 +223,8 @@ org = "ballerina"
 name = "lang.string"
 version = "0.0.0"
 dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.regexp"}
 ]
 
 [[package]]
@@ -232,7 +241,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -246,7 +255,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -259,7 +268,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -282,7 +291,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"}
@@ -291,7 +300,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "regex"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.string"}
@@ -303,7 +312,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.2.3"
+version = "2.3.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -324,7 +333,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -332,7 +341,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -340,7 +349,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "websocket"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina/Package.md
+++ b/ballerina/Package.md
@@ -986,5 +986,5 @@ type name {
 To report bugs, request new features, start new discussions, view project boards, etc., go to the [Ballerina standard library parent repository](https://github.com/ballerina-platform/ballerina-standard-library).
 
 ## Useful Links
-- Chat live with us via our [Slack channel](https://ballerina.io/community/slack/).
+- Chat live with us via our [Discord server](https://discord.gg/ballerinalang).
 - Post all technical questions on Stack Overflow with the [#ballerina](https://stackoverflow.com/questions/tagged/ballerina) tag.

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["gql", "network", "query", "service"]
 repository = "https://github.com/ballerina-platform/module-ballerina-graphql"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.2.0"
+distribution = "2201.3.0"
 
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [[#3062] Improve Compilation Error Messages To Be More Specific](https://github.com/ballerina-platform/ballerina-standard-library/issues/3062)
 - [[#2848] All the Errors Are Reported for a Given Document in a Single Response](https://github.com/ballerina-platform/ballerina-standard-library/issues/2848)
 - [[#3431] Introduce GraphQL Client Configuration](https://github.com/ballerina-platform/ballerina-standard-library/issues/3431)
+- [[#3463] Updated API Docs to Reflect Slack to Discord Migration](https://github.com/ballerina-platform/ballerina-standard-library/issues/3463)
 
 ## [1.4.1] - 2022-09-12
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -12,7 +12,7 @@ This is the specification for the GraphQL standard library of [Ballerina languag
 
 The GraphQL library specification has evolved and may continue to evolve in the future. The released versions of the specification can be found under the relevant GitHub tag.
 
-If you have any feedback or suggestions about the library, start a discussion via a [GitHub issue](https://github.com/ballerina-platform/ballerina-standard-library/issues) or in the [Slack channel](https://ballerina.io/community/). Based on the outcome of the discussion, the specification and implementation can be updated. Community feedback is always welcome. Any accepted proposal, which affects the specification is stored under `/docs/proposals`. Proposals under discussion can be found with the label `type/proposal` on GitHub.
+If you have any feedback or suggestions about the library, start a discussion via a [GitHub issue](https://github.com/ballerina-platform/ballerina-standard-library/issues) or in the [Discord server](https://discord.gg/ballerinalang). Based on the outcome of the discussion, the specification and implementation can be updated. Community feedback is always welcome. Any accepted proposal, which affects the specification is stored under `/docs/proposals`. Proposals under discussion can be found with the label `type/proposal` on GitHub.
 
 The conforming implementation of the specification is released and included in the distribution. Any deviation from the specification is considered a bug.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 version=1.5.0-SNAPSHOT
-ballerinaLangVersion=2201.2.0
+ballerinaLangVersion=2201.3.0-20221014-074800-bbf5f7a2
 
 checkstylePluginVersion=8.18
 spotbugsPluginVersion=4.5.1
@@ -11,32 +11,36 @@ releasePluginVersion=2.6.0
 testngVersion=7.4.0
 ballerinaGradlePluginVersion=0.14.1
 
-# Direct Dependencies
-stdlibAuthVersion=2.4.1-20220927-114400-615039d
-stdlibFileVersion=1.4.1-20220926-142300-9b48f88
-stdlibHttpVersion=2.4.1-20220928-131100-d539a2e
-stdlibIoVersion=1.3.0
-stdlibJwtVersion=2.4.1-20220926-140600-6b1756f
-stdlibOAuth2Version=2.4.1-20220928-092800-5ca4f8b
-stdlibRegexVersion=1.3.0
-stdlibUrlVersion=2.2.2
-stdlibWebsocketVersion=2.4.1-20220930-094900-3b7f650
-
-# Transitive Dependencies
+# Standard Library Dependencies
 # Level 01
-stdlibConstraintVersion=1.0.0
-stdlibTimeVersion=2.2.2
+stdlibConstraintVersion=1.0.1-20221012-153500-b7200cb
+stdlibIoVersion=1.3.1-20221013-104400-2228262
+stdlibRegexVersion=1.3.1-20221012-141600-b6ec370
+stdlibTimeVersion=2.2.3-20221013-110700-b1911b4
+stdlibUrlVersion=2.2.3-20221012-145800-3753746
 
 # Level 02
-stdlibCryptoVersion=2.2.3-20220921-105400-812e99d
-stdlibLogVersion=2.4.0
-stdlibOsVersion=1.4.1-20220923-100900-5935e0c
-stdlibTaskVersion=2.2.3-20220920-184600-c109457
+stdlibCryptoVersion=2.3.0-20221014-133300-0f584b5
+stdlibLogVersion=2.5.0-20221014-133600-ea6f498
+stdlibOsVersion=1.5.0-20221014-133500-f99ac89
+stdlibTaskVersion=2.3.0-20221014-133500-afca7e3
 
 # Level 03
-stdlibCacheVersion=3.3.0-20220926-104700-377cccd
-stdlibMimeVersion=2.4.0
-stdlibUuidVersion=1.3.1-20220926-130700-3e3e76b
+stdlibCacheVersion=3.4.0-20221014-150800-44fc45d
+stdlibFileVersion=1.5.0-20221014-140400-9a53e89
+stdlibMimeVersion=2.5.0-20221014-140900-ff6b57f
+stdlibUuidVersion=1.4.0-20221014-140700-0f68043
+
+# Level 04
+stdlibAuthVersion=2.5.0-20221014-153100-e83e5f7
+stdlibJwtVersion=2.5.0-20221014-153300-36ee0f4
+stdlibOAuth2Version=2.5.0-20221014-153400-ea71746
+
+# Level 06
+stdlibHttpVersion=2.5.0-20221014-181800-cf6925c
+
+# Level 07
+stdlibWebsocketVersion=2.5.0-20221017-094400-d271b77
 
 # Ballerinax Observer
 observeVersion=1.0.5


### PR DESCRIPTION
## Purpose
$Subject

- Rearranged the version order in the gradle.properties

Related Issue: [#3463](https://github.com/ballerina-platform/ballerina-standard-library/issues/3463)

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [ ] ~Added tests~
- [x] Updated the spec
- [ ] ~Checked native-image compatibility~
