### PR TITLE
Fix Compiler Plugin Failure when Returning an Invalid Intersection Type

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - [[#4489] Fix Removing Duplicate Fields with Different Arguments without Returning an Error](https://github.com/ballerina-platform/ballerina-standard-library/issues/4489)
+- [[#4566] Fix Compiler Plugin Failure when Returning an Invalid Intersection Type](https://github.com/ballerina-platform/ballerina-standard-library/issues/4566)
 
 ## [1.8.0] - 2023-06-01
 
@@ -21,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [[#4376] Introduce an API to get Subfields of a `graphql:Field` Object](https://github.com/ballerina-platform/ballerina-standard-library/issues/4376)
 
 ### Fixed
-- [[#4364]Fix Compilation Error when GraphQL Package Import has a Prefix](https://github.com/ballerina-platform/ballerina-standard-library/issues/4364)
+- [[#4364] Fix Compilation Error when GraphQL Package Import has a Prefix](https://github.com/ballerina-platform/ballerina-standard-library/issues/4364)
 - [[#4379] Fix Schema Generation Failure when Import is Missing](https://github.com/ballerina-platform/ballerina-standard-library/issues/4379)
 - [[#4447] Fix non-isolated Function Pointers in Function Calls Within Isolated Functions](https://github.com/ballerina-platform/ballerina-standard-library/issues/4447)
 - [[#4255] Fix Interceptors Returning Invalid Response for Maps](https://github.com/ballerina-platform/ballerina-standard-library/issues/4255)

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceValidationTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceValidationTest.java
@@ -245,56 +245,56 @@ public class ServiceValidationTest {
     public void testInvalidReturnTypes() {
         String packagePath = "27_invalid_return_types";
         DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
-        Assert.assertEquals(diagnosticResult.errorCount(), 18);
+        Assert.assertEquals(diagnosticResult.errorCount(), 20);
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
 
         Diagnostic diagnostic = diagnosticIterator.next();
         String message = getErrorMessage(CompilationDiagnostic.INVALID_RETURN_TYPE, "map", "Query.greeting");
-        assertErrorMessage(diagnostic, message, 28, 5);
+        assertErrorMessage(diagnostic, message, 29, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_RETURN_TYPE, "json", "Query.greeting");
-        assertErrorMessage(diagnostic, message, 34, 5);
+        assertErrorMessage(diagnostic, message, 35, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_RETURN_TYPE, "byte", "Query.greeting");
-        assertErrorMessage(diagnostic, message, 41, 5);
+        assertErrorMessage(diagnostic, message, 42, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_RETURN_TYPE, "byte", "Query.greeting");
-        assertErrorMessage(diagnostic, message, 48, 5);
+        assertErrorMessage(diagnostic, message, 49, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_UNION_MEMBER_TYPE, "float");
-        assertErrorMessage(diagnostic, message, 55, 5);
+        assertErrorMessage(diagnostic, message, 56, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_UNION_MEMBER_TYPE, "decimal");
-        assertErrorMessage(diagnostic, message, 55, 5);
+        assertErrorMessage(diagnostic, message, 56, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_UNION_MEMBER_TYPE, "Person");
-        assertErrorMessage(diagnostic, message, 61, 5);
+        assertErrorMessage(diagnostic, message, 62, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_UNION_MEMBER_TYPE, "string");
-        assertErrorMessage(diagnostic, message, 61, 5);
+        assertErrorMessage(diagnostic, message, 62, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_UNION_MEMBER_TYPE, "Person");
-        assertErrorMessage(diagnostic, message, 67, 5);
+        assertErrorMessage(diagnostic, message, 68, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_UNION_MEMBER_TYPE, "Student");
-        assertErrorMessage(diagnostic, message, 67, 5);
+        assertErrorMessage(diagnostic, message, 68, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_RETURN_TYPE, "service object {}", "Query.foo");
-        assertErrorMessage(diagnostic, message, 74, 5);
+        assertErrorMessage(diagnostic, message, 75, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.NON_DISTINCT_INTERFACE, "Interceptor");
-        assertErrorMessage(diagnostic, message, 93, 5);
+        assertErrorMessage(diagnostic, message, 94, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_FUNCTION, "Interceptor", "execute");
@@ -302,23 +302,31 @@ public class ServiceValidationTest {
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.MISSING_RESOURCE_FUNCTIONS);
-        assertErrorMessage(diagnostic, message, 93, 5);
+        assertErrorMessage(diagnostic, message, 94, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.NON_DISTINCT_INTERFACE_IMPLEMENTATION, "ServiceInterceptor");
-        assertErrorMessage(diagnostic, message, 83, 24);
+        assertErrorMessage(diagnostic, message, 84, 24);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_SUBSCRIBE_RESOURCE_RETURN_TYPE, "int", "foo");
-        assertErrorMessage(diagnostic, message, 99, 5);
+        assertErrorMessage(diagnostic, message, 100, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_SUBSCRIBE_RESOURCE_RETURN_TYPE, "int|string", "bar");
-        assertErrorMessage(diagnostic, message, 103, 5);
+        assertErrorMessage(diagnostic, message, 104, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_RETURN_TYPE_CLASS, "Foo", "Query.foo");
-        assertErrorMessage(diagnostic, message, 112, 7);
+        assertErrorMessage(diagnostic, message, 113, 7);
+
+        diagnostic = diagnosticIterator.next();
+        message = getErrorMessage(CompilationDiagnostic.INVALID_RETURN_TYPE, "tuple", "Query.foo");
+        assertErrorMessage(diagnostic, message, 129, 5);
+
+        diagnostic = diagnosticIterator.next();
+        message = getErrorMessage(CompilationDiagnostic.INVALID_RETURN_TYPE, "tuple", "Query.time.time");
+        assertErrorMessage(diagnostic, message, 133, 5);
     }
 
     @Test(groups = "invalid")

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/27_invalid_return_types/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/27_invalid_return_types/service.bal
@@ -15,6 +15,7 @@
 // under the License.
 
 import ballerina/graphql;
+import ballerina/time;
 
 type Person record {
     string name;
@@ -116,5 +117,20 @@ class Foo {
 service graphql:Service on new graphql:Listener(4000) {
     resource function get foo() returns Foo {
         return new;
+    }
+}
+
+type Time record {|
+    readonly & [int, decimal] time;
+|};
+
+service graphql:Service on new graphql:Listener(4000) {
+
+    resource function get foo() returns time:Utc {
+        return [1, 2.3];
+    }
+
+    resource function get time() returns Time {
+        return {time: [1, 2.3]};
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/service/validator/ServiceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/service/validator/ServiceValidator.java
@@ -453,7 +453,7 @@ public class ServiceValidator {
                           getLocation(typeReferenceTypeSymbol, location), typeReferenceTypeSymbol.getName().get(),
                           typeReferenceTypeSymbol.typeDescriptor().typeKind().getName());
         } else {
-            validateReturnType(typeDefinitionSymbol.typeDescriptor(), location);
+            validateReturnType(typeReferenceTypeSymbol.typeDescriptor(), location);
         }
     }
 


### PR DESCRIPTION
## Purpose

Fixes: [#4566](https://github.com/ballerina-platform/ballerina-standard-library/issues/4566)

## Examples
N/A

## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [X] Added tests
- [ ] ~Updated the spec~
- [X] Checked native-image compatibility
