### PR TITLE
Bump to the next minor version and remove JsonUtils deprecated API 

### DIFF
--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -369,7 +369,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "uuid"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -383,7 +383,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "websocket"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.8.0-20230810-094400-8a0431eb"
 [[package]]
 org = "ballerina"
 name = "auth"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -22,7 +22,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -33,7 +33,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "constraint"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -44,7 +44,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -53,7 +53,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -151,7 +151,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -168,7 +168,7 @@ version = "0.0.0"
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.8.1"
+version = "2.9.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -285,7 +285,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.8.0"
+version = "2.9.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -298,7 +298,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -311,7 +311,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -319,7 +319,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"}
@@ -328,7 +328,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -350,7 +350,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -358,7 +358,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -383,7 +383,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "websocket"
-version = "2.9.1"
+version = "2.9.0"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -8,7 +8,7 @@ keywords = ["gql", "network", "query", "service"]
 repository = "https://github.com/ballerina-platform/module-ballerina-graphql"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.7.0"
+distribution = "2201.8.0"
 
 [platform.java17]
 graalvmCompatible = true

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "uuid"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -376,7 +376,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "websocket"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.8.0-20230810-094400-8a0431eb"
 [[package]]
 org = "ballerina"
 name = "auth"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -25,7 +25,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -36,7 +36,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "constraint"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -44,7 +44,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -53,7 +53,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -129,7 +129,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -149,7 +149,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -258,7 +258,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.8.1"
+version = "2.9.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -272,7 +272,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.8.0"
+version = "2.9.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -285,7 +285,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -301,7 +301,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"}
@@ -318,7 +318,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -343,7 +343,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -354,7 +354,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -376,7 +376,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "websocket"
-version = "2.9.1"
+version = "2.9.0"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "constraint"},

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -8,7 +8,7 @@ keywords = ["gql", "network", "query", "service"]
 repository = "https://github.com/ballerina-platform/module-ballerina-graphql"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.7.0"
+distribution = "2201.8.0"
 
 [platform.java17]
 graalvmCompatible = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,40 +10,40 @@ downloadPluginVersion=5.4.0
 releasePluginVersion=2.8.0
 testngVersion=7.6.1
 eclipseLsp4jVersion=0.12.0
-ballerinaGradlePluginVersion=2.0.1-SNAPSHOT
+ballerinaGradlePluginVersion=2.0.1
 jacocoVersion=0.8.10
 
 # Standard Library Dependencies
 # Level 01
-stdlibIoVersion=1.5.0
-stdlibTimeVersion=2.3.0
-stdlibUrlVersion=2.3.0
+stdlibIoVersion=1.6.0-20230810-115500-2e569f5
+stdlibTimeVersion=2.4.0-20230810-115600-b28bb07
+stdlibUrlVersion=2.4.0-20230810-111000-683c6e4
 
 # Level 02
-stdlibConstraintVersion=1.3.0
-stdlibCryptoVersion=2.4.0
-stdlibLogVersion=2.8.1-20230718-085900-36c385c
-stdlibOsVersion=1.7.0
-stdlibTaskVersion=2.4.0
+stdlibConstraintVersion=1.4.0-20230810-133100-e09cfc1
+stdlibCryptoVersion=2.5.0-20230810-124300-ddf6788
+stdlibLogVersion=2.9.0-20230810-161500-6d3d1df
+stdlibOsVersion=1.8.0-20230810-161400-624a2aa
+stdlibTaskVersion=2.5.0-20230810-145800-b191831
 
 # Level 03
-stdlibCacheVersion=3.6.0
-stdlibFileVersion=1.8.0
-stdlibMimeVersion=2.8.0
-stdlibUuidVersion=1.6.0
+stdlibCacheVersion=3.7.0-20230811-093200-b83e72c
+stdlibFileVersion=1.9.0-20230811-093200-875a787
+stdlibMimeVersion=2.9.0-20230810-183500-af95101
+stdlibUuidVersion=1.7.0-20230811-093200-dc65fdd
 
 # Level 04
-stdlibAuthVersion=2.9.0
-stdlibJwtVersion=2.9.0
-stdlibOAuth2Version=2.9.0
+stdlibAuthVersion=2.10.0-20230811-110600-2428623
+stdlibJwtVersion=2.10.0-20230811-114700-d48ab2f
+stdlibOAuth2Version=2.10.0-20230811-111300-5550652
+
+# Level 05
+stdlibHttpVersion=2.10.0-20230811-144100-cac5d57
 
 # Level 06
-stdlibHttpVersion=2.10.0-20230810-091800-926fe3e
-
-# Level 07
-stdlibWebsocketVersion=2.9.1-20230809-174700-6942521
+stdlibWebsocketVersion=2.10.0-20230811-170000-3c42125
 
 # Ballerinax Observer
-observeVersion=1.1.0
-observeInternalVersion=1.1.0
+observeVersion=1.2.0-20230810-105500-5841859
+observeInternalVersion=1.2.0-20230810-141300-a348751
 

--- a/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/ArgumentHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/graphql/runtime/engine/ArgumentHandler.java
@@ -377,7 +377,7 @@ public class ArgumentHandler {
             case T_INT:
             case T_FLOAT:
             case T_BOOLEAN:
-                return JsonUtils.convertToJson(valueField, new ArrayList<>());
+                return JsonUtils.convertToJson(valueField);
             case T_INPUT_OBJECT:
                 return getJsonObject(argumentNode);
             case T_LIST:
@@ -394,7 +394,7 @@ public class ArgumentHandler {
             Object elementValue = getJsonArgument(argumentElementNode);
             valueArray.append(elementValue);
         }
-        return JsonUtils.convertToJson(valueArray, new ArrayList<>());
+        return JsonUtils.convertToJson(valueArray);
     }
 
     private Object getJsonObject(BObject argumentNode) {
@@ -406,7 +406,7 @@ public class ArgumentHandler {
             Object fieldValue = getJsonArgument(inputObjectField);
             mapValue.put(inputObjectFieldName, fieldValue);
         }
-        return JsonUtils.convertToJson(mapValue, new ArrayList<>());
+        return JsonUtils.convertToJson(mapValue);
     }
 
     private Object getIntersectionTypeArgument(BObject argumentNode, IntersectionType intersectionType) {


### PR DESCRIPTION
## Purpose
$Subject

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
- [ ] No `commons` package changes (if there are any, please update the GraphQL version in [GraphQL tools](https://github.com/ballerina-platform/graphql-tools))
