### PR TITLE
Deprecate executeWithType API from graphql:Client

### DIFF
--- a/ballerina-tests/Ballerina.toml
+++ b/ballerina-tests/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
 org = "ballerina"
 name = "graphql_tests"
-version = "1.9.0"
+version = "1.9.1"
 

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -67,7 +67,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "file"},
@@ -93,7 +93,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql_tests"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "file"},

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "graphql"
-version = "1.9.0"
+version = "1.9.1"
 authors = ["Ballerina"]
 export=["graphql", "graphql.subgraph"]
 keywords = ["gql", "network", "query", "service"]
@@ -16,11 +16,11 @@ graalvmCompatible = true
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "graphql-native"
-version = "1.9.0"
-path = "../native/build/libs/graphql-native-1.9.0.jar"
+version = "1.9.1"
+path = "../native/build/libs/graphql-native-1.9.1-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "graphql-compiler-plugin"
-version = "1.9.0"
-path = "../commons/build/libs/graphql-commons-1.9.0.jar"
+version = "1.9.1"
+path = "../commons/build/libs/graphql-commons-1.9.1-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "graphql-compiler-plugin"
 class = "io.ballerina.stdlib.graphql.compiler.GraphqlCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/graphql-compiler-plugin-1.9.0.jar"
+path = "../compiler-plugin/build/libs/graphql-compiler-plugin-1.9.1-SNAPSHOT.jar"
 
 [[dependency]]
-path = "../commons/build/libs/graphql-commons-1.9.0.jar"
+path = "../commons/build/libs/graphql-commons-1.9.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -67,7 +67,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "file"},

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -49,7 +49,7 @@ public isolated client class Client {
     #                `type CountryByCodeResponse record {| map<json?> extensions?; record {| record{|string name;|}? country; |} data;`
     # + return - The GraphQL response or a `graphql:ClientError` if failed to execute the query
     # # Deprecated
-    # This method is now deprecated use `execute()` API instead
+    # This method is now deprecated. Use the `execute()` API instead
     @deprecated
     remote isolated function executeWithType(string document, map<anydata>? variables = (), string? operationName = (),
                                              map<string|string[]>? headers = (),

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -48,6 +48,9 @@ public isolated client class Client {
     # + targetType - The payload, which is expected to be returned after data binding. For example
     #                `type CountryByCodeResponse record {| map<json?> extensions?; record {| record{|string name;|}? country; |} data;`
     # + return - The GraphQL response or a `graphql:ClientError` if failed to execute the query
+    # # Deprecated
+    # This method is now deprecated use `execute()` API instead
+    @deprecated
     remote isolated function executeWithType(string document, map<anydata>? variables = (), string? operationName = (),
                                              map<string|string[]>? headers = (),
                                              typedesc<GenericResponse|record{}|json> targetType = <>)

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - [[#4627] Fix Schema Generation Failure when Service has Type Alias](https://github.com/ballerina-platform/ballerina-standard-library/issues/4627)
 
+### Changed
+- [[#4630] Deprecate executeWithType() method from graphql:Client](https://github.com/ballerina-platform/ballerina-standard-library/issues/4630)
+
 ## [1.9.0] - 2023-06-30
 
 ### Added


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/4630

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
- [ ] No `commons` package changes (if there are any, please update the GraphQL version in [GraphQL tools](https://github.com/ballerina-platform/graphql-tools))
