### PR TITLE
Fix Allow to Attach a Service with Subscription to a Http2 Based Listener

### DIFF
--- a/ballerina-tests/tests/01_listener_test.bal
+++ b/ballerina-tests/tests/01_listener_test.bal
@@ -15,7 +15,9 @@
 // under the License.
 
 import ballerina/graphql;
+import ballerina/http;
 import ballerina/test;
+import ballerina/websocket;
 
 @test:Config {
     groups: ["listener", "configs"]
@@ -25,4 +27,123 @@ function testInvalidMaxQueryDepth() returns error? {
     test:assertTrue(result is graphql:Error);
     graphql:Error err = <graphql:Error>result;
     test:assertEquals(err.message(), "Max query depth value must be a positive integer");
+}
+
+@test:Config {
+    groups: ["listener"]
+}
+function testAttachServiceWithQueryToHttp2BasedListener() returns error? {
+    string document = string `query { person{ age } }`;
+    string url = "http://localhost:9190/service_with_http2";
+    json actualPayload = check getJsonPayloadFromService(url, document);
+    json expectedPayload = {
+        data: {
+            person: {
+                age: 50
+            }
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["listener"]
+}
+function testAttachServiceWithMutationToHttp2BasedListener() returns error? {
+    string document = string `mutation { setName(name: "Heisenberg") { name } }`;
+    string url = "http://localhost:9190/service_with_http2";
+    json actualPayload = check getJsonPayloadFromService(url, document);
+    json expectedPayload = {
+        data: {
+            setName: {
+                name: "Heisenberg"
+            }
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["listener"]
+}
+function testAttachServiceWithQueryToHttp1BasedListener() returns error? {
+    string document = string `query { person{ age } }`;
+    string url = "http://localhost:9191/service_with_http1";
+    json actualPayload = check getJsonPayloadFromService(url, document);
+    json expectedPayload = {
+        data: {
+            person: {
+                age: 50
+            }
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["listener"]
+}
+function testAttachServiceWithMutationToHttp1BasedListener() returns error? {
+    string document = string `mutation { setName(name: "Heisenberg") { name } }`;
+    string url = "http://localhost:9191/service_with_http1";
+    json actualPayload = check getJsonPayloadFromService(url, document);
+    json expectedPayload = {
+        data: {
+            setName: {
+                name: "Heisenberg"
+            }
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["listener", "client"]
+}
+function testAttachServiceWithQueryToHttp1BasedListenerAndClient() returns error? {
+    string document = string `query { person{ age } }`;
+    string url = "http://localhost:9191/service_with_http1";
+    json actualPayload = check getJsonPayloadFromService(url, document, httpVersion = http:HTTP_1_0);
+    json expectedPayload = {
+        data: {
+            person: {
+                age: 50
+            }
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["listener", "client"]
+}
+function testAttachServiceWithMutationToHttp1BasedListenerAndClient() returns error? {
+    string document = string `mutation { setName(name: "Heisenberg") { name } }`;
+    string url = "http://localhost:9191/service_with_http1";
+    json actualPayload = check getJsonPayloadFromService(url, document, httpVersion = http:HTTP_1_0);
+    json expectedPayload = {
+        data: {
+            setName: {
+                name: "Heisenberg"
+            }
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["listener"]
+}
+function testAttachServiceWithSubscriptionToHttp1BasedListener() returns error? {
+    string document = string `subscription { messages }`;
+    string url = "ws://localhost:9191/service_with_http1";
+    websocket:Client wsClient1 = check new(url);
+    websocket:Client wsClient2 = check new(url);
+    check writeWebSocketTextMessage(document, wsClient1);
+    check writeWebSocketTextMessage(document, wsClient2);
+    foreach int i in 1 ..< 4 {
+        json expectedPayload = {data: {messages: i}};
+        check validateWebSocketResponse(wsClient1, expectedPayload);
+        check validateWebSocketResponse(wsClient2, expectedPayload);
+    }
 }

--- a/ballerina-tests/tests/test_listeners.bal
+++ b/ballerina-tests/tests/test_listeners.bal
@@ -36,3 +36,9 @@ listener graphql:Listener subscriptionListener = new (9099);
 
 // The mock authorization server, based with https://hub.docker.com/repository/docker/ldclakmal/ballerina-sts
 listener http:Listener sts = new (9445, {secureSocket: {key: {path: KEYSTORE_PATH, password: "ballerina"}}});
+
+listener http:Listener http2Listener = new http:Listener(9190);
+listener graphql:Listener http2BasedListener = new (http2Listener);
+
+listener http:Listener http1Listener = new http:Listener(9191, httpVersion = http:HTTP_1_0);
+listener graphql:Listener http1BasedListener = new (http1Listener);

--- a/ballerina-tests/tests/test_services.bal
+++ b/ballerina-tests/tests/test_services.bal
@@ -1756,3 +1756,50 @@ service /reviews on wrappedListener {
         return [{details},{details: updatedDetails}].toStream();
     }
 }
+
+isolated service /service_with_http2 on http2BasedListener {
+    private Person p;
+    isolated function init() {
+        self.p = p2.clone();
+    }
+
+    isolated resource function get person() returns Person {
+        lock {
+            return self.p;
+        }
+    }
+
+    isolated remote function setName(string name) returns Person {
+        lock {
+            Person p = {name: name, age: self.p.age, address: self.p.address};
+            self.p = p;
+            return self.p;
+        }
+    }
+}
+
+isolated service /service_with_http1 on http1BasedListener {
+    private Person p;
+    isolated function init() {
+        self.p = p2.clone();
+    }
+
+    isolated resource function get person() returns Person {
+        lock {
+            return self.p;
+        }
+    }
+
+    isolated remote function setName(string name) returns Person {
+        lock {
+            Person p = {name: name, age: self.p.age, address: self.p.address};
+            self.p = p;
+            return self.p;
+        }
+    }
+
+    isolated resource function subscribe messages() returns stream<int, error?> {
+        int[] intArray = [1, 2, 3, 4, 5];
+        return intArray.toStream();
+    }
+}

--- a/ballerina-tests/tests/utils.bal
+++ b/ballerina-tests/tests/utils.bal
@@ -23,21 +23,21 @@ import ballerina/websocket;
 const CONTENT_TYPE_TEXT_HTML = "text/html";
 const CONTENT_TYPE_TEXT_PLAIN = "text/plain";
 
-isolated function getJsonPayloadFromService(string url, string document, json? variables = {}, string? operationName = ())
-returns json|error {
-    http:Client httpClient = check new(url, httpVersion = "1.1");
+isolated function getJsonPayloadFromService(string url, string document, json? variables = {}, string? operationName = (),
+                                            http:HttpVersion httpVersion = http:HTTP_1_1) returns json|error {
+    http:Client httpClient = check new(url, httpVersion = httpVersion);
     return httpClient->post("/", { query: document, operationName: operationName, variables: variables});
 }
 
 isolated function getTextPayloadFromService(string url, string document, json? variables = {}, string? operationName = ())
 returns string|error {
-    http:Client httpClient = check new(url, httpVersion = "1.1");
+    http:Client httpClient = check new(url, httpVersion = http:HTTP_1_1);
     http:Response response = check httpClient->post("/", { query: document, operationName: operationName, variables: variables});
     return response.getTextPayload();
 }
 
 isolated function getJsonPayloadFromRequest(string url, http:Request request) returns json|error {
-    http:Client httpClient = check new(url, httpVersion = "1.1");
+    http:Client httpClient = check new(url, httpVersion = http:HTTP_1_1);
     return httpClient->post("/", request);
 }
 
@@ -53,7 +53,7 @@ isolated function getGraphQLDocumentFromFile(string fileName) returns string|err
 
 isolated function getJsonPayloadFromBadRequest(string url, string document, json? variables = {}, string? operationName = ())
 returns json|error {
-    http:Client httpClient = check new(url, httpVersion = "1.1");
+    http:Client httpClient = check new(url, httpVersion = http:HTTP_1_1);
     http:Response response = check httpClient->post("/", { query: document, operationName: operationName, variables: variables});
     assertResponseForBadRequest(response);
     return response.getJsonPayload();
@@ -61,7 +61,7 @@ returns json|error {
 
 isolated function getTextPayloadFromBadService(string url, string document, json? variables = {}, string? operationName = ())
 returns string|error {
-    http:Client httpClient = check new(url, httpVersion = "1.1");
+    http:Client httpClient = check new(url, httpVersion = http:HTTP_1_1);
     http:Response response = check httpClient->post("/", { query: document, operationName: operationName, variables: variables});
     assertResponseForBadRequest(response);
     return response.getTextPayload();
@@ -69,14 +69,14 @@ returns string|error {
 
 isolated function assertResponseAndGetPayload(string url, string document, json? variables = {},
 string? operationName = (), int statusCode = http:STATUS_OK) returns json|error {
-    http:Client httpClient = check new(url, httpVersion = "1.1");
+    http:Client httpClient = check new(url, httpVersion = http:HTTP_1_1);
     http:Response response = check httpClient->post("/", { query: document, operationName: operationName, variables: variables});
     test:assertEquals(response.statusCode, statusCode);
     return response.getJsonPayload();
 }
 
 isolated function getTextPayloadFromBadRequest(string url, http:Request request) returns string|error {
-    http:Client httpClient = check new(url, httpVersion = "1.1");
+    http:Client httpClient = check new(url, httpVersion = http:HTTP_1_1);
     http:Response response = check httpClient->post("/", request);
     assertResponseForBadRequest(response);
     return response.getTextPayload();

--- a/ballerina/listener.bal
+++ b/ballerina/listener.bal
@@ -16,6 +16,7 @@
 
 import ballerina/http;
 import ballerina/websocket;
+import ballerina/io;
 
 # Represents a Graphql listener endpoint.
 public class Listener {
@@ -30,7 +31,7 @@ public class Listener {
     # + return - A `graphql:Error` if the listener initialization is failed or else `()`
     public isolated function init(int|http:Listener listenTo, *ListenerConfiguration configuration)
     returns Error? {
-        configuration.httpVersion = "1.1";
+        configuration.httpVersion = http:HTTP_1_1;
         if listenTo is int {
             http:Listener|error httpListener = new (listenTo, configuration);
             if httpListener is error {
@@ -85,6 +86,13 @@ public class Listener {
         __Schema & readonly schema = engine.getSchema();
         __Type? subscriptionType = schema.subscriptionType;
         if subscriptionType is __Type && self.wsListener is () {
+            string httpVersion = self.httpListener.getConfig().httpVersion;
+            io:println(httpVersion);
+            if httpVersion !is http:HTTP_1_1|http:HTTP_1_0 {
+                string message = string `Websocket listener initialization failed due to the incompatibility of ` +
+                                 string `provided HTTP(version ${httpVersion}) listener`;
+                return error Error(message);
+            }
             websocket:Listener|error wsListener = new(self.httpListener);
             if wsListener is error {
                 return error Error("Websocket listener initialization failed", wsListener);

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - [[#3466] Fix Resolver Returning Null when a Record has a Service Object as its Field](https://github.com/ballerina-platform/ballerina-standard-library/issues/3466)
 - [[#3579] Resolver Produces Null when Resolver Returns a Record Containing a Map of Service Objects as its Field](https://github.com/ballerina-platform/ballerina-standard-library/issues/3579)
+- [[#3062] Fix Allow to Attach a Service with Subscription to a HTTP2 Based Listener](https://github.com/ballerina-platform/ballerina-standard-library/issues/3601)
 
 ## [1.4.4] - 2022-10-31
 


### PR DESCRIPTION
## Purpose

Fixes: [#3601](https://github.com/ballerina-platform/ballerina-standard-library/issues/3601)

Tests for services with subscription operations are not added in the PR due to the https://github.com/ballerina-platform/ballerina-standard-library/issues/3294 fix not being available in the 2201.2.x branch.

## Examples
N/A

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~
