### PR TITLE
Revert "[2201.5.x] Fix Compiler Plugin Test Failure"

### DIFF
--- a/ballerina-tests/Ballerina.toml
+++ b/ballerina-tests/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
 org = "ballerina"
 name = "graphql_tests"
-version = "1.7.2"
+version = "1.7.1"
 

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -42,7 +42,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.3.1"
+version = "2.3.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -51,11 +51,13 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "os"},
+	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
 ]
 modules = [
@@ -65,7 +67,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql"
-version = "1.7.2"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "file"},
@@ -92,7 +94,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql_tests"
-version = "1.7.2"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "graphql"},
@@ -144,7 +146,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.4.1"
+version = "1.4.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -256,7 +258,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.7.1"
+version = "2.7.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -267,7 +269,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.7.1"
+version = "2.7.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -310,7 +312,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "regex"
-version = "1.4.3"
+version = "1.4.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.string"}
@@ -322,7 +324,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.3.2"
+version = "2.3.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -343,7 +345,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.2.5"
+version = "2.2.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -351,7 +353,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.2.4"
+version = "2.2.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -362,7 +364,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "websocket"
-version = "2.7.1"
+version = "2.7.0"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "graphql"
-version = "1.7.2"
+version = "1.7.1"
 authors = ["Ballerina"]
 export=["graphql", "graphql.subgraph"]
 keywords = ["gql", "network", "query", "service"]
@@ -13,11 +13,11 @@ distribution = "2201.5.0"
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "graphql-native"
-version = "1.7.2"
-path = "../native/build/libs/graphql-native-1.7.2-SNAPSHOT.jar"
+version = "1.7.1"
+path = "../native/build/libs/graphql-native-1.7.1.jar"
 
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "graphql-compiler-plugin"
-version = "1.7.2"
-path = "../commons/build/libs/graphql-commons-1.7.2-SNAPSHOT.jar"
+version = "1.7.1"
+path = "../commons/build/libs/graphql-commons-1.7.1.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "graphql-compiler-plugin"
 class = "io.ballerina.stdlib.graphql.compiler.GraphqlCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/graphql-compiler-plugin-1.7.2-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/graphql-compiler-plugin-1.7.1.jar"
 
 [[dependency]]
-path = "../commons/build/libs/graphql-commons-1.7.2-SNAPSHOT.jar"
+path = "../commons/build/libs/graphql-commons-1.7.1.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -45,7 +45,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.3.1"
+version = "2.3.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -54,11 +54,13 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "os"},
+	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
 ]
 modules = [
@@ -68,7 +70,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql"
-version = "1.7.2"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "file"},
@@ -127,7 +129,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.4.1"
+version = "1.4.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -245,7 +247,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.7.1"
+version = "2.7.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -259,7 +261,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.7.1"
+version = "2.7.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -305,7 +307,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "regex"
-version = "1.4.3"
+version = "1.4.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.string"}
@@ -317,7 +319,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.3.2"
+version = "2.3.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -341,7 +343,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.2.5"
+version = "2.2.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -352,7 +354,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.2.4"
+version = "2.2.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -360,7 +362,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "websocket"
-version = "2.7.1"
+version = "2.7.0"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "constraint"},

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceValidationTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceValidationTest.java
@@ -245,7 +245,7 @@ public class ServiceValidationTest {
     public void testInvalidReturnTypes() {
         String packagePath = "27_invalid_return_types";
         DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
-        Assert.assertEquals(diagnosticResult.errorCount(), 14);
+        Assert.assertEquals(diagnosticResult.errorCount(), 18);
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
 
         Diagnostic diagnostic = diagnosticIterator.next();
@@ -292,23 +292,21 @@ public class ServiceValidationTest {
         message = getErrorMessage(CompilationDiagnostic.INVALID_RETURN_TYPE, "service object {}", "Query.foo");
         assertErrorMessage(diagnostic, message, 74, 5);
 
-        // TODO: Temporary removed.
-        // Add after fixing: https://github.com/ballerina-platform/ballerina-standard-library/issues/4538
-        // diagnostic = diagnosticIterator.next();
-        // message = getErrorMessage(CompilationDiagnostic.NON_DISTINCT_INTERFACE, "Interceptor");
-        // assertErrorMessage(diagnostic, message, 93, 5);
+        diagnostic = diagnosticIterator.next();
+        message = getErrorMessage(CompilationDiagnostic.NON_DISTINCT_INTERFACE, "Interceptor");
+        assertErrorMessage(diagnostic, message, 93, 5);
 
-        // diagnostic = diagnosticIterator.next();
-        // message = getErrorMessage(CompilationDiagnostic.INVALID_FUNCTION, "Interceptor", "execute");
-        // assertErrorMessage(diagnostic, message, 75, 5);
+        diagnostic = diagnosticIterator.next();
+        message = getErrorMessage(CompilationDiagnostic.INVALID_FUNCTION, "Interceptor", "execute");
+        assertErrorMessage(diagnostic, message, 75, 5);
 
-        // diagnostic = diagnosticIterator.next();
-        // message = getErrorMessage(CompilationDiagnostic.MISSING_RESOURCE_FUNCTIONS);
-        // assertErrorMessage(diagnostic, message, 93, 5);
+        diagnostic = diagnosticIterator.next();
+        message = getErrorMessage(CompilationDiagnostic.MISSING_RESOURCE_FUNCTIONS);
+        assertErrorMessage(diagnostic, message, 93, 5);
 
-        // diagnostic = diagnosticIterator.next();
-        // message = getErrorMessage(CompilationDiagnostic.NON_DISTINCT_INTERFACE_IMPLEMENTATION, "ServiceInterceptor");
-        // assertErrorMessage(diagnostic, message, 83, 24);
+        diagnostic = diagnosticIterator.next();
+        message = getErrorMessage(CompilationDiagnostic.NON_DISTINCT_INTERFACE_IMPLEMENTATION, "ServiceInterceptor");
+        assertErrorMessage(diagnostic, message, 83, 24);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_SUBSCRIBE_RESOURCE_RETURN_TYPE, "int", "foo");

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/27_invalid_return_types/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/27_invalid_return_types/service.bal
@@ -88,12 +88,12 @@ readonly service class ServiceInterceptor {
         return result;
     }
 }
-// TODO: Temporary removed. Add after fixing: https://github.com/ballerina-platform/ballerina-standard-library/issues/4538
-// service graphql:Service on new graphql:Listener(4000) {
-//     resource function get foo() returns graphql:Interceptor {
-//         return new ServiceInterceptor();
-//     }
-// }
+
+service graphql:Service on new graphql:Listener(4000) {
+    resource function get foo() returns graphql:Interceptor {
+        return new ServiceInterceptor();
+    }
+}
 
 service graphql:Service on new graphql:Listener(4000) {
     resource function subscribe foo() returns int {


### PR DESCRIPTION
Reverts ballerina-platform/module-ballerina-graphql#1453 since the build pipeline uses the [`v1.7.1` release tag](https://github.com/ballerina-platform/ballerina-release/actions/runs/5224974918/jobs/9435058546#step:8:22057) for testing. This cannot disable the failing test.