### PR TITLE
Migrate endpoint-yaml export to CompilerLifecycleEventContext

### DIFF
--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/EndpointDetailsExtractorTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/EndpointDetailsExtractorTest.java
@@ -35,6 +35,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Comparator;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 public class EndpointDetailsExtractorTest {
@@ -249,7 +250,7 @@ public class EndpointDetailsExtractorTest {
             PackageCompilation compilation = project.currentPackage().getCompilation();
             JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(compilation, JvmTarget.JAVA_21);
             Path executablePath = project.targetDir().resolve("bin").resolve("output.jar");
-            Files.createDirectories(executablePath.getParent());
+            Files.createDirectories(Objects.requireNonNull(executablePath.getParent()));
             jBallerinaBackend.emit(JBallerinaBackend.OutputType.EXEC, executablePath);
         }
         return diagnosticResult;

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/EndpointDetailsExtractorTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/EndpointDetailsExtractorTest.java
@@ -22,7 +22,6 @@ import io.ballerina.projects.BuildOptions;
 import io.ballerina.projects.DiagnosticResult;
 import io.ballerina.projects.JBallerinaBackend;
 import io.ballerina.projects.JvmTarget;
-import io.ballerina.projects.Package;
 import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.ProjectEnvironmentBuilder;
 import io.ballerina.projects.directory.BuildProject;
@@ -245,10 +244,9 @@ public class EndpointDetailsExtractorTest {
         System.setProperty("ballerina.home", DISTRIBUTION_PATH.toString());
         BuildOptions buildOptions = BuildOptions.builder().setExportEndpoints(true).build();
         BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath, buildOptions);
-        Package currentPackage = project.currentPackage();
-        DiagnosticResult diagnosticResult = currentPackage.runCodeGenAndModifyPlugins();
+        DiagnosticResult diagnosticResult = project.currentPackage().runCodeGenAndModifyPlugins();
         if (diagnosticResult.errorCount() == 0) {
-            PackageCompilation compilation = currentPackage.getCompilation();
+            PackageCompilation compilation = project.currentPackage().getCompilation();
             JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(compilation, JvmTarget.JAVA_21);
             Path executablePath = project.targetDir().resolve("bin").resolve("output.jar");
             Files.createDirectories(executablePath.getParent());

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/EndpointDetailsExtractorTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/EndpointDetailsExtractorTest.java
@@ -20,6 +20,10 @@ package io.ballerina.stdlib.graphql.compiler;
 
 import io.ballerina.projects.BuildOptions;
 import io.ballerina.projects.DiagnosticResult;
+import io.ballerina.projects.JBallerinaBackend;
+import io.ballerina.projects.JvmTarget;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.ProjectEnvironmentBuilder;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.environment.Environment;
@@ -44,6 +48,7 @@ public class EndpointDetailsExtractorTest {
 
     private static final String TARGET_DIR = "target";
     private static final String ARTIFACT_DIR = "artifact";
+    private static final String ENDPOINTS_FILE_NAME = "endpoints.yaml";
 
     @Test
     public void testConfigurablePortWithDefaultValue() throws IOException {
@@ -52,7 +57,7 @@ public class EndpointDetailsExtractorTest {
         try {
             DiagnosticResult diagnosticResult = getDiagnosticResults(projectDirPath);
             Path artifactDir = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR);
-            Path endpointYaml = artifactDir.resolve("service_graphql_endpoint.yaml");
+            Path endpointYaml = artifactDir.resolve(ENDPOINTS_FILE_NAME);
             Assert.assertEquals(diagnosticResult.errorCount(), 0);
             assertEndpointPort(endpointYaml, 9091);
         } finally {
@@ -83,7 +88,7 @@ public class EndpointDetailsExtractorTest {
         try {
             DiagnosticResult diagnosticResult = getDiagnosticResults(projectDirPath);
             Path artifactDir = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR);
-            Path endpointYaml = artifactDir.resolve("service_graphql_endpoint.yaml");
+            Path endpointYaml = artifactDir.resolve(ENDPOINTS_FILE_NAME);
             Assert.assertEquals(diagnosticResult.errorCount(), 0);
             assertEndpointPort(endpointYaml, 9090);
             assertEndpointBasePath(endpointYaml, "/graphql");
@@ -99,14 +104,14 @@ public class EndpointDetailsExtractorTest {
         try {
             DiagnosticResult diagnosticResult = getDiagnosticResults(projectDirPath);
             Assert.assertEquals(diagnosticResult.errorCount(), 0);
-            Path endpointYaml1 = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR)
-                    .resolve("service_endpoint.yaml");
-            Path endpointYaml2 = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR)
-                    .resolve("service_too_endpoint.yaml");
-            assertEndpointBasePath(endpointYaml1, "/");
-            assertEndpointBasePath(endpointYaml2, "/too");
-            assertEndpointPort(endpointYaml1, 9091);
-            assertEndpointPort(endpointYaml2, 9093);
+            Path endpointsYaml = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR)
+                    .resolve(ENDPOINTS_FILE_NAME);
+            String content = Files.readString(endpointsYaml);
+            Assert.assertTrue(content.contains("basePath: \"/\""), "Expected basePath \"/\" for the first service");
+            Assert.assertTrue(content.contains("basePath: \"/too\""),
+                    "Expected basePath \"/too\" for the second service");
+            Assert.assertTrue(content.contains("port: 9091"), "Expected port 9091 for the first service");
+            Assert.assertTrue(content.contains("port: 9093"), "Expected port 9093 for the second service");
         } finally {
             deleteDirectories(projectDirPath);
         }
@@ -134,7 +139,7 @@ public class EndpointDetailsExtractorTest {
             Assert.assertEquals(diagnosticResult.errorCount(), 0,
                     "Expected no errors for named listener reference");
             Path endpointYaml = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR)
-                    .resolve("service_graphql_endpoint.yaml");
+                    .resolve(ENDPOINTS_FILE_NAME);
             Assert.assertTrue(Files.exists(endpointYaml), "Endpoint YAML should be generated");
             assertEndpointPort(endpointYaml, 9090);
         } finally {
@@ -151,7 +156,7 @@ public class EndpointDetailsExtractorTest {
             Assert.assertEquals(diagnosticResult.errorCount(), 0,
                     "Expected no errors for implicit new listener");
             Path endpointYaml = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR)
-                    .resolve("service_graphql_endpoint.yaml");
+                    .resolve(ENDPOINTS_FILE_NAME);
             Assert.assertTrue(Files.exists(endpointYaml), "Endpoint YAML should be generated");
             assertEndpointPort(endpointYaml, 9090);
         } finally {
@@ -168,7 +173,7 @@ public class EndpointDetailsExtractorTest {
             Assert.assertEquals(diagnosticResult.errorCount(), 0,
                     "Expected no errors for explicit new listener");
             Path endpointYaml = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR)
-                    .resolve("service_graphql_endpoint.yaml");
+                    .resolve(ENDPOINTS_FILE_NAME);
             Assert.assertTrue(Files.exists(endpointYaml), "Endpoint YAML should be generated");
             assertEndpointPort(endpointYaml, 9090);
         } finally {
@@ -185,7 +190,7 @@ public class EndpointDetailsExtractorTest {
             Assert.assertEquals(diagnosticResult.errorCount(), 0,
                     "Expected no errors when listener is wrapped in check");
             Path endpointYaml = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR)
-                    .resolve("service_graphql_endpoint.yaml");
+                    .resolve(ENDPOINTS_FILE_NAME);
             Assert.assertTrue(Files.exists(endpointYaml), "Endpoint YAML should be generated");
             assertEndpointPort(endpointYaml, 9090);
         } finally {
@@ -202,7 +207,7 @@ public class EndpointDetailsExtractorTest {
             Assert.assertEquals(diagnosticResult.errorCount(), 0,
                     "Expected no errors for named argument port");
             Path endpointYaml = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR)
-                    .resolve("service_graphql_endpoint.yaml");
+                    .resolve(ENDPOINTS_FILE_NAME);
             Assert.assertTrue(Files.exists(endpointYaml), "Endpoint YAML should be generated");
             assertEndpointPort(endpointYaml, 9090);
         } finally {
@@ -236,10 +241,20 @@ public class EndpointDetailsExtractorTest {
         }
     }
 
-    private static DiagnosticResult getDiagnosticResults(Path projectDirPath) {
+    private static DiagnosticResult getDiagnosticResults(Path projectDirPath) throws IOException {
+        System.setProperty("ballerina.home", DISTRIBUTION_PATH.toString());
         BuildOptions buildOptions = BuildOptions.builder().setExportEndpoints(true).build();
         BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath, buildOptions);
-        return project.currentPackage().runCodeGenAndModifyPlugins();
+        Package currentPackage = project.currentPackage();
+        DiagnosticResult diagnosticResult = currentPackage.runCodeGenAndModifyPlugins();
+        if (diagnosticResult.errorCount() == 0) {
+            PackageCompilation compilation = currentPackage.getCompilation();
+            JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(compilation, JvmTarget.JAVA_21);
+            Path executablePath = project.targetDir().resolve("bin").resolve("output.jar");
+            Files.createDirectories(executablePath.getParent());
+            jBallerinaBackend.emit(JBallerinaBackend.OutputType.EXEC, executablePath);
+        }
+        return diagnosticResult;
     }
 
     private static boolean hasDiagnosticCodeOrMessage(Path projectDirPath, String diagnosticCode,

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceArtifactsExtractionTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceArtifactsExtractionTest.java
@@ -478,10 +478,9 @@ public class ServiceArtifactsExtractionTest {
         System.setProperty("ballerina.home", DISTRIBUTION_PATH.toString());
         BuildOptions buildOptions = BuildOptions.builder().setExportEndpoints(isExportEndpoints).build();
         BuildProject project = load(getEnvironmentBuilder(), projectDirPath, buildOptions);
-        Package currentPackage = project.currentPackage();
-        DiagnosticResult diagnosticResult = currentPackage.runCodeGenAndModifyPlugins();
+        DiagnosticResult diagnosticResult = project.currentPackage().runCodeGenAndModifyPlugins();
         if (diagnosticResult.errorCount() == 0) {
-            PackageCompilation compilation = currentPackage.getCompilation();
+            PackageCompilation compilation = project.currentPackage().getCompilation();
             JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(compilation, JvmTarget.JAVA_21);
             Path executablePath = project.targetDir().resolve("bin").resolve("output.jar");
             Files.createDirectories(executablePath.getParent());

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceArtifactsExtractionTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceArtifactsExtractionTest.java
@@ -53,6 +53,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -483,7 +484,7 @@ public class ServiceArtifactsExtractionTest {
             PackageCompilation compilation = project.currentPackage().getCompilation();
             JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(compilation, JvmTarget.JAVA_21);
             Path executablePath = project.targetDir().resolve("bin").resolve("output.jar");
-            Files.createDirectories(executablePath.getParent());
+            Files.createDirectories(Objects.requireNonNull(executablePath.getParent()));
             jBallerinaBackend.emit(JBallerinaBackend.OutputType.EXEC, executablePath);
         }
         return diagnosticResult;

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceArtifactsExtractionTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceArtifactsExtractionTest.java
@@ -28,6 +28,8 @@ import io.ballerina.projects.BuildOptions;
 import io.ballerina.projects.DiagnosticResult;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.JBallerinaBackend;
+import io.ballerina.projects.JvmTarget;
 import io.ballerina.projects.Package;
 import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.ProjectEnvironmentBuilder;
@@ -72,7 +74,7 @@ public class ServiceArtifactsExtractionTest {
     private static final String ARTIFACT_DIR = "artifact";
     private static final String TARGET_DIR = "target";
 
-    private static final String ENDPOINT_SUFFIX = "_endpoint.yaml";
+    private static final String ENDPOINTS_FILE_NAME = "endpoints.yaml";
     private static final String GQL_SUFFIX = ".graphql";
 
     @Test
@@ -85,12 +87,12 @@ public class ServiceArtifactsExtractionTest {
                     "Expected no compilation/plugin errors");
 
             Path artifactDir = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR);
-            Path endpointYaml = artifactDir.resolve("service_graphql2_endpoint.yaml");
-            Path expectedEndpointYaml = YAML_FILES_DIRECTORY.resolve("service_graphql2_endpoint.yaml");
+            Path endpointsYaml = artifactDir.resolve(ENDPOINTS_FILE_NAME);
+            Path expectedEndpointsYaml = YAML_FILES_DIRECTORY.resolve("endpoints_single_service.yaml");
 
             Assert.assertTrue(Files.exists(artifactDir), "Artifact directory should exist");
-            Assert.assertTrue(Files.exists(endpointYaml), "Endpoint YAML file should be generated");
-            verifyYamlContent(endpointYaml, expectedEndpointYaml);
+            Assert.assertTrue(Files.exists(endpointsYaml), "Consolidated endpoints YAML should be generated");
+            verifyYamlContent(endpointsYaml, expectedEndpointsYaml);
 
         } finally {
             deleteDirectories(projectDirPath);
@@ -110,15 +112,12 @@ public class ServiceArtifactsExtractionTest {
             Path artifactDir = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR);
             Assert.assertTrue(Files.exists(artifactDir), "Artifact directory should exist");
 
-            Path endpointYaml1 = artifactDir.resolve("service_endpoint.yaml");
-            Path endpointYaml2 = artifactDir.resolve("service_too_endpoint.yaml");
-            Path expectedDir = YAML_FILES_DIRECTORY;
+            Path endpointsYaml = artifactDir.resolve(ENDPOINTS_FILE_NAME);
+            Assert.assertTrue(Files.exists(endpointsYaml), "Consolidated endpoints YAML should be generated");
 
-            Assert.assertTrue(Files.exists(endpointYaml1), "Endpoint YAML file should be generated");
-            Assert.assertTrue(Files.exists(endpointYaml2), "Endpoint YAML file should be generated");
-
-            verifyYamlContent(endpointYaml1, expectedDir.resolve("service_endpoint.yaml"));
-            verifyYamlContent(endpointYaml2, expectedDir.resolve("service_too_endpoint.yaml"));
+            String content = Files.readString(endpointsYaml);
+            Assert.assertTrue(content.contains("port: 9091"), "Expected port 9091 for the first service");
+            Assert.assertTrue(content.contains("port: 9093"), "Expected port 9093 for the second service");
 
             long schemaCount = countFilesWithSuffix(artifactDir, GQL_SUFFIX);
             Assert.assertTrue(schemaCount > 1, "Expected schema artifacts for " +
@@ -153,9 +152,9 @@ public class ServiceArtifactsExtractionTest {
                     "Expected no compilation/plugin errors");
             Path artifactDir = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR);
             Assert.assertTrue(Files.exists(artifactDir), "Artifact directory should exist");
-            long endpointYamlCount = countFilesWithSuffix(artifactDir, ENDPOINT_SUFFIX);
+            long endpointCount = countEndpointEntries(artifactDir.resolve(ENDPOINTS_FILE_NAME));
             long schemaCount = countFilesWithSuffix(artifactDir, GQL_SUFFIX);
-            Assert.assertTrue(endpointYamlCount >= 2);
+            Assert.assertTrue(endpointCount >= 2);
             Assert.assertEquals(schemaCount, 2);
         } finally {
             deleteDirectories(projectDirPath);
@@ -203,7 +202,7 @@ public class ServiceArtifactsExtractionTest {
 
             Path artifactDir = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR);
             Assert.assertTrue(Files.exists(artifactDir), "Artifact directory should exist");
-            Assert.assertTrue(countFilesWithSuffix(artifactDir, ENDPOINT_SUFFIX) >= 2);
+            Assert.assertTrue(countEndpointEntries(artifactDir.resolve(ENDPOINTS_FILE_NAME)) >= 2);
             Assert.assertTrue(countFilesWithSuffix(artifactDir, GQL_SUFFIX) >= 2);
         } finally {
             deleteDirectories(projectDirPath);
@@ -474,15 +473,32 @@ public class ServiceArtifactsExtractionTest {
                 expectedEndpointContent.replaceAll("\\s+", ""));
     }
 
-    private static DiagnosticResult getDiagnosticResults(Path projectDirPath, boolean isExportEndpoints) {
+    private static DiagnosticResult getDiagnosticResults(Path projectDirPath, boolean isExportEndpoints)
+            throws IOException {
+        System.setProperty("ballerina.home", DISTRIBUTION_PATH.toString());
         BuildOptions buildOptions = BuildOptions.builder().setExportEndpoints(isExportEndpoints).build();
         BuildProject project = load(getEnvironmentBuilder(), projectDirPath, buildOptions);
-        return project.currentPackage().runCodeGenAndModifyPlugins();
+        Package currentPackage = project.currentPackage();
+        DiagnosticResult diagnosticResult = currentPackage.runCodeGenAndModifyPlugins();
+        if (diagnosticResult.errorCount() == 0) {
+            PackageCompilation compilation = currentPackage.getCompilation();
+            JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(compilation, JvmTarget.JAVA_21);
+            Path executablePath = project.targetDir().resolve("bin").resolve("output.jar");
+            Files.createDirectories(executablePath.getParent());
+            jBallerinaBackend.emit(JBallerinaBackend.OutputType.EXEC, executablePath);
+        }
+        return diagnosticResult;
     }
 
     private static ProjectEnvironmentBuilder getEnvironmentBuilder() {
         Environment environment = EnvironmentBuilder.getBuilder().setBallerinaHome(DISTRIBUTION_PATH).build();
         return ProjectEnvironmentBuilder.getBuilder(environment);
+    }
+
+    private static long countEndpointEntries(Path endpointsYaml) throws IOException {
+        try (Stream<String> lines = Files.lines(endpointsYaml)) {
+            return lines.filter(line -> line.trim().startsWith("- name:")).count();
+        }
     }
 
     private static long countFilesWithSuffix(Path directory, String suffix) throws IOException {

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/endpointyaml/generator/EndpointsYamlWriterTaskTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/endpointyaml/generator/EndpointsYamlWriterTaskTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.graphql.compiler.endpointyaml.generator;
+
+import io.ballerina.projects.BalCommand;
+import io.ballerina.projects.BuildOptions;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.PackageCompilation;
+import io.ballerina.projects.ProjectEnvironmentBuilder;
+import io.ballerina.projects.directory.BuildProject;
+import io.ballerina.projects.environment.Environment;
+import io.ballerina.projects.environment.EnvironmentBuilder;
+import io.ballerina.projects.plugins.CompilerLifecycleEventContext;
+import io.ballerina.stdlib.graphql.compiler.Utils;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class EndpointsYamlWriterTaskTest {
+
+    private static final Path RESOURCE_DIRECTORY = Paths.get("src", "test", "resources", "ballerina_sources")
+            .toAbsolutePath();
+    private static final Path DISTRIBUTION_PATH = Paths.get("../", "target", "ballerina-runtime")
+            .toAbsolutePath();
+
+    @Test
+    public void testPerformReportsDiagnosticWhenWriteFails() throws Exception {
+        Path projectDirPath = RESOURCE_DIRECTORY.resolve("endpoint_details_extraction_tests")
+                .resolve("01_hardcoded_port");
+        System.setProperty("ballerina.home", DISTRIBUTION_PATH.toString());
+        BuildOptions buildOptions = BuildOptions.builder().build();
+        BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath, buildOptions);
+        Package currentPackage = project.currentPackage();
+        PackageCompilation compilation = currentPackage.getCompilation();
+        Path targetDir = project.targetDir();
+
+        try {
+            // Pre-create "artifact" as a plain file so EndpointYamlGenerator's
+            // Files.createDirectories(outPath.resolve("artifact")) fails with an IOException.
+            deleteDirectories(targetDir);
+            Files.createDirectories(targetDir);
+            Files.createFile(targetDir.resolve("artifact"));
+
+            Map<String, Object> ctxData = new HashMap<>();
+            ctxData.put(Utils.GRAPHQL_EXPORTED_ENDPOINTS,
+                    List.of(new Endpoint("/graphql", 9090, "/graphql", "GraphQL", "service_graphql.graphql")));
+
+            List<Diagnostic> reportedDiagnostics = new ArrayList<>();
+            CompilerLifecycleEventContext context = new CompilerLifecycleEventContext() {
+                @Override
+                public Package currentPackage() {
+                    return currentPackage;
+                }
+
+                @Override
+                public PackageCompilation compilation() {
+                    return compilation;
+                }
+
+                @Override
+                public void reportDiagnostic(Diagnostic diagnostic) {
+                    reportedDiagnostics.add(diagnostic);
+                }
+
+                @Override
+                public Optional<Path> getGeneratedArtifactPath() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public BalCommand balCommand() {
+                    return BalCommand.BUILD;
+                }
+            };
+
+            new EndpointsYamlWriterTask(ctxData).perform(context);
+
+            Assert.assertEquals(reportedDiagnostics.size(), 1,
+                    "Expected one diagnostic reporting the endpoints.yaml write failure");
+            Assert.assertEquals(reportedDiagnostics.get(0).diagnosticInfo().severity(), DiagnosticSeverity.ERROR);
+            Assert.assertTrue(reportedDiagnostics.get(0).message().contains("artifact"),
+                    "Expected diagnostic to describe the write failure: " + reportedDiagnostics.get(0).message());
+        } finally {
+            deleteDirectories(targetDir);
+        }
+    }
+
+    private static void deleteDirectories(Path targetDir) throws Exception {
+        if (Files.exists(targetDir)) {
+            try (Stream<Path> paths = Files.walk(targetDir)) {
+                paths.sorted(Comparator.reverseOrder()).forEach(p -> {
+                    try {
+                        Files.delete(p);
+                    } catch (Exception e) {
+                        // best-effort cleanup
+                    }
+                });
+            }
+        }
+    }
+
+    private static ProjectEnvironmentBuilder getEnvironmentBuilder() {
+        Environment environment = EnvironmentBuilder.getBuilder().setBallerinaHome(DISTRIBUTION_PATH).build();
+        return ProjectEnvironmentBuilder.getBuilder(environment);
+    }
+}

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/endpointyaml/generator/EndpointsYamlWriterTaskTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/endpointyaml/generator/EndpointsYamlWriterTaskTest.java
@@ -55,6 +55,7 @@ public class EndpointsYamlWriterTaskTest {
     public void testPerformReportsDiagnosticWhenWriteFails() throws Exception {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("endpoint_details_extraction_tests")
                 .resolve("01_hardcoded_port");
+        String previousBallerinaHome = System.getProperty("ballerina.home");
         System.setProperty("ballerina.home", DISTRIBUTION_PATH.toString());
         BuildOptions buildOptions = BuildOptions.builder().build();
         BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath, buildOptions);
@@ -110,6 +111,11 @@ public class EndpointsYamlWriterTaskTest {
                     "Expected diagnostic to describe the write failure: " + reportedDiagnostics.get(0).message());
         } finally {
             deleteDirectories(targetDir);
+            if (previousBallerinaHome == null) {
+                System.clearProperty("ballerina.home");
+            } else {
+                System.setProperty("ballerina.home", previousBallerinaHome);
+            }
         }
     }
 

--- a/compiler-plugin-tests/src/test/resources/yaml_files/endpoints_single_service.yaml
+++ b/compiler-plugin-tests/src/test/resources/yaml_files/endpoints_single_service.yaml
@@ -1,4 +1,5 @@
-endpoint:
+endpoints:
+- name: "/graphql2"
   port: 4001
   basePath: "/graphql2"
   type: "GraphQL"

--- a/compiler-plugin-tests/src/test/resources/yaml_files/service_endpoint.yaml
+++ b/compiler-plugin-tests/src/test/resources/yaml_files/service_endpoint.yaml
@@ -1,5 +1,0 @@
-endpoint:
-  port: 9091
-  basePath: "/"
-  type: "GraphQL"
-  schemaPath: "service.graphql"

--- a/compiler-plugin-tests/src/test/resources/yaml_files/service_too_endpoint.yaml
+++ b/compiler-plugin-tests/src/test/resources/yaml_files/service_too_endpoint.yaml
@@ -1,5 +1,0 @@
-endpoint:
-  port: 9093
-  basePath: "/too"
-  type: "GraphQL"
-  schemaPath: "service_too.graphql"

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/GraphqlCompilerPlugin.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/GraphqlCompilerPlugin.java
@@ -21,6 +21,14 @@ package io.ballerina.stdlib.graphql.compiler;
 import io.ballerina.projects.plugins.CompilerPlugin;
 import io.ballerina.projects.plugins.CompilerPluginContext;
 import io.ballerina.stdlib.graphql.compiler.analyzer.GraphqlCodeAnalyzer;
+import io.ballerina.stdlib.graphql.compiler.endpointyaml.generator.Endpoint;
+import io.ballerina.stdlib.graphql.compiler.endpointyaml.generator.GraphqlEndpointsLifecycleListener;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+
+import static io.ballerina.stdlib.graphql.compiler.Utils.GRAPHQL_EXPORTED_ENDPOINTS;
 
 /**
  * This is the compiler plugin for Ballerina GraphQL package.
@@ -28,7 +36,10 @@ import io.ballerina.stdlib.graphql.compiler.analyzer.GraphqlCodeAnalyzer;
 public class GraphqlCompilerPlugin extends CompilerPlugin {
     @Override
     public void init(CompilerPluginContext compilerPluginContext) {
-        compilerPluginContext.addCodeModifier(new GraphqlCodeModifier(compilerPluginContext.userData()));
-        compilerPluginContext.addCodeAnalyzer(new GraphqlCodeAnalyzer(compilerPluginContext.userData()));
+        Map<String, Object> userData = compilerPluginContext.userData();
+        userData.put(GRAPHQL_EXPORTED_ENDPOINTS, Collections.synchronizedList(new ArrayList<Endpoint>()));
+        compilerPluginContext.addCodeModifier(new GraphqlCodeModifier(userData));
+        compilerPluginContext.addCodeAnalyzer(new GraphqlCodeAnalyzer(userData));
+        compilerPluginContext.addCompilerLifecycleListener(new GraphqlEndpointsLifecycleListener(userData));
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/ServiceDeclarationAnalysisTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/ServiceDeclarationAnalysisTask.java
@@ -25,6 +25,7 @@ import io.ballerina.projects.DocumentId;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 import io.ballerina.stdlib.graphql.commons.types.Schema;
+import io.ballerina.stdlib.graphql.compiler.endpointyaml.generator.Endpoint;
 import io.ballerina.stdlib.graphql.compiler.endpointyaml.generator.EndpointYamlGenerator;
 import io.ballerina.stdlib.graphql.compiler.schema.generator.SchemaExporter;
 import io.ballerina.stdlib.graphql.compiler.service.InterfaceEntityFinder;
@@ -33,9 +34,12 @@ import io.ballerina.tools.diagnostics.DiagnosticFactory;
 import io.ballerina.tools.diagnostics.DiagnosticInfo;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static io.ballerina.stdlib.graphql.commons.utils.Utils.isGraphqlService;
+import static io.ballerina.stdlib.graphql.compiler.Utils.GRAPHQL_EXPORTED_ENDPOINTS;
 import static io.ballerina.stdlib.graphql.compiler.Utils.hasCompilationErrors;
 import static io.ballerina.stdlib.graphql.compiler.schema.generator.GeneratorUtils.getDescription;
 
@@ -43,9 +47,11 @@ import static io.ballerina.stdlib.graphql.compiler.schema.generator.GeneratorUti
  * Validates a Ballerina GraphQL Service declaration.
  */
 public class ServiceDeclarationAnalysisTask extends ServiceAnalysisTask {
+    private final Map<String, Object> userData;
 
     public ServiceDeclarationAnalysisTask(Map<String, Object> nodeMap) {
         super(nodeMap);
+        this.userData = nodeMap;
     }
 
     @Override
@@ -95,7 +101,12 @@ public class ServiceDeclarationAnalysisTask extends ServiceAnalysisTask {
             EndpointYamlGenerator endpointYamlGeneratorImplGql = new EndpointYamlGenerator(node, context);
             SchemaExporter schemaExporter = new SchemaExporter(schema, context);
             try {
-                endpointYamlGeneratorImplGql.writeEndpointYaml();
+                Optional<Endpoint> endpoint = endpointYamlGeneratorImplGql.getEndpoint();
+                if (endpoint.isPresent()) {
+                    @SuppressWarnings("unchecked")
+                    List<Endpoint> collectedEndpoints = (List<Endpoint>) userData.get(GRAPHQL_EXPORTED_ENDPOINTS);
+                    collectedEndpoints.add(endpoint.get());
+                }
                 schemaExporter.exportSchema();
             } catch (Exception e) {
                 DiagnosticInfo diagnosticInfo = new DiagnosticInfo(

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/Utils.java
@@ -101,6 +101,7 @@ public final class Utils {
     // User data map keys
     public static final String IS_ANALYSIS_COMPLETED = "isAnalysisCompleted";
     public static final String MODIFIER_CONTEXT_MAP = "modifierContextMap";
+    public static final String GRAPHQL_EXPORTED_ENDPOINTS = "graphqlExportedEndpoints";
 
     private Utils() {
     }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/endpointyaml/generator/Endpoint.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/endpointyaml/generator/Endpoint.java
@@ -19,16 +19,22 @@
 package io.ballerina.stdlib.graphql.compiler.endpointyaml.generator;
 
 public class Endpoint {
+    private final String name;
     private final int port;
     private final String basePath;
     private final String type;
     private final String schemaPath;
 
-    Endpoint(int port, String basePath, String type, String schemaPath) {
+    Endpoint(String name, int port, String basePath, String type, String schemaPath) {
+        this.name = name;
         this.port = port;
         this.basePath = basePath;
         this.type = type;
         this.schemaPath = schemaPath;
+    }
+
+    public String getName() {
+        return name;
     }
 
     public String getBasePath() {

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/endpointyaml/generator/EndpointYamlGenerator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/endpointyaml/generator/EndpointYamlGenerator.java
@@ -42,8 +42,6 @@ import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
 import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
-import io.ballerina.projects.Package;
-import io.ballerina.projects.Project;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 import io.ballerina.tools.diagnostics.DiagnosticFactory;
 import io.ballerina.tools.diagnostics.DiagnosticInfo;
@@ -53,11 +51,9 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import static io.ballerina.stdlib.graphql.compiler.endpointyaml.generator.FileNameGeneratorUtil.resolveContractFileName;
 
 
 public class EndpointYamlGenerator {
@@ -70,8 +66,7 @@ public class EndpointYamlGenerator {
 
     private static final String ARTIFACT_DIR = "artifact";
     private static final String GRAPHQL = "GraphQL";
-    private static final String YAML_EXTENSION = ".yaml";
-    private static final String ENDPOINT_SUFFIX = "_endpoint";
+    private static final String ENDPOINTS_FILE_NAME = "endpoints.yaml";
     private static final String LISTEN_TO = "listenTo";
     private static final String EMPTY_STR = "";
     private static final int PORT_PARAMETER_INDEX = 0;
@@ -107,7 +102,7 @@ public class EndpointYamlGenerator {
         port = resolvePort(listenerInfo.argList());
         String basePath = buildBasePath();
 
-        return Optional.of(new Endpoint(port, basePath, GRAPHQL, this.schemaFileName));
+        return Optional.of(new Endpoint(basePath, port, basePath, GRAPHQL, this.schemaFileName));
     }
 
     private void ensureModuleVisited(String moduleName) {
@@ -259,31 +254,13 @@ public class EndpointYamlGenerator {
         return serviceBasePath;
     }
 
-    public void writeEndpointYaml() throws IOException {
-        Optional<Endpoint> ep = getEndpoint();
-        if (ep.isEmpty()) {
-            return;
-        }
-        Path outPath = resolveOutputPath();
-        String fileName = buildEndpointFileName(outPath);
-        Path path = outPath.resolve(ARTIFACT_DIR).resolve(fileName + YAML_EXTENSION);
-        writeYaml(path, new EndpointWrapper(ep.get()));
+    public static void writeEndpointsYaml(Path outPath, List<Endpoint> endpoints) throws IOException {
+        Files.createDirectories(outPath.resolve(ARTIFACT_DIR));
+        Path path = outPath.resolve(ARTIFACT_DIR).resolve(ENDPOINTS_FILE_NAME).toAbsolutePath();
+        writeYaml(path, new EndpointsWrapper(endpoints));
     }
 
-    private Path resolveOutputPath() throws IOException {
-        Package currentPackage = this.context.currentPackage();
-        Project project = currentPackage.project();
-        Path outPath = project.targetDir();
-        Files.createDirectories(Paths.get(String.valueOf(outPath), ARTIFACT_DIR));
-        return outPath;
-    }
-
-    private String buildEndpointFileName(Path outPath) {
-        String base = this.schemaFileName.split("\\.")[0] + ENDPOINT_SUFFIX;
-        return resolveContractFileName(outPath.resolve(ARTIFACT_DIR), base, context);
-    }
-
-    private void writeYaml(Path path, EndpointWrapper wrapper) throws IOException {
+    private static void writeYaml(Path path, EndpointsWrapper wrapper) throws IOException {
         YAMLFactory yamlFactory = YAMLFactory.builder()
                 .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
                 .build();

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/endpointyaml/generator/EndpointsWrapper.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/endpointyaml/generator/EndpointsWrapper.java
@@ -18,17 +18,19 @@
 
 package io.ballerina.stdlib.graphql.compiler.endpointyaml.generator;
 
-import java.util.Objects;
+import java.util.List;
 
-public class EndpointWrapper {
-    private final Endpoint endpoint;
-    private static final String ENDPOINT_NOT_NULL_MSG = "endpoint must not be null";
+/*
+ * Represents the wrapper class to serialize the consolidated list of endpoints.
+ */
+public class EndpointsWrapper {
+    private final List<Endpoint> endpoints;
 
-    public EndpointWrapper(Endpoint endpoint) {
-        this.endpoint = Objects.requireNonNull(endpoint, ENDPOINT_NOT_NULL_MSG);
+    public EndpointsWrapper(List<Endpoint> endpoints) {
+        this.endpoints = List.copyOf(endpoints);
     }
 
-    public Endpoint getEndpoint() {
-        return endpoint;
+    public List<Endpoint> getEndpoints() {
+        return endpoints;
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/endpointyaml/generator/EndpointsYamlWriterTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/endpointyaml/generator/EndpointsYamlWriterTask.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.graphql.compiler.endpointyaml.generator;
+
+import io.ballerina.projects.Package;
+import io.ballerina.projects.plugins.CompilerLifecycleEventContext;
+import io.ballerina.projects.plugins.CompilerLifecycleTask;
+import io.ballerina.tools.diagnostics.DiagnosticFactory;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+import io.ballerina.tools.diagnostics.Location;
+import io.ballerina.tools.text.LinePosition;
+import io.ballerina.tools.text.LineRange;
+import io.ballerina.tools.text.TextRange;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static io.ballerina.stdlib.graphql.compiler.Utils.GRAPHQL_EXPORTED_ENDPOINTS;
+
+/*
+ * Writes every endpoint collected by {@link io.ballerina.stdlib.graphql.compiler.ServiceDeclarationAnalysisTask}
+ * during code analysis into a single, consolidated endpoints.yaml, once for the whole compilation after code
+ * generation has completed.
+ */
+public class EndpointsYamlWriterTask implements CompilerLifecycleTask<CompilerLifecycleEventContext> {
+    private final Map<String, Object> ctxData;
+
+    public EndpointsYamlWriterTask(Map<String, Object> ctxData) {
+        this.ctxData = ctxData;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void perform(CompilerLifecycleEventContext context) {
+        List<Endpoint> endpoints = (List<Endpoint>) ctxData.get(GRAPHQL_EXPORTED_ENDPOINTS);
+        if (endpoints == null || endpoints.isEmpty()) {
+            return;
+        }
+        Package currentPackage = context.currentPackage();
+        if (currentPackage == null) {
+            return;
+        }
+        try {
+            EndpointYamlGenerator.writeEndpointsYaml(currentPackage.project().targetDir(), endpoints);
+        } catch (IOException e) {
+            context.reportDiagnostic(DiagnosticFactory.createDiagnostic(
+                    new DiagnosticInfo("GRAPHQL_PLUGIN_DEBUG", "[graphql-plugin] " + e.getMessage(),
+                            DiagnosticSeverity.ERROR),
+                    NULL_LOCATION));
+        }
+    }
+
+    private static final Location NULL_LOCATION = new Location() {
+        private static final LineRange LINE_RANGE =
+                LineRange.from("", LinePosition.from(0, 0), LinePosition.from(0, 0));
+        private static final TextRange TEXT_RANGE = TextRange.from(0, 0);
+
+        @Override
+        public LineRange lineRange() {
+            return LINE_RANGE;
+        }
+
+        @Override
+        public TextRange textRange() {
+            return TEXT_RANGE;
+        }
+    };
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/endpointyaml/generator/GraphqlEndpointsLifecycleListener.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/endpointyaml/generator/GraphqlEndpointsLifecycleListener.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.graphql.compiler.endpointyaml.generator;
+
+import io.ballerina.projects.plugins.CompilerLifecycleContext;
+import io.ballerina.projects.plugins.CompilerLifecycleListener;
+
+import java.util.Map;
+
+/*
+ * Registers the {@code EndpointsYamlWriterTask} to run once the whole compilation's code generation
+ * has completed, so it can aggregate every service's endpoint details into a single endpoints.yaml.
+ */
+public class GraphqlEndpointsLifecycleListener extends CompilerLifecycleListener {
+    private final Map<String, Object> ctxData;
+
+    public GraphqlEndpointsLifecycleListener(Map<String, Object> ctxData) {
+        this.ctxData = ctxData;
+    }
+
+    @Override
+    public void init(CompilerLifecycleContext context) {
+        context.addCodeGenerationCompletedTask(new EndpointsYamlWriterTask(ctxData));
+    }
+}


### PR DESCRIPTION
## Summary

Applies the same architectural migration already shipped for `module-ballerina-http` (#2660) and `module-ballerina-grpc` (#1756/#1765): move the final endpoint-yaml artifact write from per-service `SyntaxNodeAnalysisContext` handling to a single consolidated write via `CompilerLifecycleEventContext`, run once after code generation completes.

- Per-service extraction (`EndpointYamlGenerator.getEndpoint()`) stays on `SyntaxNodeAnalysisContext`, since semantic-model symbol resolution for resource methods becomes unreliable once code generation has completed.
- Endpoints are now collected into a shared list (via the existing compiler-plugin `userData` map) instead of writing a separate `<service>_endpoint.yaml` file per service directly inside the analysis task.
- A new `EndpointsYamlWriterTask` (`CompilerLifecycleTask`), registered via `GraphqlEndpointsLifecycleListener`, writes one consolidated `endpoints.yaml` after code generation completes.
- `EndpointWrapper` → `EndpointsWrapper` (wraps a `List<Endpoint>`); `Endpoint` gained a `name` field (= basePath) for the multi-entry YAML shape.
- Tests updated for the new consolidated file name/shape.

## Update: root cause found and fixed - no longer blocked

The 14/34 test failures originally reported here were **not** caused by registering a `CompilerLifecycleListener` alongside `GraphqlCodeModifier`'s `addSourceModifierTask`, and are not a ballerina-lang bug. Full analysis: [ballerina-lang#44684](https://github.com/ballerina-platform/ballerina-lang/issues/44684#issuecomment-5201015558).

Root cause: `Package.runCodeGenAndModifyPlugins()` swaps the `Project`'s internal current-package reference as a side effect of running the code modifier, but only returns a `DiagnosticResult` - not the updated package. `getDiagnosticResults()` in the test helpers captured `currentPackage` *before* calling it and then called `.getCompilation()` on that stale, pre-rewrite reference. Since the stale and fresh `Package` share the same `Project` (and therefore the same `CompilerContext`), compiling the rewritten package internally (inside the modifier pipeline) then compiling the stale package right after reused compiler-internal closure/symbol bookkeeping sized for the wrong tree - producing `IndexOutOfBoundsException` in `ClosureGenerator` during desugaring. `bal build`'s own `CompileTask` never hits this because it re-fetches `project.currentPackage()` fresh instead of reusing a captured reference.

Fixed by re-fetching `project.currentPackage()` in both test helpers instead of reusing the stale local variable. Verified against the real pinned `2201.13.3` distribution: compiler-plugin-tests suite is now 151/151 passing (was 14/34 failing in this module's test class before the fix).

## Test plan

- [x] `./gradlew :graphql-compiler-plugin-tests:test` - 151/151 passing
- [x] Root cause isolated and confirmed via an A/B/C reference-identity probe (stale reference crashes; fresh `project.currentPackage()` or `codeModifierResult.updatedPackage()` both pass)
- [x] Verified `bal build --export-endpoints` against real fixtures independently succeeds, consistent with the fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Migrates GraphQL endpoint YAML export to the compiler lifecycle architecture used by the HTTP and gRPC modules.

- Collects endpoints through compiler-plugin user data during analysis.
- Writes all endpoints to one `endpoints.yaml` file after code generation.
- Adds endpoint names and updates the YAML structure.
- Updates lifecycle components, wrappers, generators, and tests.
- Refreshes test package references after code generation changes the current package.
- Reports endpoint artifact write failures as compiler diagnostics.
- All 151 compiler-plugin tests pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->