### PR TITLE
Fix allowing empty record types as GraphQL object types

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [[#4660] Fix GraphiQL Client Endpoint for Secured Listeners](https://github.com/ballerina-platform/ballerina-standard-library/issues/4660)
 - [[#4681] Removed Adding All Possible Federated Directives to SDL String in GraphQL Subgraph](https://github.com/ballerina-platform/ballerina-standard-library/issues/4681)
 - [[#4685] Fix `ID` Scalar Type Treated as a Non Built-in Type](https://github.com/ballerina-platform/ballerina-standard-library/issues/4685)
+- [[#4724] Fix Allowing Empty Records as GraphQL Object Types](https://github.com/ballerina-platform/ballerina-standard-library/issues/4724)
 
 ### Changed
 - [[#4630] Deprecate executeWithType() method from graphql:Client](https://github.com/ballerina-platform/ballerina-standard-library/issues/4630)

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceValidationTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceValidationTest.java
@@ -41,7 +41,7 @@ import java.util.Iterator;
 public class ServiceValidationTest {
 
     private static final Path RESOURCE_DIRECTORY = Paths.get("src", "test", "resources", "ballerina_sources",
-                                                             "validator_tests").toAbsolutePath();
+            "validator_tests").toAbsolutePath();
     private static final Path DISTRIBUTION_PATH = Paths.get("../", "target", "ballerina-runtime").toAbsolutePath();
     private static final String TEST_MODULE_PREFIX = "graphql_test/test_package:0.1.0:";
 
@@ -362,12 +362,12 @@ public class ServiceValidationTest {
         String subModulePrefix = "graphql_test/test_package.types:0.1.0:";
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_INPUT_PARAMETER_TYPE, subModulePrefix + "Headers",
-                                  "Query.greet");
+                "Query.greet");
         assertErrorMessage(diagnostic, message, 68, 47);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_INPUT_PARAMETER_TYPE, subModulePrefix + "Service",
-                                  "Query.greet");
+                "Query.greet");
         assertErrorMessage(diagnostic, message, 74, 47);
     }
 
@@ -485,7 +485,7 @@ public class ServiceValidationTest {
         // Same erroneous class is used in two different GraphQL services. Hence, the duplication of errors.
         Diagnostic diagnostic = diagnosticIterator.next();
         String message = getErrorMessage(CompilationDiagnostic.INVALID_RESOURCE_FUNCTION_ACCESSOR, "post",
-                                         "generalGreeting");
+                "generalGreeting");
         assertErrorMessage(diagnostic, message, 44, 23);
 
         diagnostic = diagnosticIterator.next();
@@ -532,22 +532,22 @@ public class ServiceValidationTest {
         // Same erroneous class is used in two different GraphQL services. Hence, the duplication of errors.
         Diagnostic diagnostic = diagnosticIterator.next();
         String message = getErrorMessage(CompilationDiagnostic.INVALID_INPUT_PARAMETER_TYPE, "json",
-                                         "Query.greet.generalGreeting");
+                "Query.greet.generalGreeting");
         assertErrorMessage(diagnostic, message, 44, 48);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_INPUT_PARAMETER_TYPE, "json",
-                                  "Query.greet.generalGreeting");
+                "Query.greet.generalGreeting");
         assertErrorMessage(diagnostic, message, 44, 48);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_INPUT_PARAMETER_TYPE, "map<string>",
-                                  "Query.greet.status");
+                "Query.greet.status");
         assertErrorMessage(diagnostic, message, 50, 46);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_INPUT_PARAMETER_TYPE, "map<string>",
-                                  "Query.greet.status");
+                "Query.greet.status");
         assertErrorMessage(diagnostic, message, 50, 46);
     }
 
@@ -588,7 +588,7 @@ public class ServiceValidationTest {
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_FIELD_NAME, "Query.lift.getStatus.__elevationgain",
-                                  "__elevationgain");
+                "__elevationgain");
         assertErrorMessage(diagnostic, message, 50, 5);
 
         diagnostic = diagnosticIterator.next();
@@ -676,7 +676,7 @@ public class ServiceValidationTest {
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
         Diagnostic diagnostic = diagnosticIterator.next();
         String message = getErrorMessage(CompilationDiagnostic.INVALID_RESOURCE_INPUT_OBJECT_PARAM, "Query.profile",
-                                         "Person");
+                "Person");
         assertErrorMessage(diagnostic, message, 39, 42);
 
         diagnostic = diagnosticIterator.next();
@@ -689,7 +689,7 @@ public class ServiceValidationTest {
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_RESOURCE_INPUT_OBJECT_PARAM, "Query.locationArray",
-                                  "Location");
+                "Location");
         assertErrorMessage(diagnostic, message, 77, 50);
 
         diagnostic = diagnosticIterator.next();
@@ -725,12 +725,12 @@ public class ServiceValidationTest {
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
         Diagnostic diagnostic = diagnosticIterator.next();
         String message = getErrorMessage(CompilationDiagnostic.INVALID_INPUT_PARAMETER_TYPE,
-                                         TEST_MODULE_PREFIX + "Context", "Query.profile");
+                TEST_MODULE_PREFIX + "Context", "Query.profile");
         assertErrorMessage(diagnostic, message, 21, 43);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_INPUT_PARAMETER_TYPE, TEST_MODULE_PREFIX + "Context",
-                                  "Mutation.updateName");
+                "Mutation.updateName");
         assertErrorMessage(diagnostic, message, 25, 40);
     }
 
@@ -753,7 +753,7 @@ public class ServiceValidationTest {
 
         Diagnostic diagnostic = diagnosticIterator.next();
         String message = getErrorMessage(CompilationDiagnostic.INVALID_RESOURCE_INPUT_OBJECT_PARAM, "Query.profile",
-                                         "Person");
+                "Person");
         assertErrorMessage(diagnostic, message, 35, 44);
 
         diagnostic = diagnosticIterator.next();
@@ -769,7 +769,7 @@ public class ServiceValidationTest {
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_RESOURCE_INPUT_OBJECT_PARAM, "Query.locationArray",
-                                  "Location");
+                "Location");
         assertErrorMessage(diagnostic, message, 88, 52);
     }
 
@@ -810,12 +810,12 @@ public class ServiceValidationTest {
 
         Diagnostic diagnostic = diagnosticIterator.next();
         String message = getErrorMessage(CompilationDiagnostic.INVALID_RETURN_TYPE, "stream",
-                                         "Query.getImage.byteStream");
+                "Query.getImage.byteStream");
         assertErrorMessage(diagnostic, message, 36, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_RETURN_TYPE, "stream",
-                                  "Query.getImageIfExist.byteStream");
+                "Query.getImageIfExist.byteStream");
         assertErrorMessage(diagnostic, message, 43, 5);
 
         diagnostic = diagnosticIterator.next();
@@ -836,17 +836,17 @@ public class ServiceValidationTest {
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_RETURN_TYPE, "stream",
-                                  "Mutation.uploadAndGet.byteStream");
+                "Mutation.uploadAndGet.byteStream");
         assertErrorMessage(diagnostic, message, 82, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_RETURN_TYPE, "stream",
-                                  "Mutation.uploadAndGet.byteStream");
+                "Mutation.uploadAndGet.byteStream");
         assertErrorMessage(diagnostic, message, 93, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_RETURN_TYPE, "stream",
-                                  "Mutation.uploadAndGetMultiple.byteStream");
+                "Mutation.uploadAndGetMultiple.byteStream");
         assertErrorMessage(diagnostic, message, 104, 5);
 
         diagnostic = diagnosticIterator.next();
@@ -855,22 +855,22 @@ public class ServiceValidationTest {
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_INPUT_PARAMETER_TYPE, TEST_MODULE_PREFIX + "File",
-                                  "Query.uploadFile");
+                "Query.uploadFile");
         assertErrorMessage(diagnostic, message, 122, 52);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_INPUT_PARAMETER_TYPE, TEST_MODULE_PREFIX + "File",
-                                  "Mutation.upload");
+                "Mutation.upload");
         assertErrorMessage(diagnostic, message, 133, 33);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_RETURN_TYPE, "stream",
-                                  "Query.uploadFile.file.byteStream");
+                "Query.uploadFile.file.byteStream");
         assertErrorMessage(diagnostic, message, 140, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_RETURN_TYPE, "stream",
-                                  "Mutation.upload.file.byteStream");
+                "Mutation.upload.file.byteStream");
         assertErrorMessage(diagnostic, message, 154, 5);
     }
 
@@ -941,7 +941,7 @@ public class ServiceValidationTest {
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_RETURN_TYPE, "byte",
-                                  "Subscription.profiles.bytes");
+                "Subscription.profiles.bytes");
         assertErrorMessage(diagnostic, message, 31, 5);
 
         diagnostic = diagnosticIterator.next();
@@ -958,12 +958,12 @@ public class ServiceValidationTest {
 
         Diagnostic diagnostic = diagnosticIterator.next();
         String message = getErrorMessage(CompilationDiagnostic.RESOURCE_METHOD_INSIDE_INTERCEPTOR,
-                                         "isolated resource function get name (int id) returns string");
+                "isolated resource function get name (int id) returns string");
         assertErrorMessage(diagnostic, message, 27, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_REMOTE_METHOD_INSIDE_INTERCEPTOR,
-                                  "isolated remote function updateName(string name) returns string");
+                "isolated remote function updateName(string name) returns string");
         assertErrorMessage(diagnostic, message, 34, 5);
     }
 
@@ -976,44 +976,44 @@ public class ServiceValidationTest {
 
         Diagnostic diagnostic = diagnosticIterator.next();
         String message = getErrorMessage(CompilationDiagnostic.INVALID_ANONYMOUS_FIELD_TYPE,
-                                         "record {|int number; string street; string city;|}", "Query.profile.address");
+                "record {|int number; string street; string city;|}", "Query.profile.address");
         assertErrorMessage(diagnostic, message, 26, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_ANONYMOUS_FIELD_TYPE,
-                                  "record {|int number; string street; string city;|}", "Query.address");
+                "record {|int number; string street; string city;|}", "Query.address");
         assertErrorMessage(diagnostic, message, 38, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_ANONYMOUS_FIELD_TYPE,
-                                  "record {|string name; int age;|}", "Query.class.profile");
+                "record {|string name; int age;|}", "Query.class.profile");
         assertErrorMessage(diagnostic, message, 52, 23);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_ANONYMOUS_INPUT_TYPE,
-                                  "record {|string name; int age;|}", "Query.name");
+                "record {|string name; int age;|}", "Query.name");
         assertErrorMessage(diagnostic, message, 58, 67);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_ANONYMOUS_INPUT_TYPE,
-                                  "record {|string name; int age;|}", "Query.school.name");
+                "record {|string name; int age;|}", "Query.school.name");
         assertErrorMessage(diagnostic, message, 68, 67);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_ANONYMOUS_FIELD_TYPE,
-                                  "record {|int number; string street; string city;|}", "Mutation.updateName.address");
+                "record {|int number; string street; string city;|}", "Mutation.updateName.address");
         assertErrorMessage(diagnostic, message, 78, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_ANONYMOUS_FIELD_TYPE,
-                                  "record {|int number; string street; string city;|}",
-                                  "Subscription.profiles.address");
+                "record {|int number; string street; string city;|}",
+                "Subscription.profiles.address");
         assertErrorMessage(diagnostic, message, 96, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_ANONYMOUS_FIELD_TYPE,
-                                  "record {|int number; string street; string city;|}",
-                                  "Query.company.profile.address");
+                "record {|int number; string street; string city;|}",
+                "Query.company.profile.address");
         assertErrorMessage(diagnostic, message, 112, 5);
     }
 
@@ -1046,12 +1046,12 @@ public class ServiceValidationTest {
 
         Diagnostic diagnostic = diagnosticIterator.next();
         String message = getErrorMessage(CompilationDiagnostic.INVALID_USE_OF_RESERVED_TYPE_AS_OUTPUT_TYPE, "Query.any",
-                                         "_Any");
+                "_Any");
         assertErrorMessage(diagnostic, message, 43, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_USE_OF_RESERVED_TYPE_AS_OUTPUT_TYPE,
-                                  "Mutation.services", "_Service");
+                "Mutation.services", "_Service");
         assertErrorMessage(diagnostic, message, 36, 15);
 
         diagnostic = diagnosticIterator.next();
@@ -1060,12 +1060,12 @@ public class ServiceValidationTest {
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_USE_OF_RESERVED_TYPE_AS_OUTPUT_TYPE, "Query.linkImport",
-                                  "link__Import");
+                "link__Import");
         assertErrorMessage(diagnostic, message, 55, 5);
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.INVALID_USE_OF_RESERVED_TYPE_AS_OUTPUT_TYPE,
-                                  "Query.linkPurpose", "link__Purpose");
+                "Query.linkPurpose", "link__Purpose");
         assertErrorMessage(diagnostic, message, 27, 6);
 
         diagnostic = diagnosticIterator.next();
@@ -1146,7 +1146,7 @@ public class ServiceValidationTest {
 
         Diagnostic diagnostic = diagnosticIterator.next();
         String message = getErrorMessage(CompilationDiagnostic.INVALID_PARAMETER_IN_PREFETCH_METHOD, "int id",
-                                         "preBooks", "books");
+                "preBooks", "books");
         assertErrorMessage(diagnostic, message, 26, 23);
     }
 
@@ -1159,7 +1159,7 @@ public class ServiceValidationTest {
 
         Diagnostic diagnostic = diagnosticIterator.next();
         String message = getErrorMessage(CompilationDiagnostic.INVALID_RETURN_TYPE_IN_PREFETCH_METHOD, "int",
-                                         "preBooks");
+                "preBooks");
         assertErrorMessage(diagnostic, message, 30, 23);
     }
 
@@ -1183,7 +1183,7 @@ public class ServiceValidationTest {
 
         diagnostic = diagnosticIterator.next();
         message = getErrorMessage(CompilationDiagnostic.UNABLE_TO_FIND_PREFETCH_METHOD, "prefetchUpdateAuthor",
-                                  "updateAuthor");
+                "updateAuthor");
         assertErrorMessage(diagnostic, message, 37, 21);
     }
 
@@ -1196,7 +1196,7 @@ public class ServiceValidationTest {
 
         Diagnostic diagnostic = diagnosticIterator.next();
         String message = getErrorMessage(CompilationDiagnostic.INVALID_USAGE_OF_PREFETCH_METHOD_NAME_CONFIG,
-                                         "prefetchMethodName", "authors");
+                "prefetchMethodName", "authors");
         assertErrorMessage(diagnostic, message, 24, 5);
     }
 
@@ -1209,7 +1209,7 @@ public class ServiceValidationTest {
 
         Diagnostic diagnostic = diagnosticIterator.next();
         String message = getErrorMessage(CompilationDiagnostic.UNABLE_TO_VALIDATE_PREFETCH_METHOD, "prefetchMethodName",
-                                         "updateAuthor");
+                "updateAuthor");
         assertWarningMessage(diagnostic, message, 36, 5);
     }
 
@@ -1228,11 +1228,39 @@ public class ServiceValidationTest {
         assertWarningMessage(diagnostic, message, 23, 9);
     }
 
+    @Test(groups = "invalid")
+    public void testInvalidEmptyRecordTypes() {
+        String packagePath = "76_invalid_empty_record_types";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
+        Assert.assertEquals(diagnosticResult.errorCount(), 4);
+        Iterator<Diagnostic> diagnosticIterator = diagnosticResult.errors().iterator();
+
+        Diagnostic diagnostic = diagnosticIterator.next();
+        String message = getErrorMessage(CompilationDiagnostic.INVALID_EMPTY_RECORD_OBJECT_TYPE, "Profile",
+                "Query.profile");
+        assertErrorMessage(diagnostic, message, 27, 5);
+
+        diagnostic = diagnosticIterator.next();
+        message = getErrorMessage(CompilationDiagnostic.INVALID_EMPTY_RECORD_INPUT_TYPE, "Profile", "Query.name");
+        assertErrorMessage(diagnostic, message, 33, 40);
+
+        diagnostic = diagnosticIterator.next();
+        message = getErrorMessage(CompilationDiagnostic.INVALID_EMPTY_RECORD_OBJECT_TYPE, "Profile",
+                "Query.name.profile");
+        assertErrorMessage(diagnostic, message, 39, 5);
+
+        diagnostic = diagnosticIterator.next();
+        message = getErrorMessage(CompilationDiagnostic.INVALID_EMPTY_RECORD_INPUT_TYPE, "Profile",
+                "Query.name");
+        assertErrorMessage(diagnostic, message, 45, 44);
+    }
+
     private DiagnosticResult getDiagnosticResult(String packagePath) {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve(packagePath);
         BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath);
         DiagnosticResult diagnosticResult = project.currentPackage().getCompilation().diagnosticResult();
-        Assert.assertEquals(diagnosticResult.errorCount(), 0);
+        Assert.assertEquals(diagnosticResult.errorCount(), 0,
+                "Package compilation encountered errors before running compiler plugin");
         return project.currentPackage().runCodeGenAndModifyPlugins();
     }
 

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/76_invalid_empty_record_types/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/76_invalid_empty_record_types/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "graphql_test"
+name = "test_package"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/76_invalid_empty_record_types/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validator_tests/76_invalid_empty_record_types/service.bal
@@ -1,0 +1,48 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/graphql;
+
+type Profile record {};
+
+type Information record {|
+    string id;
+    Profile profile;
+|};
+
+service on new graphql:Listener(4000) {
+    resource function get profile() returns Profile {
+        return {};
+    }
+}
+
+service on new graphql:Listener(4000) {
+    resource function get name(Profile input) returns string {
+        return "Hello";
+    }
+}
+
+service on new graphql:Listener(4000) {
+    resource function get name() returns Information {
+        return {id: "test", profile: {}};
+    }
+}
+
+service on new graphql:Listener(4000) {
+    resource function get name(Information input) returns string {
+        return "Hello";
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/CompilationDiagnostic.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/CompilationDiagnostic.java
@@ -90,7 +90,9 @@ public enum CompilationDiagnostic {
     UNSUPPORTED_INPUT_FIELD_DEPRECATION(DiagnosticMessage.WARNING_201, DiagnosticCode.GRAPHQL_201,
                                         DiagnosticSeverity.WARNING),
     UNABLE_TO_VALIDATE_PREFETCH_METHOD(DiagnosticMessage.WARNING_202, DiagnosticCode.GRAPHQL_202,
-                                       DiagnosticSeverity.WARNING);
+                                       DiagnosticSeverity.WARNING),
+    INVALID_EMPTY_RECORD_OBJECT_TYPE(DiagnosticMessage.ERROR_146, DiagnosticCode.GRAPHQL_146, DiagnosticSeverity.ERROR),
+    INVALID_EMPTY_RECORD_INPUT_TYPE(DiagnosticMessage.ERROR_147, DiagnosticCode.GRAPHQL_147, DiagnosticSeverity.ERROR),;
 
     private final String diagnostic;
     private final String diagnosticCode;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/DiagnosticCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/DiagnosticCode.java
@@ -67,6 +67,8 @@ public enum DiagnosticCode {
     GRAPHQL_143,
     GRAPHQL_144,
     GRAPHQL_145,
+    GRAPHQL_146,
+    GRAPHQL_147,
     GRAPHQL_201,
     GRAPHQL_202
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/DiagnosticMessage.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/DiagnosticMessage.java
@@ -94,6 +94,8 @@ public enum DiagnosticMessage {
     ERROR_144("no prefetch method found with name ''{0}'' for the GraphQL field ''{1}''"),
     ERROR_145("invalid usage of ''{0}'' configuration found in subscription resource ''{1}''. ''{0}'' configuration is"
                       + " only supported for 'remote' methods and 'get' resource methods"),
+    ERROR_146("invalid empty record type ''{0}'' found for GraphQL object type at field ''{1}''"),
+    ERROR_147("invalid empty record type ''{0}'' found for GraphQL input object type at field ''{1}''"),
 
     WARNING_201("invalid usage of @deprecated directive found in ''{0}''. Input object field(s) deprecation "
                     + "is not supported by the current GraphQL spec."),

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/service/validator/ServiceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/service/validator/ServiceValidator.java
@@ -218,12 +218,12 @@ public class ServiceValidator {
                 prefetchMethodName = getPrefetchMethodName(annotation.get());
                 if (prefetchMethodName == null) {
                     addDiagnostic(CompilationDiagnostic.UNABLE_TO_VALIDATE_PREFETCH_METHOD, annotation.get().location(),
-                                  PREFETCH_METHOD_NAME_CONFIG, graphqlFieldName);
+                            PREFETCH_METHOD_NAME_CONFIG, graphqlFieldName);
                     return;
                 }
                 if (isSubscription(methodSymbol)) {
                     addDiagnostic(CompilationDiagnostic.INVALID_USAGE_OF_PREFETCH_METHOD_NAME_CONFIG,
-                                  annotation.get().location(), PREFETCH_METHOD_NAME_CONFIG, graphqlFieldName);
+                            annotation.get().location(), PREFETCH_METHOD_NAME_CONFIG, graphqlFieldName);
                     return;
                 }
             }
@@ -235,7 +235,7 @@ public class ServiceValidator {
         if (prefetchMethod == null) {
             if (hasPrefetchMethodConfig) {
                 addDiagnostic(CompilationDiagnostic.UNABLE_TO_FIND_PREFETCH_METHOD, methodLocation, prefetchMethodName,
-                              graphqlFieldName);
+                        graphqlFieldName);
             }
             return;
         }
@@ -338,7 +338,7 @@ public class ServiceValidator {
         Location accessorLocation = getLocation(methodSymbol, location);
         if (isReservedFederatedResolverName(resourceMethodName)) {
             addDiagnostic(CompilationDiagnostic.INVALID_USE_OF_RESERVED_RESOURCE_PATH, accessorLocation,
-                          resourceMethodName);
+                    resourceMethodName);
         }
         String accessor = getAccessor(methodSymbol);
         if (RESOURCE_FUNCTION_SUBSCRIBE.equals(accessor)) {
@@ -352,7 +352,7 @@ public class ServiceValidator {
             this.currentFieldPath.remove(TypeName.QUERY.getName());
         } else {
             addDiagnostic(CompilationDiagnostic.INVALID_ROOT_RESOURCE_ACCESSOR, accessorLocation, accessor,
-                          resourceMethodName);
+                    resourceMethodName);
         }
     }
 
@@ -367,7 +367,7 @@ public class ServiceValidator {
         if (!RESOURCE_FUNCTION_GET.equals(accessor)) {
             Location accessorLocation = getLocation(methodSymbol, location);
             addDiagnostic(CompilationDiagnostic.INVALID_RESOURCE_FUNCTION_ACCESSOR, accessorLocation, accessor,
-                          getFieldPath(methodSymbol));
+                    getFieldPath(methodSymbol));
         }
         validateGetResource(methodSymbol, getLocation(methodSymbol, location));
     }
@@ -387,7 +387,7 @@ public class ServiceValidator {
             PathSegmentList pathSegmentList = (PathSegmentList) resourcePath;
             if (pathSegmentList.list().size() > 1) {
                 addDiagnostic(CompilationDiagnostic.INVALID_HIERARCHICAL_RESOURCE_PATH, location,
-                              resourcePathSignature);
+                        resourcePathSignature);
             } else {
                 validateResourcePathSegment(location, pathSegmentList.list().get(0));
             }
@@ -421,14 +421,14 @@ public class ServiceValidator {
                 hasContextParam = true;
             } else if (!fieldMethodParamSignatures.contains(symbol.signature().trim())) {
                 addDiagnostic(CompilationDiagnostic.INVALID_PARAMETER_IN_PREFETCH_METHOD, prefetchMethodLocation,
-                              symbol.signature(), prefetchMethodName,
-                              isResourceMethod(resolverMethod) ? getFieldPath((ResourceMethodSymbol) resolverMethod) :
-                                      resolverMethod.getName().orElse(resolverMethod.signature()));
+                        symbol.signature(), prefetchMethodName,
+                        isResourceMethod(resolverMethod) ? getFieldPath((ResourceMethodSymbol) resolverMethod) :
+                                resolverMethod.getName().orElse(resolverMethod.signature()));
             }
         }
         if (!hasContextParam) {
             addDiagnostic(CompilationDiagnostic.MISSING_GRAPHQL_CONTEXT_PARAMETER, prefetchMethodLocation,
-                          prefetchMethod.getName().orElse(prefetchMethod.signature()));
+                    prefetchMethod.getName().orElse(prefetchMethod.signature()));
         }
     }
 
@@ -439,8 +439,8 @@ public class ServiceValidator {
                 return;
             }
             addDiagnostic(CompilationDiagnostic.INVALID_RETURN_TYPE_IN_PREFETCH_METHOD,
-                          getLocation(returnType, prefetchMethodLocation), returnType.signature(),
-                          prefetchMethod.getName().orElse(""));
+                    getLocation(returnType, prefetchMethodLocation), returnType.signature(),
+                    prefetchMethod.getName().orElse(""));
         }
     }
 
@@ -455,7 +455,7 @@ public class ServiceValidator {
             List<TypeSymbol> effectiveTypes = getEffectiveTypes((UnionTypeSymbol) returnTypeSymbol);
             if (effectiveTypes.size() != 1) {
                 addDiagnostic(CompilationDiagnostic.INVALID_SUBSCRIBE_RESOURCE_RETURN_TYPE, location, returnTypeName,
-                              resourceMethodName);
+                        resourceMethodName);
                 return;
             } else {
                 returnTypeSymbol = effectiveTypes.get(0);
@@ -464,7 +464,7 @@ public class ServiceValidator {
 
         if (returnTypeSymbol.typeKind() != TypeDescKind.STREAM) {
             addDiagnostic(CompilationDiagnostic.INVALID_SUBSCRIBE_RESOURCE_RETURN_TYPE, location, returnTypeName,
-                          resourceMethodName);
+                    resourceMethodName);
         } else {
             String path = getFieldPath(methodSymbol);
             this.currentFieldPath.add(path);
@@ -567,15 +567,15 @@ public class ServiceValidator {
                 break;
             case RECORD:
                 addDiagnostic(CompilationDiagnostic.INVALID_ANONYMOUS_FIELD_TYPE, location, typeSymbol.signature(),
-                              getCurrentFieldPath());
+                        getCurrentFieldPath());
                 break;
             case OBJECT:
                 addDiagnostic(CompilationDiagnostic.INVALID_RETURN_TYPE, location, typeSymbol.signature(),
-                              getCurrentFieldPath());
+                        getCurrentFieldPath());
                 break;
             default:
                 addDiagnostic(CompilationDiagnostic.INVALID_RETURN_TYPE, location,
-                              typeSymbol.getName().orElse(typeSymbol.typeKind().getName()), getCurrentFieldPath());
+                        typeSymbol.getName().orElse(typeSymbol.typeKind().getName()), getCurrentFieldPath());
         }
     }
 
@@ -597,7 +597,7 @@ public class ServiceValidator {
         Location enumLocation = getLocation(enumSymbol, location);
         if (isReservedFederatedTypeName(enumName)) {
             addDiagnostic(CompilationDiagnostic.INVALID_USE_OF_RESERVED_TYPE_AS_OUTPUT_TYPE, enumLocation,
-                          getCurrentFieldPath(), enumName);
+                    getCurrentFieldPath(), enumName);
         }
     }
 
@@ -619,7 +619,7 @@ public class ServiceValidator {
             validateServiceClassDefinition(classSymbol, classSymbolLocation);
         } else {
             addDiagnostic(CompilationDiagnostic.INVALID_RETURN_TYPE_CLASS, classSymbolLocation,
-                          classSymbol.getName().get(), getCurrentFieldPath());
+                    classSymbol.getName().get(), getCurrentFieldPath());
         }
     }
 
@@ -638,8 +638,8 @@ public class ServiceValidator {
         } else if (isPrimitiveTypeSymbol(typeReferenceTypeSymbol.typeDescriptor())) {
             // noinspection OptionalGetWithoutIsPresent
             addDiagnostic(CompilationDiagnostic.UNSUPPORTED_TYPE_ALIAS,
-                          getLocation(typeReferenceTypeSymbol, location), typeReferenceTypeSymbol.getName().get(),
-                          typeReferenceTypeSymbol.typeDescriptor().typeKind().getName());
+                    getLocation(typeReferenceTypeSymbol, location), typeReferenceTypeSymbol.getName().get(),
+                    typeReferenceTypeSymbol.typeDescriptor().typeKind().getName());
         } else if (typeDefinitionSymbol.getModule().isPresent()
                 && Utils.isValidUuidModule(typeDefinitionSymbol.getModule().get())
                 && typeDefinitionSymbol.getName().isPresent()
@@ -654,14 +654,14 @@ public class ServiceValidator {
         if (typeDefinitionSymbol.getName().isEmpty()) {
             ObjectTypeSymbol objectTypeSymbol = (ObjectTypeSymbol) typeDefinitionSymbol.typeDescriptor();
             addDiagnostic(CompilationDiagnostic.INVALID_RETURN_TYPE, location, objectTypeSymbol.signature(),
-                          getCurrentFieldPath());
+                    getCurrentFieldPath());
             return;
         }
 
         String objectTypeName = typeDefinitionSymbol.getName().get();
         if (isReservedFederatedTypeName(objectTypeName)) {
             addDiagnostic(CompilationDiagnostic.INVALID_USE_OF_RESERVED_TYPE_AS_OUTPUT_TYPE, location,
-                          getCurrentFieldPath(), objectTypeName);
+                    getCurrentFieldPath(), objectTypeName);
         }
         if (!this.interfaceEntityFinder.isPossibleInterface(objectTypeName)) {
             addDiagnostic(CompilationDiagnostic.INVALID_RETURN_TYPE, location, objectTypeName, getCurrentFieldPath());
@@ -692,7 +692,7 @@ public class ServiceValidator {
                 String interfaceName = typeDefinitionSymbol.getName().get();
                 String remoteMethodName = methodSymbol.getName().orElse(methodSymbol.signature());
                 addDiagnostic(CompilationDiagnostic.INVALID_FUNCTION, getLocation(methodSymbol, location),
-                              interfaceName, remoteMethodName);
+                        interfaceName, remoteMethodName);
             }
             validatePrefetchMethodMapping(methodSymbol, methodSymbols, location);
         }
@@ -711,7 +711,7 @@ public class ServiceValidator {
                     String implementationName = implementation.getName().get();
                     Location implementationLocation = getLocation(implementation, location);
                     addDiagnostic(CompilationDiagnostic.NON_DISTINCT_INTERFACE_IMPLEMENTATION, implementationLocation,
-                                  implementationName);
+                            implementationName);
                     continue;
                 }
                 validateReturnTypeClass((ClassSymbol) implementation, location);
@@ -723,19 +723,26 @@ public class ServiceValidator {
 
     private void validateReturnType(RecordTypeSymbol recordTypeSymbol, TypeSymbol descriptor, Location location,
                                     String recordTypeName) {
+        if (this.existingReturnTypes.contains(descriptor)) {
+            return;
+        }
         if (isReservedFederatedTypeName(recordTypeName)) {
             addDiagnostic(CompilationDiagnostic.INVALID_USE_OF_RESERVED_TYPE_AS_OUTPUT_TYPE, location,
-                          getCurrentFieldPath(), recordTypeName);
-        } else if (this.existingInputObjectTypes.contains(descriptor)) {
-            addDiagnostic(CompilationDiagnostic.INVALID_RETURN_TYPE_INPUT_OBJECT, location, getCurrentFieldPath(),
-                          recordTypeName);
-        } else {
-            if (this.existingReturnTypes.contains(descriptor)) {
-                return;
-            }
-            this.existingReturnTypes.add(descriptor);
-            validateRecordFields(recordTypeSymbol, location);
+                    getCurrentFieldPath(), recordTypeName);
+            return;
         }
+        if (this.existingInputObjectTypes.contains(descriptor)) {
+            addDiagnostic(CompilationDiagnostic.INVALID_RETURN_TYPE_INPUT_OBJECT, location, getCurrentFieldPath(),
+                    recordTypeName);
+            return;
+        }
+        if (recordTypeSymbol.fieldDescriptors().isEmpty()) {
+            addDiagnostic(CompilationDiagnostic.INVALID_EMPTY_RECORD_OBJECT_TYPE, location, recordTypeName,
+                    getCurrentFieldPath());
+            return;
+        }
+        this.existingReturnTypes.add(descriptor);
+        validateRecordFields(recordTypeSymbol, location);
     }
 
     private void validateInputParameters(MethodSymbol methodSymbol, Location location) {
@@ -749,7 +756,7 @@ public class ServiceValidator {
                 }
                 if (parameter.annotations().isEmpty()) {
                     validateInputParameterType(parameter.typeDescriptor(), inputLocation,
-                                               isResourceMethod(methodSymbol));
+                            isResourceMethod(methodSymbol));
                 }
             }
         }
@@ -812,11 +819,11 @@ public class ServiceValidator {
                 break;
             case RECORD:
                 addDiagnostic(CompilationDiagnostic.INVALID_ANONYMOUS_INPUT_TYPE, location, typeSymbol.signature(),
-                              getCurrentFieldPath());
+                        getCurrentFieldPath());
                 break;
             default:
                 addDiagnostic(CompilationDiagnostic.INVALID_INPUT_PARAMETER_TYPE, location,
-                              rootInputParameterTypeSymbol.signature(), getCurrentFieldPath());
+                        rootInputParameterTypeSymbol.signature(), getCurrentFieldPath());
         }
         if (isRootInputParameterTypeSymbol(typeSymbol)) {
             resetRootInputParameterTypeSymbol();
@@ -864,7 +871,7 @@ public class ServiceValidator {
         } else if (isPrimitiveTypeSymbol(typeDescriptor)) {
             // noinspection OptionalGetWithoutIsPresent
             addDiagnostic(CompilationDiagnostic.UNSUPPORTED_TYPE_ALIAS, getLocation(typeSymbol, location),
-                          typeSymbol.getName().get(), typeDescriptor.typeKind().getName());
+                    typeSymbol.getName().get(), typeDescriptor.typeKind().getName());
         } else {
             validateInputParameterType(typeDescriptor, location, isResourceMethod);
         }
@@ -877,7 +884,7 @@ public class ServiceValidator {
         for (TypeSymbol memberType : unionTypeSymbol.userSpecifiedMemberTypes()) {
             if (memberType.typeKind() == TypeDescKind.ERROR) {
                 addDiagnostic(CompilationDiagnostic.INVALID_INPUT_PARAMETER_TYPE, location,
-                              TypeDescKind.ERROR.getName(), this.getCurrentFieldPath());
+                        TypeDescKind.ERROR.getName(), this.getCurrentFieldPath());
             } else if (memberType.typeKind() != TypeDescKind.NIL) {
                 foundDataType = true;
                 dataTypeCount++;
@@ -908,15 +915,19 @@ public class ServiceValidator {
                                             boolean isResourceMethod) {
         if (this.existingReturnTypes.contains(recordTypeSymbol)) {
             addDiagnostic(CompilationDiagnostic.INVALID_RESOURCE_INPUT_OBJECT_PARAM, location, getCurrentFieldPath(),
-                          recordTypeName);
+                    recordTypeName);
         } else {
+            if (recordTypeSymbol.fieldDescriptors().isEmpty()) {
+                addDiagnostic(CompilationDiagnostic.INVALID_EMPTY_RECORD_INPUT_TYPE, location, recordTypeName,
+                        getCurrentFieldPath());
+            }
             if (this.existingInputObjectTypes.contains(recordTypeSymbol)) {
                 return;
             }
             this.existingInputObjectTypes.add(recordTypeSymbol);
             if (isReservedFederatedTypeName(recordTypeName)) {
                 addDiagnostic(CompilationDiagnostic.INVALID_USE_OF_RESERVED_TYPE_AS_INPUT_TYPE, location,
-                              recordTypeName);
+                        recordTypeName);
             }
             for (RecordFieldSymbol recordFieldSymbol : recordTypeSymbol.fieldDescriptors().values()) {
                 boolean isDeprecated = recordFieldSymbol.deprecated();
@@ -938,7 +949,7 @@ public class ServiceValidator {
         String className = classSymbol.getName().get();
         if (isReservedFederatedTypeName(className)) {
             addDiagnostic(CompilationDiagnostic.INVALID_USE_OF_RESERVED_TYPE_AS_OUTPUT_TYPE, location,
-                          getCurrentFieldPath(), className);
+                    getCurrentFieldPath(), className);
         }
         boolean resourceMethodFound = false;
         List<MethodSymbol> methodSymbols = new ArrayList<>(classSymbol.methods().values());
@@ -949,7 +960,7 @@ public class ServiceValidator {
             } else if (isRemoteMethod(methodSymbol)) {
                 // noinspection OptionalGetWithoutIsPresent
                 addDiagnostic(CompilationDiagnostic.INVALID_FUNCTION, getLocation(methodSymbol, location), className,
-                              methodSymbol.getName().get());
+                        methodSymbol.getName().get());
             }
             validatePrefetchMethodMapping(methodSymbol, methodSymbols, location);
         }

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -3,7 +3,7 @@
 _Owners_: @shafreenAnfar @DimuthuMadushan @ThisaruGuruge @MohamedSabthar \
 _Reviewers_: @shafreenAnfar @ThisaruGuruge @DimuthuMadushan @ldclakmal \
 _Created_: 2022/01/06 \
-_Updated_: 2023/08/15 \
+_Updated_: 2023/08/17 \
 _Edition_: Swan Lake \
 _GraphQL Specification_: [October 2021](https://spec.graphql.org/October2021/)  
 
@@ -749,6 +749,8 @@ In Ballerina, a GraphQL object type can be represented using either a service ty
 
 A Ballerina record type can be used as an Object type in GraphQL. Each record field is mapped to a field in the GraphQL object and the type of the record field will be mapped to the type of the corresponding GraphQL field.
 
+>**Note:** A GraphQL object must have at least one field. Therefore, an empty record type cannot be used as an object type in GraphQL, and using an empty record type will result in a compilation error.
+
 ###### Example: Record Type as Object
 ```ballerina
 service on new graphql:Listener(9090) {
@@ -924,6 +926,8 @@ service on new graphql:Listener(9090) {
 Although `Scalar` and `enum` types can be used as input and output types without a limitation, an object type can not be used as an input type and an output type at the same time. Therefore, separate kinds of objects are used to define input objects.
 
 In Ballerina, a `record` type can be used as an input object. When a `record` type is used as the type of the input argument of a `resource` or `remote` method in a GraphQL service (or in a `resource` method in a `service` type returned from the GraphQL service), it is mapped to an `INPUT_OBJECT` type in GraphQL.
+
+>**Note:** A GraphQL input object must have at least one field. Therefore, an empty record type cannot be used as an input object type in GraphQL, and using an empty record type will result in a compilation error.
 
 >**Note:** Since GraphQL schema can not use the same type as an input and an output type when a record type is used as an input and an output, a compilation error will be thrown.
 
@@ -2659,7 +2663,7 @@ graphql:Error? result = context.remove("key");
 
 ##### 10.1.1.4 Register DataLoader in Context
 
-To register a [DataLoader](#111-dataloader) in the `graphql:Context` object, you can use the `registerDataLoader()` method, which requires two parameters.
+To register a [DataLoader](#106-dataloader) in the `graphql:Context` object, you can use the `registerDataLoader()` method, which requires two parameters.
 
 - `key`: The key used to identify a specific DataLoader instance. This key can later be used to retrieve the DataLoader instance when needed. The `key` must be a `string`.
 - `dataloader`: The DataLoader instance.


### PR DESCRIPTION
## Purpose
$Subject

Fixes: [#4224](https://github.com/ballerina-platform/ballerina-standard-library/issues/4724)

## Examples
N/A

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
- [x] Checked native-image compatibility
- [x] No `commons` package changes (if there are any, please update the GraphQL version in [GraphQL tools](https://github.com/ballerina-platform/graphql-tools))
