### PR TITLE
[DO NOT MERGE] Update lang version after reverting lang pull 39568

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 version=1.6.0-SNAPSHOT
-ballerinaLangVersion=2201.4.0-20230213-151200-6d175fd1
+ballerinaLangVersion=2201.4.0-20230214-120800-e519fdeb
 
 checkstylePluginVersion=8.18
 spotbugsPluginVersion=4.5.1


### PR DESCRIPTION
## Purpose

With the previous lang bump, the code coverage of the grapql significantly dropped. Hence a new lang timestamp with https://github.com/ballerina-platform/ballerina-lang/pull/39568 reverted is applied.

Fixes:

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
