### PR TITLE
[2201.9.x] Fix Service Crashing when Input Object Type Variable Value Includes an Additional Field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ velocity.log*
 graphql-ballerina/modules/graphql/
 examples/**/Dependencies.toml
 load-tests/**/Dependencies.toml
+
+# Java Logs
+java_pid*.hprof

--- a/ballerina-tests/tests/25_input_objects.bal
+++ b/ballerina-tests/tests/25_input_objects.bal
@@ -83,6 +83,22 @@ function dataProviderInputObject() returns map<[string, json]> {
         dir: "Chris Columbus"
     };
 
+    json var8 = {
+        bName: "Harry",
+        bAuthor: {name:"J.K Rowling", age:44, address: {street: "Baker Street", city: "London"}},
+        dir: "Chris Columbus"
+    };
+
+    json var9 = {
+        bInfo: {
+            bookName: "Harry",
+            author: {name:"J.K Rowling", age:44, address: {street: "Baker Street", city: "London"}},
+            dir: "Chris Columbus",
+            movie: {movieName: "End Game", director: "Russo", episodes: [{timeDuration: 120}]},
+            edition: 6
+        }
+    };
+
     map<[string, json]> dataSet = {
         "1": ["input_object"],
         "2": ["input_object_with_missing_arguments"],
@@ -108,7 +124,9 @@ function dataProviderInputObject() returns map<[string, json]> {
         "22": ["input_object_with_unexpected_variable_values", var7],
         "23": ["input_object_variables_with_invalid_type_name", {profile:{name: "Arthur", age: 5}}],
         "24": ["input_object_with_missing_nullable_variable_value"],
-        "25": ["default_values_in_input_object_fields"]
+        "25": ["default_values_in_input_object_fields"],
+        "26": ["input_object_with_unexpected_variable_fields1", var8],
+        "27": ["input_object_with_unexpected_variable_fields2", var9]
     };
     return dataSet;
 }

--- a/ballerina-tests/tests/resources/documents/input_object_with_unexpected_variable_fields1.graphql
+++ b/ballerina-tests/tests/resources/documents/input_object_with_unexpected_variable_fields1.graphql
@@ -1,0 +1,9 @@
+query getBook($bName:String!, $bAuthor:ProfileDetail!, $dir:String) {
+    ...on Query {
+        book(info: {bookName: $bName, edition: 6, author: $bAuthor, movie:{movieName: "End Game", director: $dir}}) {
+            ...on Book {
+                name
+            }
+        }
+    }
+}

--- a/ballerina-tests/tests/resources/documents/input_object_with_unexpected_variable_fields2.graphql
+++ b/ballerina-tests/tests/resources/documents/input_object_with_unexpected_variable_fields2.graphql
@@ -1,0 +1,9 @@
+query getBook($bInfo:Info!) {
+    ...on Query {
+        book(info: $bInfo) {
+            ...on Book {
+                name
+            }
+        }
+    }
+}

--- a/ballerina-tests/tests/resources/expected_results/input_object_with_unexpected_variable_fields1.json
+++ b/ballerina-tests/tests/resources/expected_results/input_object_with_unexpected_variable_fields1.json
@@ -1,0 +1,13 @@
+{
+    "errors": [
+        {
+            "message":"Input type \"ProfileDetail\" does not have a field \"address\".",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 60
+                }
+            ]
+        }
+    ]
+}

--- a/ballerina-tests/tests/resources/expected_results/input_object_with_unexpected_variable_fields2.json
+++ b/ballerina-tests/tests/resources/expected_results/input_object_with_unexpected_variable_fields2.json
@@ -1,0 +1,31 @@
+{
+    "errors": [
+        {
+            "message": "Input type \"ProfileDetail\" does not have a field \"address\".",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 21
+                }
+            ]
+        },
+        {
+            "message": "Input type \"Movie\" does not have a field \"episodes\".",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 21
+                }
+            ]
+        },
+        {
+            "message": "Input type \"Info\" does not have a field \"dir\".",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 21
+                }
+            ]
+        }
+    ]
+}

--- a/ballerina/field_validator_visitor.bal
+++ b/ballerina/field_validator_visitor.bal
@@ -327,11 +327,14 @@ class FieldValidatorVisitor {
         __Type argType = getOfType(inputValue.'type);
         __InputValue[]? inputFields = argType?.inputFields;
         if inputFields is __InputValue[] {
+            string[] keys = variableValues.keys();
             foreach __InputValue subInputValue in inputFields {
                 if getOfType(subInputValue.'type).name == UPLOAD {
                     return;
                 }
-                if variableValues.hasKey(subInputValue.name) {
+                int? index = keys.indexOf(subInputValue.name);
+                if index is int {
+                    _ = keys.remove(index);
                     anydata fieldValue = variableValues.get(subInputValue.name);
                     if fieldValue is Scalar {
                         if getOfType(subInputValue.'type).kind == ENUM {
@@ -368,6 +371,13 @@ class FieldValidatorVisitor {
                                          string `"${getTypeNameFromType(subInputValue.'type)}" was not provided.`;
                         self.errors.push(getErrorDetailRecord(message, location));
                     }
+                }
+            }
+            if keys.length() > 0 {
+                foreach string 'key in keys {
+                    string expectedTypeName = getOfTypeName(argType);
+                    string message = string `Input type "${expectedTypeName}" does not have a field "${'key}".`;
+                    self.errors.push(getErrorDetailRecord(message, location));
                 }
             }
         } else {

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- [[#7317] Fix Service Crashing when Input Object Type Variable Value Includes an Additional Field](https://github.com/ballerina-platform/ballerina-library/issues/7317)
+
+## [1.13.1] - 2024-07-02
+
 ### Changed
 - [[#6652] Cache Entire Record Having All Non-Optional Fields Instead of Caching Each Field Separately](https://github.com/ballerina-platform/ballerina-library/issues/6652)
 


### PR DESCRIPTION
## Purpose

Fixes: [#7317](https://github.com/ballerina-platform/ballerina-library/issues/7317)

## Examples
N/A

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
- [x] Checked native-image compatibility
- [x] No `commons` package changes (if there are any, please update the GraphQL version in [GraphQL tools](https://github.com/ballerina-platform/graphql-tools) and [Ballerina dev tools](https://github.com/ballerina-platform/ballerina-dev-tools))
- [x] No `compiler` package changes (if there are any, please update the GraphQL version in [Ballerina dev tools](https://github.com/ballerina-platform/ballerina-dev-tools))
