### PR TITLE
Remove unnecessary init method in the service

### DIFF
--- a/examples/starwars/service.bal
+++ b/examples/starwars/service.bal
@@ -46,10 +46,6 @@ public type ReviewInput record {|
 service /graphql on new graphql:Listener(9090) {
     private final pubsub:PubSub pubsub = new;
 
-    function init() returns error? {
-        check self.pubsub.createTopic("reviews");
-    }
-
     # Fetch the hero of the Star Wars
     # + return - The hero
     resource function get hero(Episode? episode) returns Character {


### PR DESCRIPTION
## Purpose
$Subject

We don't need to create the topic manually since the PubSub will create topics automatically.

## Examples
N/A

## Checklist
- [ ] ~Linked to an issue~
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~
