### PR TITLE
Disable test testDataLoaderWithDifferentAliasForSameField

### DIFF
--- a/ballerina-tests/graphql-dataloader-test-suite/Dependencies.toml
+++ b/ballerina-tests/graphql-dataloader-test-suite/Dependencies.toml
@@ -114,7 +114,6 @@ dependencies = [
 	{org = "ballerina", name = "graphql"},
 	{org = "ballerina", name = "graphql_test_common"},
 	{org = "ballerina", name = "http"},
-	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "websocket"}
 ]
@@ -181,9 +180,6 @@ scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
-]
-modules = [
-	{org = "ballerina", packageName = "io", moduleName = "io"}
 ]
 
 [[package]]

--- a/ballerina-tests/graphql-dataloader-test-suite/tests/01_dataloader_tests.bal
+++ b/ballerina-tests/graphql-dataloader-test-suite/tests/01_dataloader_tests.bal
@@ -35,7 +35,8 @@ isolated function testDataLoaderWithQuery() returns error? {
 
 @test:Config {
     groups: ["dataloader", "query"],
-    after: resetDispatchCounters
+    after: resetDispatchCounters,
+    enable: false
 }
 isolated function testDataLoaderWithDifferentAliasForSameField() returns error? {
     graphql:Client graphqlClient = check new ("localhost:9090/dataloader");

--- a/ballerina-tests/graphql-dataloader-test-suite/tests/01_dataloader_tests.bal
+++ b/ballerina-tests/graphql-dataloader-test-suite/tests/01_dataloader_tests.bal
@@ -18,14 +18,12 @@ import ballerina/graphql;
 import ballerina/graphql_test_common as common;
 import ballerina/test;
 import ballerina/websocket;
-import ballerina/io;
 
 @test:Config {
     groups: ["dataloader", "query"],
     after: resetDispatchCounters
 }
 isolated function testDataLoaderWithQuery() returns error? {
-    io:println("start testDataLoaderWithQuery");
     graphql:Client graphqlClient = check new ("localhost:9090/dataloader");
     string document = check common:getGraphqlDocumentFromFile("dataloader_with_query");
     json response = check graphqlClient->execute(document);
@@ -33,7 +31,6 @@ isolated function testDataLoaderWithQuery() returns error? {
     common:assertJsonValuesWithOrder(response, expectedPayload);
     assertDispatchCountForAuthorLoader(1);
     assertDispatchCountForBookLoader(1);
-    io:println("end testDataLoaderWithQuery");
 }
 
 @test:Config {
@@ -41,7 +38,6 @@ isolated function testDataLoaderWithQuery() returns error? {
     after: resetDispatchCounters
 }
 isolated function testDataLoaderWithDifferentAliasForSameField() returns error? {
-    io:println("start testDataLoaderWithDifferentAliasForSameField");
     graphql:Client graphqlClient = check new ("localhost:9090/dataloader");
     string document = check common:getGraphqlDocumentFromFile("dataloader_with_different_alias_for_same_field");
     json response = check graphqlClient->execute(document);
@@ -49,7 +45,6 @@ isolated function testDataLoaderWithDifferentAliasForSameField() returns error? 
     common:assertJsonValuesWithOrder(response, expectedPayload);
     assertDispatchCountForAuthorLoader(1);
     assertDispatchCountForBookLoader(1);
-    io:println("end testDataLoaderWithDifferentAliasForSameField");
 }
 
 @test:Config {
@@ -80,7 +75,6 @@ isolated function testDataLoaderWithSubscription() returns error? {
     after: resetDispatchCounters
 }
 isolated function testDataLoaderWithMutation() returns error? {
-    io:println("start testDataLoaderWithMutation");
     graphql:Client graphqlClient = check new ("localhost:9090/dataloader");
     string document = check common:getGraphqlDocumentFromFile("dataloader_with_mutation");
     json response = check graphqlClient->execute(document);
@@ -88,7 +82,6 @@ isolated function testDataLoaderWithMutation() returns error? {
     common:assertJsonValuesWithOrder(response, expectedPayload);
     assertDispatchCountForUpdateAuthorLoader(1);
     assertDispatchCountForBookLoader(1);
-    io:println("end testDataLoaderWithMutation");
 }
 
 @test:Config {
@@ -96,7 +89,6 @@ isolated function testDataLoaderWithMutation() returns error? {
     after: resetDispatchCounters
 }
 isolated function testDataLoaderWithInterceptors() returns error? {
-    io:println("start testDataLoaderWithInterceptors");
     graphql:Client graphqlClient = check new ("localhost:9090/dataloader_with_interceptor");
     string document = check common:getGraphqlDocumentFromFile("dataloader_with_interceptor");
     json response = check graphqlClient->execute(document);
@@ -104,7 +96,6 @@ isolated function testDataLoaderWithInterceptors() returns error? {
     common:assertJsonValuesWithOrder(response, expectedPayload);
     assertDispatchCountForAuthorLoader(1);
     assertDispatchCountForBookLoader(1);
-    io:println("end testDataLoaderWithInterceptors");
 }
 
 @test:Config {
@@ -112,7 +103,6 @@ isolated function testDataLoaderWithInterceptors() returns error? {
     after: resetDispatchCounters
 }
 isolated function testBatchFunctionReturningErrors() returns error? {
-    io:println("start testBatchFunctionReturningErrors");
     graphql:Client graphqlClient = check new ("localhost:9090/dataloader");
     string document = check common:getGraphqlDocumentFromFile("batch_function_returing_errors");
     json response = check graphqlClient->execute(document);
@@ -120,7 +110,6 @@ isolated function testBatchFunctionReturningErrors() returns error? {
     common:assertJsonValuesWithOrder(response, expectedPayload);
     assertDispatchCountForAuthorLoader(1);
     assertDispatchCountForBookLoader(0);
-    io:println("end testBatchFunctionReturningErrors");
 }
 
 @test:Config {
@@ -128,11 +117,9 @@ isolated function testBatchFunctionReturningErrors() returns error? {
     after: resetDispatchCounters
 }
 isolated function testBatchFunctionReturingNonMatchingNumberOfResults() returns error? {
-    io:println("start testBatchFunctionReturingNonMatchingNumberOfResults");
     graphql:Client graphqlClient = check new ("localhost:9090/dataloader_with_faulty_batch_function");
     string document = check common:getGraphqlDocumentFromFile("batch_function_returning_non_matcing_number_of_results");
     json response = check graphqlClient->execute(document);
     json expectedPayload = check common:getJsonContentFromFile("batch_function_returning_non_matcing_number_of_results");
     common:assertJsonValuesWithOrder(response, expectedPayload);
-    io:println("end testBatchFunctionReturingNonMatchingNumberOfResults");
 }

--- a/ballerina-tests/graphql-dataloader-test-suite/tests/02_dataloader_with_server_cache.bal
+++ b/ballerina-tests/graphql-dataloader-test-suite/tests/02_dataloader_with_server_cache.bal
@@ -16,14 +16,12 @@
 
 import ballerina/graphql_test_common as common;
 import ballerina/test;
-import ballerina/io;
 
 @test:Config {
-    groups: ["server_cache", "dataloader"],
+    groups: ["server_cache", "data_loader"],
     dataProvider: dataProviderServerCacheWithDataloader
 }
 isolated function testServerSideCacheWithDataLoader(string documentFile, string[] resourceFileNames, json variables = (), string[] operationNames = []) returns error? {
-    io:println("start testServerSideCacheWithDataLoader");
     string url = "http://localhost:9090/caching_with_dataloader";
     string document = check common:getGraphqlDocumentFromFile(documentFile);
     foreach int i in 0 ..< resourceFileNames.length() {
@@ -32,7 +30,6 @@ isolated function testServerSideCacheWithDataLoader(string documentFile, string[
         common:assertJsonValuesWithOrder(actualPayload, expectedPayload);
     }
     resetDispatchCounters();
-    io:println("end testServerSideCacheWithDataLoader");
 }
 
 function dataProviderServerCacheWithDataloader() returns map<[string, string[], json, string[]]> {
@@ -44,11 +41,10 @@ function dataProviderServerCacheWithDataloader() returns map<[string, string[], 
 }
 
 @test:Config {
-    groups: ["server_cache", "dataloader"],
+    groups: ["server_cache", "data_loader"],
     dataProvider: dataProviderServerCacheWithDataloaderInOperationalLevel
 }
 isolated function testServerSideCacheWithDataLoaderInOperationalLevel(string documentFile, string[] resourceFileNames, json variables = (), string[] operationNames = []) returns error? {
-    io:println("start testServerSideCacheWithDataLoaderInOperationalLevel");
     string url = "http://localhost:9090/caching_with_dataloader_operational";
     string document = check common:getGraphqlDocumentFromFile(documentFile);
     foreach int i in 0 ..< resourceFileNames.length() {
@@ -57,7 +53,6 @@ isolated function testServerSideCacheWithDataLoaderInOperationalLevel(string doc
         common:assertJsonValuesWithOrder(actualPayload, expectedPayload);
     }
     resetDispatchCounters();
-    io:println("end testServerSideCacheWithDataLoaderInOperationalLevel");
 }
 
 function dataProviderServerCacheWithDataloaderInOperationalLevel() returns map<[string, string[], json, string[]]> {


### PR DESCRIPTION
## Purpose
Temporarily disable test case: testDataLoaderWithDifferentAliasForSameField
Related issue: https://github.com/ballerina-platform/ballerina-library/issues/7453

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
- [ ] No `commons` package changes (if there are any, please update the GraphQL version in [GraphQL tools](https://github.com/ballerina-platform/graphql-tools) and [Ballerina dev tools](https://github.com/ballerina-platform/ballerina-dev-tools))
- [ ] No `compiler` package changes (if there are any, please update the GraphQL version in [Ballerina dev tools](https://github.com/ballerina-platform/ballerina-dev-tools))
