### PR TITLE
[2201.10.X] Fix Service Crashing when Input Object Type Variable Value Includes an Additional Field

### DIFF
--- a/ballerina-tests/Ballerina.toml
+++ b/ballerina-tests/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "graphql_tests"
-version = "1.14.1"
+version = "1.14.2"
 
 [build-options]
 observabilityIncluded = true

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -67,7 +67,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql"
-version = "1.14.1"
+version = "1.14.2"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -99,7 +99,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql_tests"
-version = "1.14.1"
+version = "1.14.2"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "file"},
@@ -123,7 +123,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.12.0"
+version = "2.12.8"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -155,7 +155,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.6.1"
+version = "1.6.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -290,7 +290,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -390,7 +390,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "websocket"
-version = "2.12.0"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina-tests/tests/25_input_objects.bal
+++ b/ballerina-tests/tests/25_input_objects.bal
@@ -83,6 +83,22 @@ function dataProviderInputObject() returns map<[string, json]> {
         dir: "Chris Columbus"
     };
 
+    json var8 = {
+        bName: "Harry",
+        bAuthor: {name:"J.K Rowling", age:44, address: {street: "Baker Street", city: "London"}},
+        dir: "Chris Columbus"
+    };
+
+    json var9 = {
+        bInfo: {
+            bookName: "Harry",
+            author: {name:"J.K Rowling", age:44, address: {street: "Baker Street", city: "London"}},
+            dir: "Chris Columbus",
+            movie: {movieName: "End Game", director: "Russo", episodes: [{timeDuration: 120}]},
+            edition: 6
+        }
+    };
+
     map<[string, json]> dataSet = {
         "1": ["input_object"],
         "2": ["input_object_with_missing_arguments"],
@@ -108,7 +124,9 @@ function dataProviderInputObject() returns map<[string, json]> {
         "22": ["input_object_with_unexpected_variable_values", var7],
         "23": ["input_object_variables_with_invalid_type_name", {profile:{name: "Arthur", age: 5}}],
         "24": ["input_object_with_missing_nullable_variable_value"],
-        "25": ["default_values_in_input_object_fields"]
+        "25": ["default_values_in_input_object_fields"],
+        "26": ["input_object_with_unexpected_variable_fields1", var8],
+        "27": ["input_object_with_unexpected_variable_fields2", var9]
     };
     return dataSet;
 }

--- a/ballerina-tests/tests/resources/documents/input_object_with_unexpected_variable_fields1.graphql
+++ b/ballerina-tests/tests/resources/documents/input_object_with_unexpected_variable_fields1.graphql
@@ -1,0 +1,9 @@
+query getBook($bName:String!, $bAuthor:ProfileDetail!, $dir:String) {
+    ...on Query {
+        book(info: {bookName: $bName, edition: 6, author: $bAuthor, movie:{movieName: "End Game", director: $dir}}) {
+            ...on Book {
+                name
+            }
+        }
+    }
+}

--- a/ballerina-tests/tests/resources/documents/input_object_with_unexpected_variable_fields2.graphql
+++ b/ballerina-tests/tests/resources/documents/input_object_with_unexpected_variable_fields2.graphql
@@ -1,0 +1,9 @@
+query getBook($bInfo:Info!) {
+    ...on Query {
+        book(info: $bInfo) {
+            ...on Book {
+                name
+            }
+        }
+    }
+}

--- a/ballerina-tests/tests/resources/expected_results/input_object_with_unexpected_variable_fields1.json
+++ b/ballerina-tests/tests/resources/expected_results/input_object_with_unexpected_variable_fields1.json
@@ -1,0 +1,13 @@
+{
+    "errors": [
+        {
+            "message":"Input type \"ProfileDetail\" does not have a field \"address\".",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 60
+                }
+            ]
+        }
+    ]
+}

--- a/ballerina-tests/tests/resources/expected_results/input_object_with_unexpected_variable_fields2.json
+++ b/ballerina-tests/tests/resources/expected_results/input_object_with_unexpected_variable_fields2.json
@@ -1,0 +1,31 @@
+{
+    "errors": [
+        {
+            "message": "Input type \"ProfileDetail\" does not have a field \"address\".",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 21
+                }
+            ]
+        },
+        {
+            "message": "Input type \"Movie\" does not have a field \"episodes\".",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 21
+                }
+            ]
+        },
+        {
+            "message": "Input type \"Info\" does not have a field \"dir\".",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 21
+                }
+            ]
+        }
+    ]
+}

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "graphql"
-version = "1.14.1"
+version = "1.14.2"
 authors = ["Ballerina"]
 export=["graphql", "graphql.subgraph", "graphql.dataloader"]
 keywords = ["gql", "network", "query", "service"]
@@ -16,11 +16,11 @@ graalvmCompatible = true
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "graphql-native"
-version = "1.14.1"
-path = "../native/build/libs/graphql-native-1.14.1.jar"
+version = "1.14.2"
+path = "../native/build/libs/graphql-native-1.14.2-SNAPSHOT.jar"
 
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "graphql-commons"
-version = "1.14.1"
-path = "../commons/build/libs/graphql-commons-1.14.1.jar"
+version = "1.14.2"
+path = "../commons/build/libs/graphql-commons-1.14.2-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "graphql-compiler-plugin"
 class = "io.ballerina.stdlib.graphql.compiler.GraphqlCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/graphql-compiler-plugin-1.14.1.jar"
+path = "../compiler-plugin/build/libs/graphql-compiler-plugin-1.14.2-SNAPSHOT.jar"
 
 [[dependency]]
-path = "../commons/build/libs/graphql-commons-1.14.1.jar"
+path = "../commons/build/libs/graphql-commons-1.14.2-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -73,7 +73,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql"
-version = "1.14.1"
+version = "1.14.2"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -106,7 +106,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.12.0"
+version = "2.12.8"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -138,7 +138,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.6.1"
+version = "1.6.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -282,7 +282,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -392,7 +392,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "websocket"
-version = "2.12.0"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina/field_validator_visitor.bal
+++ b/ballerina/field_validator_visitor.bal
@@ -328,11 +328,14 @@ class FieldValidatorVisitor {
         readonly & __Type argType = getOfType(inputValue.'type);
         readonly & __InputValue[]? inputFields = argType?.inputFields;
         if inputFields is __InputValue[] {
+            string[] keys = variableValues.keys();
             foreach __InputValue subInputValue in inputFields {
                 if getOfType(subInputValue.'type).name == UPLOAD {
                     return;
                 }
-                if variableValues.hasKey(subInputValue.name) {
+                int? index = keys.indexOf(subInputValue.name);
+                if index is int {
+                    _ = keys.remove(index);
                     anydata fieldValue = variableValues.get(subInputValue.name);
                     if fieldValue is Scalar {
                         if getOfType(subInputValue.'type).kind == ENUM {
@@ -369,6 +372,13 @@ class FieldValidatorVisitor {
                                         string `"${getTypeNameFromType(subInputValue.'type)}" was not provided.`;
                         self.errors.push(getErrorDetailRecord(message, location));
                     }
+                }
+            }
+            if keys.length() > 0 {
+                foreach string 'key in keys {
+                    string expectedTypeName = getOfTypeName(argType);
+                    string message = string `Input type "${expectedTypeName}" does not have a field "${'key}".`;
+                    self.errors.push(getErrorDetailRecord(message, location));
                 }
             }
         } else {

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- [[#7317] Fix Service Crashing when Input Object Type Variable Value Includes an Additional Field](https://github.com/ballerina-platform/ballerina-library/issues/7317)
+
 ## [1.14.1] - 2025-03-19
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Fixed
+
 - [[#7317] Fix Service Crashing when Input Object Type Variable Value Includes an Additional Field](https://github.com/ballerina-platform/ballerina-library/issues/7317)
 
 ## [1.14.1] - 2025-03-19


### PR DESCRIPTION
## Purpose

Fixes: [#7317](https://github.com/ballerina-platform/ballerina-library/issues/7317)

## Examples

## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [X] Added tests
- [ ] ~Updated the spec~
- [X] Checked native-image compatibility
- [X] No `commons` package changes (if there are any, please update the GraphQL version in [GraphQL tools](https://github.com/ballerina-platform/graphql-tools) and [Ballerina dev tools](https://github.com/ballerina-platform/ballerina-dev-tools))
- [X] No `compiler` package changes (if there are any, please update the GraphQL version in [Ballerina dev tools](https://github.com/ballerina-platform/ballerina-dev-tools))
