### PR TITLE
Increase Java heap size for native test workflow

### DIFF
--- a/.github/workflows/build-with-bal-test-native.yml
+++ b/.github/workflows/build-with-bal-test-native.yml
@@ -26,6 +26,6 @@ jobs:
         with:
             lang_tag: ${{ inputs.lang_tag }}
             lang_version: ${{ inputs.lang_version }}
-            native_image_options: ${{ inputs.native_image_options }}
+            native_image_options: '-J-Xmx7G ${{ inputs.native_image_options }}'
             additional_ubuntu_build_flags: '-x :graphql-compiler-plugin-tests:test'
             additional_windows_build_flags: '-x :graphql-compiler-plugin-tests:test'


### PR DESCRIPTION
## Purpose

GraphQL tests requires about 6.2GB of memory to build the GraalVM native image. The GitHub runner only have 7GB memory, and, by default, about 80% of that memory (5.8GB) is available for native image builder. In this PR, the maximum Java heap size for native image builder is increased to 7GB.

Fixes : `Build with bal test native` workflow failure due to OOM

Workflow run with this fix : https://github.com/ballerina-platform/module-ballerina-graphql/actions/runs/3581779235

## Examples

N/A

## Checklist
- [ ] <s>Linked to an issue</s>
- [ ] <s>Updated the changelog</s>
- [ ] <s>Added tests</s>
- [ ] <s>Updated the spec</s>
- [ ] <s>Checked native-image compatibility</s>
