### PR TITLE
Update symlinks for example readme files

### DIFF
--- a/examples/news_alerts/.github/README.md
+++ b/examples/news_alerts/.github/README.md
@@ -1,0 +1,1 @@
+../A Guide on GraphQL Subscriptions with Apache Kafka in Ballerina.md

--- a/examples/simple_github_issue_tracker/.github/README.md
+++ b/examples/simple_github_issue_tracker/.github/README.md
@@ -1,0 +1,1 @@
+../Integrating Multiple Endpoints to Expose as a GraphQL API in Ballerina.md

--- a/examples/snowtooth/.github/README.md
+++ b/examples/snowtooth/.github/README.md
@@ -1,0 +1,1 @@
+../GraphQL Snowtooth Example with Ballerina.md

--- a/examples/starwars/.github/README.md
+++ b/examples/starwars/.github/README.md
@@ -1,0 +1,1 @@
+../GraphQL Starwars API (SWAPI) in Ballerina.md


### PR DESCRIPTION
## Purpose

This is to show the example markdown file as a README file properly. Since we have different names for the MD file, GitHub does not show them as the README file by default.

## Checklist
- [ ] ~Linked to an issue~
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~
- [ ] ~No `commons` package changes (if there are any, please update the GraphQL version in [GraphQL tools](https://github.com/ballerina-platform/graphql-tools) and [Ballerina dev tools](https://github.com/ballerina-platform/ballerina-dev-tools))~
- [ ] ~No `compiler` package changes (if there are any, please update the GraphQL version in [Ballerina dev tools](https://github.com/ballerina-platform/ballerina-dev-tools))~
