### PR TITLE
Add support for GraphQL ID scalar type

### DIFF
--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -18,6 +18,14 @@ import ballerina/http;
 import ballerina/io;
 import ballerina/websocket;
 
+// Types allowed to have as the ID type.
+public type IdTypes record {|
+    string|int id = "default";
+|};
+
+// Represents the annotation of the ID type.
+public annotation IdTypes ID on field, record field, parameter, return;
+
 # Represents the Scalar types supported by the Ballerina GraphQL module.
 public type Scalar boolean|int|float|string|decimal;
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceValidationTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceValidationTest.java
@@ -298,7 +298,7 @@ public class ServiceValidationTest {
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_FUNCTION, "Interceptor", "execute");
-        assertErrorMessage(diagnostic, message, 75, 5);
+        assertErrorMessage(diagnostic, message, 85, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.MISSING_RESOURCE_FUNCTIONS);

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/generator_tests/04_union_types/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/generator_tests/04_union_types/service.bal
@@ -44,9 +44,9 @@ type Person Teacher|Student;
 # Represents a Student as a class.
 public isolated distinct service class Student {
     final string name;
-    final int id;
+    @graphql:ID final int id;
 
-    isolated function init(string name, int id) {
+    isolated function init(string name, @graphql:ID int id) {
         self.name = name;
         self.id = id;
     }
@@ -55,7 +55,7 @@ public isolated distinct service class Student {
         return self.name;
     }
 
-    isolated resource function get id() returns int {
+    isolated resource function get id() returns @graphql:ID int {
         return self.id;
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/generator_tests/23_federated_subgraph/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/generator_tests/23_federated_subgraph/service.bal
@@ -47,6 +47,6 @@ distinct service class User {
     }
 }
 type App record {
-    int id;
+    @graphql:ID int id;
     string name;
 };

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/18_interfaces/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/18_interfaces/service.bal
@@ -17,9 +17,9 @@
 import ballerina/graphql;
 
 service /graphql on new graphql:Listener(4000) {
-    isolated resource function get name(int id) returns Person {
+    isolated resource function get name(@graphql:ID int id) returns Person {
         if id < 10 {
-        return new Student("Jesse Pinkman", 25, "student-1");
+            return new Student("Jesse Pinkman", 25, "student-1");
         }
         return new Teacher("Walter White", 52, "teacher-1", "Chemistry");
     }
@@ -34,10 +34,10 @@ public isolated distinct service class Student {
     *Person;
 
     final string name;
-    final string id;
+    @graphql:ID final string id;
     final int age;
 
-    isolated function init(string name, int age, string id) {
+    isolated function init(string name, int age, @graphql:ID string id) {
         self.name = name;
         self.age = age;
         self.id = id;
@@ -51,7 +51,7 @@ public isolated distinct service class Student {
         return self.age;
     }
 
-    isolated resource function get id() returns string {
+    isolated resource function get id() returns @graphql:ID string {
         return self.id;
     }
 }
@@ -60,11 +60,11 @@ public isolated distinct service class Teacher {
     *Person;
 
     final string name;
-    final string id;
+    @graphql:ID final string id;
     final int age;
     final string subject;
 
-    isolated function init(string name, int age, string id, string subject) {
+    isolated function init(string name, int age, @graphql:ID string id, string subject) {
         self.name = name;
         self.age = age;
         self.id = id;
@@ -79,7 +79,7 @@ public isolated distinct service class Teacher {
         return self.age;
     }
 
-    isolated resource function get id() returns string {
+    isolated resource function get id() returns @graphql:ID string {
         return self.id;
     }
 

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/19_interfaces_implementing_interfaces/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/19_interfaces_implementing_interfaces/service.bal
@@ -17,7 +17,7 @@
 import ballerina/graphql;
 
 service /graphql on new graphql:Listener(4000) {
-    isolated resource function get name(int id) returns Animal {
+    isolated resource function get name(@graphql:ID int id) returns Animal {
         return new Dog("Lassie");
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/20_multiple_interface_implementations/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/20_multiple_interface_implementations/service.bal
@@ -17,7 +17,7 @@
 import ballerina/graphql;
 
 service /graphql on new graphql:Listener(4000) {
-    isolated resource function get name(int id) returns Animal {
+    isolated resource function get name(@graphql:ID int id) returns Animal {
         return new Dog("Lassie", "Sam");
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/52_non_distinct_interface_implementation/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/52_non_distinct_interface_implementation/service.bal
@@ -17,9 +17,9 @@
 import ballerina/graphql;
 
 service /graphql on new graphql:Listener(4000) {
-    isolated resource function get name(int id) returns Person {
+    isolated resource function get name(@graphql:ID int id) returns Person {
         if id < 10 {
-        return new Student("Jesse Pinkman", 25, "student-1");
+            return new Student("Jesse Pinkman", 25, "student-1");
         }
         return new Teacher("Walter White", 52, "teacher-1", "Chemistry");
     }
@@ -34,10 +34,10 @@ public isolated distinct service class Student {
     *Person;
 
     final string name;
-    final string id;
+    @graphql:ID final string id;
     final int age;
 
-    isolated function init(string name, int age, string id) {
+    isolated function init(string name, int age, @graphql:ID string id) {
         self.name = name;
         self.age = age;
         self.id = id;
@@ -51,7 +51,7 @@ public isolated distinct service class Student {
         return self.age;
     }
 
-    isolated resource function get id() returns string {
+    isolated resource function get id() returns @graphql:ID string {
         return self.id;
     }
 }
@@ -60,11 +60,11 @@ public isolated service class Teacher {
     *Person;
 
     final string name;
-    final string id;
+    @graphql:ID final string id;
     final int age;
     final string subject;
 
-    isolated function init(string name, int age, string id, string subject) {
+    isolated function init(string name, int age, @graphql:ID string id, string subject) {
         self.name = name;
         self.age = age;
         self.id = id;
@@ -79,7 +79,7 @@ public isolated service class Teacher {
         return self.age;
     }
 
-    isolated resource function get id() returns string {
+    isolated resource function get id() returns @graphql:ID string {
         return self.id;
     }
 

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/53_non_distinct_interface/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/53_non_distinct_interface/service.bal
@@ -17,7 +17,7 @@
 import ballerina/graphql;
 
 service /graphql on new graphql:Listener(4000) {
-    isolated resource function get name(int id) returns Person {
+    isolated resource function get name(@graphql:ID int id) returns Person {
         if id < 10 {
             return new Student("Jesse Pinkman", 25, "student-1");
         }
@@ -34,10 +34,10 @@ public isolated distinct service class Student {
     *Person;
 
     final string name;
-    final string id;
+    @graphql:ID final string id;
     final int age;
 
-    isolated function init(string name, int age, string id) {
+    isolated function init(string name, int age, @graphql:ID string id) {
         self.name = name;
         self.age = age;
         self.id = id;
@@ -51,7 +51,7 @@ public isolated distinct service class Student {
         return self.age;
     }
 
-    isolated resource function get id() returns string {
+    isolated resource function get id() returns @graphql:ID string {
         return self.id;
     }
 }
@@ -60,11 +60,11 @@ public isolated service class Teacher {
     *Person;
 
     final string name;
-    final string id;
+    @graphql:ID final string id;
     final int age;
     final string subject;
 
-    isolated function init(string name, int age, string id, string subject) {
+    isolated function init(string name, int age, @graphql:ID string id, string subject) {
         self.name = name;
         self.age = age;
         self.id = id;
@@ -79,7 +79,7 @@ public isolated service class Teacher {
         return self.age;
     }
 
-    isolated resource function get id() returns string {
+    isolated resource function get id() returns @graphql:ID string {
         return self.id;
     }
 

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/54_invalid_resource_functions_in_interface_implementations/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/54_invalid_resource_functions_in_interface_implementations/service.bal
@@ -17,9 +17,9 @@
 import ballerina/graphql;
 
 service /graphql on new graphql:Listener(4000) {
-    isolated resource function get name(int id) returns Person {
+    isolated resource function get name(@graphql:ID int id) returns Person {
         if id < 10 {
-        return new Student("Jesse Pinkman", 25, "student-1");
+            return new Student("Jesse Pinkman", 25, "student-1");
         }
         return new Teacher("Walter White", 52, "teacher-1", "Chemistry");
     }
@@ -34,10 +34,10 @@ public isolated distinct service class Student {
     *Person;
 
     final string name;
-    final string id;
+    @graphql:ID final string id;
     final int age;
 
-    isolated function init(string name, int age, string id) {
+    isolated function init(string name, int age, @graphql:ID string id) {
         self.name = name;
         self.age = age;
         self.id = id;
@@ -51,7 +51,7 @@ public isolated distinct service class Student {
         return self.age;
     }
 
-    isolated resource function read id() returns string {
+    isolated resource function read id() returns @graphql:ID string {
         return self.id;
     }
 }
@@ -60,11 +60,11 @@ public isolated distinct service class Teacher {
     *Person;
 
     final string name;
-    final string id;
+    @graphql:ID final string id;
     final int age;
     final string subject;
 
-    isolated function init(string name, int age, string id, string subject) {
+    isolated function init(string name, int age, @graphql:ID string id, string subject) {
         self.name = name;
         self.age = age;
         self.id = id;
@@ -79,7 +79,7 @@ public isolated distinct service class Teacher {
         return self.age;
     }
 
-    isolated resource function get id() returns string {
+    isolated resource function get id() returns @graphql:ID string {
         return self.id;
     }
 

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/55_invalid_return_types_in_interface_implementations/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/55_invalid_return_types_in_interface_implementations/service.bal
@@ -17,9 +17,9 @@
 import ballerina/graphql;
 
 service /graphql on new graphql:Listener(4000) {
-    isolated resource function get name(int id) returns Person {
+    isolated resource function get name(@graphql:ID int id) returns Person {
         if id < 10 {
-        return new Student("Jesse Pinkman", 25, "student-1");
+            return new Student("Jesse Pinkman", 25, "student-1");
         }
         return new Teacher("Walter White", 52, "teacher-1", "Chemistry");
     }
@@ -34,10 +34,10 @@ public isolated distinct service class Student {
     *Person;
 
     final string name;
-    final string id;
+    @graphql:ID final string id;
     final int age;
 
-    isolated function init(string name, int age, string id) {
+    isolated function init(string name, int age, @graphql:ID string id) {
         self.name = name;
         self.age = age;
         self.id = id;
@@ -51,7 +51,7 @@ public isolated distinct service class Student {
         return self.age;
     }
 
-    isolated resource function get id() returns string {
+    isolated resource function get id() returns @graphql:ID string {
         return self.id;
     }
 }
@@ -60,11 +60,11 @@ public isolated distinct service class Teacher {
     *Person;
 
     final string name;
-    final string id;
+    @graphql:ID final string id;
     final int age;
     final string subject;
 
-    isolated function init(string name, int age, string id, string subject) {
+    isolated function init(string name, int age, @graphql:ID string id, string subject) {
         self.name = name;
         self.age = age;
         self.id = id;
@@ -79,7 +79,7 @@ public isolated distinct service class Teacher {
         return self.age;
     }
 
-    isolated resource function get id() returns string {
+    isolated resource function get id() returns @graphql:ID string {
         return self.id;
     }
 

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/57_invalid_interceptor/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/57_invalid_interceptor/service.bal
@@ -24,7 +24,7 @@ readonly service class ServiceInterceptor {
         return result;
     }
 
-    isolated resource function get name(int id) returns string {
+    isolated resource function get name(@graphql:ID int id) returns string {
         if id < 10 {
             return "Ballerina";
         }


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/4202

The ID scalar type in GraphQL is often numeric, it should always serialize as a String. This proposal intends to introduce the type graphql:ID in order to differentiate the scalar type ID.

```ballerina
# Represents the Scalar type ID supported by the Ballerina GraphQL module.
public type ID string|int;
```

## Examples

```ballerina

distinct service class Person {
    private graphql:ID id;
    private string name;

    public function init(int id, string name) {
        self.id = id;
        self.name = name;
    }

    resource function get id() returns graphql:ID {
        return self.id;
    }

    resource function get name() returns string {
        return self.name;
    }
}
```
```ballerina
public type Person record {|
    graphql:ID id; 
    string name;
    int age;
    string city;
|};

service /graphql on new graphql:Listener(4000) {
    private Person profile;
    function init() {
        self.profile = { name: "Walter White", age: 50, city: "Albuquerque" };
    }
    resource function get profile() returns Person {
        return self.profile;
    }
    remote function updateName(string name) returns Person {
        self.profile.name = name;
        return self.profile;
    }
    remote function updateCity(string city) returns Person {
        self.profile.city = city;
        return self.profile;
    }
}
```

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
