### PR TITLE
chore(ci): use ** for wildcard directory

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 fixes:
-    - "ballerina/graphql/*/::../ballerina/"
+    - "ballerina/graphql/**/::../ballerina/"
 
 ignore:
     - "ballerina-tests"


### PR DESCRIPTION
## Purpose

Fixes:
Unexplained coode coverage drop (see [Codecov community post](https://community.codecov.com/t/coverage-dropped-by-60-after-merging-a-commit/4129/16))

You can see the fix implemented [here](https://github.com/thomasrockhu-codecov/module-ballerina-graphql/pull/2)

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
