### PR TITLE
Fix Allowing the use of Non-Distinct Service Objects as GraphQL Interfaces

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [[#3865] Fix Incomplete Type Info Given in Compiler Errors Issued from GraphQL Compiler Plugin](https://github.com/ballerina-platform/ballerina-standard-library/issues/3865)
 - [[#3721] Fix Passing Incorrect Values when a Resolver Method has an Enum as Input Parameter](https://github.com/ballerina-platform/ballerina-standard-library/issues/3721)
 - [[#4038] Fix `__typename` Introspection not Working on Introspection Types](https://github.com/ballerina-platform/ballerina-standard-library/issues/4038)
+- [[#3337] Fix Allowing the use of non-distinct Service Objects as GraphQL Interfaces](https://github.com/ballerina-platform/ballerina-standard-library/issues/3337)
 
 ### Changed
 - [[#3430] Parallelise GraphQL Document Validation](https://github.com/ballerina-platform/ballerina-standard-library/issues/3430)

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceValidationTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceValidationTest.java
@@ -245,7 +245,7 @@ public class ServiceValidationTest {
     public void testInvalidReturnTypes() {
         String packagePath = "27_invalid_return_types";
         DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
-        Assert.assertEquals(diagnosticResult.errorCount(), 17);
+        Assert.assertEquals(diagnosticResult.errorCount(), 18);
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
 
         Diagnostic diagnostic = diagnosticIterator.next();
@@ -293,6 +293,10 @@ public class ServiceValidationTest {
         assertErrorMessage(diagnostic, message, 74, 5);
 
         diagnostic = diagnosticIterator.next();
+        message = getErrorMessage(CompilationDiagnostic.NON_DISTINCT_INTERFACE, "Interceptor");
+        assertErrorMessage(diagnostic, message, 93, 5);
+
+        diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_FUNCTION, "Interceptor", "execute");
         assertErrorMessage(diagnostic, message, 75, 5);
 
@@ -302,7 +306,7 @@ public class ServiceValidationTest {
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.NON_DISTINCT_INTERFACE_IMPLEMENTATION, "ServiceInterceptor");
-        assertErrorMessage(diagnostic, message, 93, 5);
+        assertErrorMessage(diagnostic, message, 83, 24);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_SUBSCRIBE_RESOURCE_RETURN_TYPE, "int", "foo");
@@ -873,19 +877,25 @@ public class ServiceValidationTest {
         Assert.assertEquals(diagnosticResult.errorCount(), 1);
         Diagnostic diagnostic = diagnosticResult.errors().iterator().next();
         String message = getErrorMessage(CompilationDiagnostic.NON_DISTINCT_INTERFACE_IMPLEMENTATION, "Teacher");
-        assertErrorMessage(diagnostic, message, 20, 5);
+        assertErrorMessage(diagnostic, message, 59, 31);
     }
 
-    @Test(groups = "invalid", enabled = false)
+    @Test(groups = "invalid")
     public void testNonDistinctInterface() {
         // TODO: check for non distinct object
         // https://github.com/ballerina-platform/ballerina-standard-library/issues/3337
         String packagePath = "53_non_distinct_interface";
         DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
-        Assert.assertEquals(diagnosticResult.errorCount(), 1);
-        Diagnostic diagnostic = diagnosticResult.errors().iterator().next();
-        String message = "Non-distinct service class `Person` is used as a GraphQL interface";
+        Assert.assertEquals(diagnosticResult.errorCount(), 2);
+        Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
+
+        Diagnostic diagnostic = diagnosticIterator.next();
+        String message = getErrorMessage(CompilationDiagnostic.NON_DISTINCT_INTERFACE, "Person");
         assertErrorMessage(diagnostic, message, 20, 5);
+
+        diagnostic = diagnosticIterator.next();
+        message = getErrorMessage(CompilationDiagnostic.NON_DISTINCT_INTERFACE_IMPLEMENTATION, "Teacher");
+        assertErrorMessage(diagnostic, message, 59, 31);
     }
 
     @Test(groups = "invalid")

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/53_non_distinct_interface/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/53_non_distinct_interface/service.bal
@@ -19,7 +19,7 @@ import ballerina/graphql;
 service /graphql on new graphql:Listener(4000) {
     isolated resource function get name(int id) returns Person {
         if id < 10 {
-        return new Student("Jesse Pinkman", 25, "student-1");
+            return new Student("Jesse Pinkman", 25, "student-1");
         }
         return new Teacher("Walter White", 52, "teacher-1", "Chemistry");
     }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/CompilationDiagnostic.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/CompilationDiagnostic.java
@@ -41,6 +41,7 @@ public enum CompilationDiagnostic {
     INVALID_RETURN_TYPE_INPUT_OBJECT(DiagnosticMessage.ERROR_114, DiagnosticCode.GRAPHQL_114, DiagnosticSeverity.ERROR),
     INVALID_RESOURCE_INPUT_OBJECT_PARAM(DiagnosticMessage.ERROR_115, DiagnosticCode.GRAPHQL_115,
                                         DiagnosticSeverity.ERROR),
+    NON_DISTINCT_INTERFACE(DiagnosticMessage.ERROR_116, DiagnosticCode.GRAPHQL_116, DiagnosticSeverity.ERROR),
     INVALID_PATH_PARAMETERS(DiagnosticMessage.ERROR_117, DiagnosticCode.GRAPHQL_117, DiagnosticSeverity.ERROR),
     INVALID_RESOURCE_PATH(DiagnosticMessage.ERROR_118, DiagnosticCode.GRAPHQL_118, DiagnosticSeverity.ERROR),
     INVALID_FILE_UPLOAD_IN_RESOURCE_FUNCTION(DiagnosticMessage.ERROR_119, DiagnosticCode.GRAPHQL_119,

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/DiagnosticCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/DiagnosticCode.java
@@ -37,6 +37,7 @@ public enum DiagnosticCode {
     GRAPHQL_113,
     GRAPHQL_114,
     GRAPHQL_115,
+    GRAPHQL_116,
     GRAPHQL_117,
     GRAPHQL_118,
     GRAPHQL_119,

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/DiagnosticMessage.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/DiagnosticMessage.java
@@ -49,6 +49,7 @@ public enum DiagnosticMessage {
                       + "type as an output type"),
     ERROR_115("the GraphQL field ''{0}'' use output type ''{1}'' as an input type. A GraphQL field cannot use an output"
                       + " type as an input type"),
+    ERROR_116("non-distinct service class ''{0}'' is used as a GraphQL interface"),
     ERROR_117("found path parameters ''{0}'' in GraphQL resource. Path parameters are not allowed in GraphQL "
                       + "resources"),
     ERROR_118("invalid resource path ''{0}'' found in GraphQL resource"),

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -862,6 +862,8 @@ In GraphQL, an interface can be used to define a set of common fields for object
 
 In Ballerina, `distinct` `service` objects can be used to define GraphQL interfaces. The other `distinct` `service` classes can be used to implement the interface. All the service classes that are implementing the interface must provide the implementation for all resource methods declared in the interface, and they can define additional resource methods.
 
+Non-distinct `service` objects and `service` classes can not be used to define or implement GraphQL interfaces.
+
 ###### Example: Interfaces
 ```ballerina
 public type Profile distinct service object {
@@ -910,6 +912,35 @@ public isolated distinct service class Teacher {
 ```
 
 In the above example, the `Profile` object is an interface. The `Student` and `Teacher` classes are `Object` types that implement the `Profile` interface.
+
+###### Counter Example: Invalid Interfaces
+
+```ballerina
+public type Profile service object {
+    resource function get name() returns string;
+};
+
+public isolated service class Student {
+    *Profile;
+    final string name;
+    final int id;
+
+    isolated function init(string name, int id) {
+        self.name = name;
+        self.id = id;
+    }
+
+    isolated resource function get name() returns string {
+        return self.name;
+    }
+
+    isolated resource function get id() returns int {
+        return self.id;
+    }
+}
+```
+
+The above example results in a compilation error because the `Profile` object is not a `distinct` object, and the `Student` class is not a `distinct` class.
 
 #### 4.6.1 Interfaces Implementing Interfaces
 


### PR DESCRIPTION
## Purpose

$Subject

Fixes: [#3337](https://github.com/ballerina-platform/ballerina-standard-library/issues/3337)

## Examples

N/A

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
- [x] Checked native-image compatibility
