### PR TITLE
Fix context and Field Object Parameter Ordering Issue

### DIFF
--- a/ballerina-tests/tests/39_field_object.bal
+++ b/ballerina-tests/tests/39_field_object.bal
@@ -68,3 +68,38 @@ function testFieldObjectUsingFragments() returns error? {
     };
     assertJsonValuesWithOrder(actualPayload, expectedPayload);
 }
+
+@test:Config {
+    groups: ["field-object"]
+}
+function testFieldObjectParameterOrder() returns error? {
+    string document = check getGraphQLDocumentFromFile("field_object_parameter_order.graphql");
+    string url = "localhost:9092/service_objects";
+    json actualPayload = check getJsonPayloadFromService(url, document, operationName = "FieldObjectParameterOrder1");
+    json expectedPayload = {
+        data: {
+            student: {
+                name: "Jesse Pinkman"
+            }
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}
+
+@test:Config {
+    groups: ["field-object"]
+}
+function testFieldObjectParameterOrder2() returns error? {
+    string document = check getGraphQLDocumentFromFile("field_object_parameter_order.graphql");
+    string url = "localhost:9092/service_objects";
+    json actualPayload = check getJsonPayloadFromService(url, document, operationName = "FieldObjectParameterOrder2");
+    json expectedPayload = {
+        data: {
+            student: {
+                name: "Skinny Pete",
+                id: 100
+            }
+        }
+    };
+    assertJsonValuesWithOrder(actualPayload, expectedPayload);
+}

--- a/ballerina-tests/tests/resources/documents/field_object_parameter_order.graphql
+++ b/ballerina-tests/tests/resources/documents/field_object_parameter_order.graphql
@@ -1,0 +1,12 @@
+query FieldObjectParameterOrder1 {
+    student(name: "Skinny Pete", id: 100) {
+        name
+    }
+}
+
+query FieldObjectParameterOrder2 {
+    student(name: "Skinny Pete", id: 100) {
+        name
+        id
+    }
+}

--- a/ballerina-tests/tests/resources/expected_results/complex_introspection_query.json
+++ b/ballerina-tests/tests/resources/expected_results/complex_introspection_query.json
@@ -35,6 +35,10 @@
                     "kind": "ENUM"
                 },
                 {
+                    "name": "StudentService",
+                    "kind": "OBJECT"
+                },
+                {
                     "name": "String",
                     "kind": "SCALAR"
                 },

--- a/ballerina-tests/tests/resources/expected_results/complex_introspection_query_with_other_fields.json
+++ b/ballerina-tests/tests/resources/expected_results/complex_introspection_query_with_other_fields.json
@@ -35,6 +35,10 @@
                     "kind": "ENUM"
                 },
                 {
+                    "name": "StudentService",
+                    "kind": "OBJECT"
+                },
+                {
                     "name": "String",
                     "kind": "SCALAR"
                 },

--- a/ballerina-tests/tests/test_services.bal
+++ b/ballerina-tests/tests/test_services.bal
@@ -563,6 +563,17 @@ service /service_objects on serviceTypeListener {
     isolated resource function get teacher() returns TeacherService {
         return new TeacherService(737, "Walter White", "Chemistry");
     }
+
+    isolated resource function get student(string name, graphql:Context context, int id,
+            graphql:Field 'field) returns StudentService {
+        if context.get("scope") is error {
+            // ignore
+        }
+        if 'field.getSubfieldNames().indexOf("id") is int {
+            return new StudentService(id, name);
+        }
+        return new StudentService(10, "Jesse Pinkman");
+    }
 }
 
 service /timeoutService on timeoutListener {
@@ -1921,21 +1932,21 @@ graphql:Service greetingService2 = @graphql:ServiceConfig {maxQueryDepth: 5} ser
 service /covid19 on basicListener {
     resource function get all() returns table<CovidEntry> {
         table<CovidEntry> covidEntryTable = table [
-                {isoCode: "AFG"},
-                {isoCode: "SL"},
-                {isoCode: "US"}
-            ];
+            {isoCode: "AFG"},
+            {isoCode: "SL"},
+            {isoCode: "US"}
+        ];
         return covidEntryTable;
     }
 }
 
 table<Review> reviews = table [
-        {product: new ("1"), score: 20, description: "Product 01"},
-        {product: new ("2"), score: 20, description: "Product 02"},
-        {product: new ("3"), score: 20, description: "Product 03"},
-        {product: new ("4"), score: 20, description: "Product 04"},
-        {product: new ("5"), score: 20, description: "Product 05"}
-    ];
+    {product: new ("1"), score: 20, description: "Product 01"},
+    {product: new ("2"), score: 20, description: "Product 02"},
+    {product: new ("3"), score: 20, description: "Product 03"},
+    {product: new ("4"), score: 20, description: "Product 04"},
+    {product: new ("5"), score: 20, description: "Product 05"}
+];
 
 service /reviews on wrappedListener {
     resource function get latest() returns Review {
@@ -1964,7 +1975,7 @@ service /reviews on wrappedListener {
         map<AccountDetails> details = {acc1: new AccountDetails("James", 2022), acc2: new AccountDetails("Paul", 2015)};
         map<AccountDetails> updatedDetails = {...details};
         updatedDetails["acc1"] = new AccountDetails("James Deen", 2022);
-        return [{details},{details: updatedDetails}].toStream();
+        return [{details}, {details: updatedDetails}].toStream();
     }
 }
 

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/ArgumentHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/ArgumentHandler.java
@@ -214,12 +214,12 @@ public class ArgumentHandler {
         Object[] result = new Object[parameters.length * 2];
         for (int i = 0, j = 0; i < parameters.length; i += 1, j += 2) {
             if (isContext(parameters[i].type)) {
-                result[i] = this.context;
+                result[j] = this.context;
                 result[j + 1] = true;
                 continue;
             }
             if (isField(parameters[i].type)) {
-                result[i] = this.field;
+                result[j] = this.field;
                 result[j + 1] = true;
                 continue;
             }


### PR DESCRIPTION
## Purpose

This is to fix the issue where the `graphql:Context` and `graphql:Field` object parameters are not populated properly when they are added after the other parameters. Found this issue when testing with the SwanLake Update 4 RC1. 

An issue was not created because the issue is part of the feature that is intended to ship with this release. This issue hasn't been affected anything. 

## Examples

## Checklist
- [ ] ~Linked to an issue~
- [ ] ~Updated the changelog~
- [x] Added tests
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~
