### PR TITLE
[Docs] Add service authoring guidelines to the package README

### DIFF
--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -32,6 +32,8 @@ listener graphql:Listener graphqlListener = check new(httpListener);
 
 The Ballerina GraphQL service represents the GraphQL schema. When a service is attached to a `graphql:Listener`, a GraphQL schema will be auto-generated.
 
+> **Authoring guidelines**: A GraphQL service always requires a `graphql:Listener` attached to it, and it needs a base path - `/graphql` is the conventional choice unless a different path is required. Expose **query** operations as `resource` functions and **mutation** operations as `remote` functions. Input fields are represented by function parameters; use only records and basic types as input parameter types.
+
 The GraphQL services are exposed through a single endpoint. The path of the GraphQL service endpoint can be provided via the service path of the GraphQL service. The endpoint of the following Ballerina GraphQL service will be `/graphql`.
 
 ```ballerina

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -32,7 +32,7 @@ listener graphql:Listener graphqlListener = check new(httpListener);
 
 The Ballerina GraphQL service represents the GraphQL schema. When a service is attached to a `graphql:Listener`, a GraphQL schema will be auto-generated.
 
-> **Authoring guidelines**: A GraphQL service always requires a `graphql:Listener` attached to it, and it needs a base path - `/graphql` is the conventional choice unless a different path is required. Expose **query** operations as `resource` functions and **mutation** operations as `remote` functions. Input fields are represented by function parameters; use only records and basic types as input parameter types.
+> **Authoring guidelines**: A GraphQL service always requires a `graphql:Listener` attached to it. The base path is optional and defaults to `/`; `/graphql` is the conventional choice. Expose **query** operations as `resource` functions and **mutation** operations as `remote` functions. Input fields are represented by function parameters, which may be scalar types, enums, records (input objects), lists, nullable unions, or `graphql:Upload`.
 
 The GraphQL services are exposed through a single endpoint. The path of the GraphQL service endpoint can be provided via the service path of the GraphQL service. The endpoint of the following Ballerina GraphQL service will be `/graphql`.
 


### PR DESCRIPTION
### Purpose

The Service section describes what a GraphQL service is, but the mapping from GraphQL operations to Ballerina function kinds (query -> `resource`, mutation -> `remote`) is spread across later sections. A short summary up front makes it easier to get right.

### Changes

- Added an authoring-guidelines note in the Service section covering the listener requirement, the conventional `/graphql` base path, the query/mutation to resource/remote mapping, and the constraint that input parameters be records or basic types.
These package READMEs are also surfaced as reference context in IDE and AI-assisted tooling, so keeping usage guidance in the README benefits both readers and tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated `ballerina/README.md` with clearer service authoring guidelines for GraphQL, including the requirement to attach a `graphql:Listener`, the conventional (but optional) `/graphql` base path behavior, the mapping of queries to `resource` functions and mutations to `remote` functions, and the supported input parameter types. This improves discoverability for readers and for IDE/AI-assisted tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->