### PR TITLE
Fix invalid publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,8 +10,8 @@ jobs:
         name: Run Release Workflow
         if: ${{ github.repository_owner == 'ballerina-platform' }}
         uses: ballerina-platform/ballerina-standard-library/.github/workflows/release-package-template.yml@main
+        secrets: inherit
         with:
             package-name: graphql
             package-org: ballerina
             additional-build-flags: '-x :graphql-examples:build'
-            secrets: inherit


### PR DESCRIPTION
## Purpose
$subject

The publish release [workflow was failing](https://github.com/ballerina-platform/module-ballerina-graphql/actions/runs/6218336398/workflow) with the error `The workflow is not valid. .github/workflows/publish-release.yml (Line: 17, Col: 22): Invalid input, secrets is not defined in the referenced workflow.`

This PR fixes the above