### PR TITLE
[2201.4.x] Fix compilation failure when type alias is used with primitive type

### DIFF
--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -290,7 +290,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -285,7 +285,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [[#3721] Fix Passing Incorrect Values when a Resolver Method has an Enum as Input Parameter](https://github.com/ballerina-platform/ballerina-standard-library/issues/3721)
 - [[#4038] Fix `__typename` Introspection not Working on Introspection Types](https://github.com/ballerina-platform/ballerina-standard-library/issues/4038)
 - [[#3337] Fix Allowing the use of non-distinct Service Objects as GraphQL Interfaces](https://github.com/ballerina-platform/ballerina-standard-library/issues/3337)
+- [[#4172] Fix Compilation Failure when Type Alias is Used with Primitive type](https://github.com/ballerina-platform/ballerina-standard-library/issues/4172)
 
 ### Changed
 - [[#3430] Parallelise GraphQL Document Validation](https://github.com/ballerina-platform/ballerina-standard-library/issues/3430)

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceValidationTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceValidationTest.java
@@ -1013,6 +1013,23 @@ public class ServiceValidationTest {
         assertErrorMessage(diagnostic, message, 112, 5);
     }
 
+    @Test(groups = "invalid")
+    public void testUnsupportedPrimitiveTypeAlias() {
+        String packagePath = "59_unsupported_primitive_type_alias";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
+        Assert.assertEquals(diagnosticResult.errorCount(), 2);
+        Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
+
+        Diagnostic diagnostic = diagnosticIterator.next();
+        String message = getErrorMessage(CompilationDiagnostic.UNSUPPORTED_PRIMITIVE_TYPE_ALIAS, "Id", "int");
+        // error message for return type with primitive type alias
+        assertErrorMessage(diagnostic, message, 19, 6);
+
+        diagnostic = diagnosticIterator.next();
+        // a duplicate error message is expected for input type with primitive type alias
+        assertErrorMessage(diagnostic, message, 19, 6);
+    }
+
     private DiagnosticResult getDiagnosticResult(String packagePath) {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve(packagePath);
         BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath);

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/59_unsupported_primitive_type_alias/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/59_unsupported_primitive_type_alias/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "graphql_test"
+name = "test_package"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/59_unsupported_primitive_type_alias/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/59_unsupported_primitive_type_alias/service.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/graphql;
+
+type Id int;
+
+service on new graphql:Listener(4000) {
+    resource function get id(Id id) returns Id {
+        return id;
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/Utils.java
@@ -213,4 +213,23 @@ public final class Utils {
         return node.kind() == SyntaxKind.RESOURCE_ACCESSOR_DEFINITION
                 || node.kind() == SyntaxKind.OBJECT_METHOD_DEFINITION;
     }
+
+    public static boolean isPrimitiveTypeSymbol(TypeSymbol typeSymbol) {
+        switch (typeSymbol.typeKind()) {
+            case INT:
+            case INT_SIGNED8:
+            case INT_UNSIGNED8:
+            case INT_SIGNED16:
+            case INT_UNSIGNED16:
+            case INT_SIGNED32:
+            case INT_UNSIGNED32:
+            case STRING:
+            case STRING_CHAR:
+            case BOOLEAN:
+            case DECIMAL:
+            case FLOAT:
+                return true;
+        }
+        return false;
+    }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/CompilationDiagnostic.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/CompilationDiagnostic.java
@@ -63,7 +63,8 @@ public enum CompilationDiagnostic {
                                              DiagnosticSeverity.ERROR),
     INVALID_ANONYMOUS_FIELD_TYPE(DiagnosticMessage.ERROR_130, DiagnosticCode.GRAPHQL_130, DiagnosticSeverity.ERROR),
     INVALID_ANONYMOUS_INPUT_TYPE(DiagnosticMessage.ERROR_131, DiagnosticCode.GRAPHQL_131, DiagnosticSeverity.ERROR),
-    INVALID_RETURN_TYPE_CLASS(DiagnosticMessage.ERROR_132, DiagnosticCode.GRAPHQL_132, DiagnosticSeverity.ERROR);
+    INVALID_RETURN_TYPE_CLASS(DiagnosticMessage.ERROR_132, DiagnosticCode.GRAPHQL_132, DiagnosticSeverity.ERROR),
+    UNSUPPORTED_PRIMITIVE_TYPE_ALIAS(DiagnosticMessage.ERROR_133, DiagnosticCode.GRAPHQL_133, DiagnosticSeverity.ERROR);
 
     private final String diagnostic;
     private final String diagnosticCode;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/DiagnosticCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/DiagnosticCode.java
@@ -53,5 +53,6 @@ public enum DiagnosticCode {
     GRAPHQL_129,
     GRAPHQL_130,
     GRAPHQL_131,
+    GRAPHQL_133,
     GRAPHQL_132
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/DiagnosticMessage.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/DiagnosticMessage.java
@@ -70,7 +70,8 @@ public enum DiagnosticMessage {
     ERROR_129("invalid remote method ''{0}'' found in interceptor service. Only \"execute\" remote method is allowed"),
     ERROR_130("anonymous record ''{0}'' cannot be used as the type of the field ''{1}''"),
     ERROR_131("anonymous record ''{0}'' cannot be used as an input object type of the field ''{1}''"),
-    ERROR_132("invalid return type ''{0}'' provided for the GraphQL field ''{1}''. ''{0}'' is not a service class");
+    ERROR_132("invalid return type ''{0}'' provided for the GraphQL field ''{1}''. ''{0}'' is not a service class"),
+    ERROR_133("failed to generate schema for type ''{0}''. Type alias for primitive type ''{1}'' is not supported");
 
     private final String message;
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/service/validator/ServiceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/service/validator/ServiceValidator.java
@@ -65,6 +65,7 @@ import static io.ballerina.stdlib.graphql.compiler.Utils.getEffectiveTypes;
 import static io.ballerina.stdlib.graphql.compiler.Utils.isDistinctServiceClass;
 import static io.ballerina.stdlib.graphql.compiler.Utils.isDistinctServiceReference;
 import static io.ballerina.stdlib.graphql.compiler.Utils.isFileUploadParameter;
+import static io.ballerina.stdlib.graphql.compiler.Utils.isPrimitiveTypeSymbol;
 import static io.ballerina.stdlib.graphql.compiler.Utils.isRemoteMethod;
 import static io.ballerina.stdlib.graphql.compiler.Utils.isResourceMethod;
 import static io.ballerina.stdlib.graphql.compiler.Utils.isServiceClass;
@@ -393,6 +394,11 @@ public class ServiceValidator {
             validateReturnType(recordTypeSymbol, typeReferenceTypeSymbol.typeDescriptor(), location, recordName);
         } else if (typeReferenceTypeSymbol.typeDescriptor().typeKind() == TypeDescKind.OBJECT) {
             validateReturnTypeObject(typeDefinitionSymbol, location);
+        } else if (isPrimitiveTypeSymbol(typeReferenceTypeSymbol.typeDescriptor())) {
+            // noinspection OptionalGetWithoutIsPresent
+            addDiagnostic(CompilationDiagnostic.UNSUPPORTED_PRIMITIVE_TYPE_ALIAS,
+                          getLocation(typeReferenceTypeSymbol, location), typeReferenceTypeSymbol.getName().get(),
+                          typeReferenceTypeSymbol.typeDescriptor().typeKind().getName());
         } else {
             validateReturnType(typeDefinitionSymbol.typeDescriptor(), location);
         }
@@ -579,6 +585,12 @@ public class ServiceValidator {
             // noinspection OptionalGetWithoutIsPresent
             String typeName = typeDefinition.getName().get();
             validateInputParameterType((RecordTypeSymbol) typeDescriptor, location, typeName, isResourceMethod);
+            return;
+        }
+        if (isPrimitiveTypeSymbol(typeDescriptor)) {
+            // noinspection OptionalGetWithoutIsPresent
+            addDiagnostic(CompilationDiagnostic.UNSUPPORTED_PRIMITIVE_TYPE_ALIAS, getLocation(typeSymbol, location),
+                          typeSymbol.getName().get(), typeDescriptor.typeKind().getName());
             return;
         }
         validateInputParameterType(typeDescriptor, location, isResourceMethod);


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/4172

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
