### PR TITLE
Fix GraphQL endpoint export missing port when listener wraps another listener

### DIFF
--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/EndpointDetailsExtractorTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/EndpointDetailsExtractorTest.java
@@ -229,6 +229,57 @@ public class EndpointDetailsExtractorTest {
     }
 
     @Test
+    public void testGraphqlListenerWrappingSharedHttpListener() throws IOException {
+        Path projectDirPath = RESOURCE_DIRECTORY.resolve(ENDPOINT_DETAILS_EXTRACTION_TESTS)
+                .resolve("16_graphql_wrapping_shared_http_listener");
+        try {
+            DiagnosticResult diagnosticResult = getDiagnosticResults(projectDirPath);
+            Assert.assertEquals(diagnosticResult.errorCount(), 0,
+                    "Expected no errors when a GraphQL listener wraps a shared http listener");
+            Path endpointYaml = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR)
+                    .resolve(ENDPOINTS_FILE_NAME);
+            Assert.assertTrue(Files.exists(endpointYaml), "Endpoint YAML should be generated");
+            assertPortForEndpointType(endpointYaml, "GraphQL", 9100);
+        } finally {
+            deleteDirectories(projectDirPath);
+        }
+    }
+
+    @Test
+    public void testGraphqlListenerDeclarationWrappingSharedListener() throws IOException {
+        Path projectDirPath = RESOURCE_DIRECTORY.resolve(ENDPOINT_DETAILS_EXTRACTION_TESTS)
+                .resolve("17_graphql_listener_wrapping_shared_listener");
+        try {
+            DiagnosticResult diagnosticResult = getDiagnosticResults(projectDirPath);
+            Assert.assertEquals(diagnosticResult.errorCount(), 0,
+                    "Expected no errors when a `listener graphql:Listener` wraps a shared http listener");
+            Path endpointYaml = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR)
+                    .resolve(ENDPOINTS_FILE_NAME);
+            Assert.assertTrue(Files.exists(endpointYaml), "Endpoint YAML should be generated");
+            assertEndpointPort(endpointYaml, 9101);
+        } finally {
+            deleteDirectories(projectDirPath);
+        }
+    }
+
+    @Test
+    public void testGraphqlListenerWrappingInlineNewListener() throws IOException {
+        Path projectDirPath = RESOURCE_DIRECTORY.resolve(ENDPOINT_DETAILS_EXTRACTION_TESTS)
+                .resolve("18_graphql_wrapping_inline_new_listener");
+        try {
+            DiagnosticResult diagnosticResult = getDiagnosticResults(projectDirPath);
+            Assert.assertEquals(diagnosticResult.errorCount(), 0,
+                    "Expected no errors when a GraphQL listener wraps an inline `new` listener expression");
+            Path endpointYaml = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR)
+                    .resolve(ENDPOINTS_FILE_NAME);
+            Assert.assertTrue(Files.exists(endpointYaml), "Endpoint YAML should be generated");
+            assertEndpointPort(endpointYaml, 9102);
+        } finally {
+            deleteDirectories(projectDirPath);
+        }
+    }
+
+    @Test
     public void testRequiredConfigurablePortReportsDiagnostic() throws IOException {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve(ENDPOINT_DETAILS_EXTRACTION_TESTS)
                 .resolve("03_configurable_port_required");
@@ -291,6 +342,28 @@ public class EndpointDetailsExtractorTest {
             int actualPort = Integer.parseInt(portLine.substring("port:".length()).trim());
             Assert.assertEquals(actualPort, expectedPort, "Unexpected endpoint port in " + endpointYaml);
         }
+    }
+
+    private static void assertPortForEndpointType(Path endpointYaml, String type, int expectedPort)
+            throws IOException {
+        String content = Files.readString(endpointYaml);
+        String typeMarker = "type: \"" + type + "\"";
+        for (String block : content.split("(?=- name:)")) {
+            if (!block.contains(typeMarker)) {
+                continue;
+            }
+            String portLine = block.lines()
+                    .map(String::trim)
+                    .filter(line -> line.startsWith("port:"))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("No port field found for type " + type + " in "
+                            + endpointYaml));
+            int actualPort = Integer.parseInt(portLine.substring("port:".length()).trim());
+            Assert.assertEquals(actualPort, expectedPort, "Unexpected port for endpoint type " + type + " in "
+                    + endpointYaml);
+            return;
+        }
+        Assert.fail("No endpoint of type " + type + " found in " + endpointYaml);
     }
 
     private static void assertEndpointBasePath(Path endpointYaml, String expectedBasePath) throws IOException {

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/EndpointDetailsExtractorTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/EndpointDetailsExtractorTest.java
@@ -280,6 +280,23 @@ public class EndpointDetailsExtractorTest {
     }
 
     @Test
+    public void testGraphqlListenerWrappingImplicitNewListener() throws IOException {
+        Path projectDirPath = RESOURCE_DIRECTORY.resolve(ENDPOINT_DETAILS_EXTRACTION_TESTS)
+                .resolve("19_graphql_wrapping_implicit_new_listener");
+        try {
+            DiagnosticResult diagnosticResult = getDiagnosticResults(projectDirPath);
+            Assert.assertEquals(diagnosticResult.errorCount(), 0,
+                    "Expected no errors when a GraphQL listener wraps an implicit `new` listener expression");
+            Path endpointYaml = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR)
+                    .resolve(ENDPOINTS_FILE_NAME);
+            Assert.assertTrue(Files.exists(endpointYaml), "Endpoint YAML should be generated");
+            assertPortForEndpointType(endpointYaml, "GraphQL", 9103);
+        } finally {
+            deleteDirectories(projectDirPath);
+        }
+    }
+
+    @Test
     public void testRequiredConfigurablePortReportsDiagnostic() throws IOException {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve(ENDPOINT_DETAILS_EXTRACTION_TESTS)
                 .resolve("03_configurable_port_required");

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/16_graphql_wrapping_shared_http_listener/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/16_graphql_wrapping_shared_http_listener/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "graphql_test"
+name = "graphql_wrapping_shared_http_listener"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/16_graphql_wrapping_shared_http_listener/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/16_graphql_wrapping_shared_http_listener/service.bal
@@ -1,6 +1,6 @@
-// Copyright (c) 2026 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2026 WSO2 LLC. (http://www.wso2.org).
 //
-// WSO2 Inc. licenses this file to you under the Apache License,
+// WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.
 // You may obtain a copy of the License at

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/16_graphql_wrapping_shared_http_listener/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/16_graphql_wrapping_shared_http_listener/service.bal
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/graphql;
+import ballerina/http;
+
+listener http:Listener sharedEp = new (9100);
+
+service / on new graphql:Listener(sharedEp) {
+    resource function get greeting() returns string {
+        return "Hello";
+    }
+}
+
+service /api on sharedEp {
+    resource function get greeting() returns string {
+        return "Hello";
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/17_graphql_listener_wrapping_shared_listener/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/17_graphql_listener_wrapping_shared_listener/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "graphql_test"
+name = "graphql_listener_wrapping_shared_listener"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/17_graphql_listener_wrapping_shared_listener/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/17_graphql_listener_wrapping_shared_listener/service.bal
@@ -1,6 +1,6 @@
-// Copyright (c) 2026 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2026 WSO2 LLC. (http://www.wso2.org).
 //
-// WSO2 Inc. licenses this file to you under the Apache License,
+// WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.
 // You may obtain a copy of the License at

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/17_graphql_listener_wrapping_shared_listener/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/17_graphql_listener_wrapping_shared_listener/service.bal
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/graphql;
+import ballerina/http;
+
+listener http:Listener httpEp = new (9101);
+listener graphql:Listener gqlEp = new (httpEp);
+
+service /graphql on gqlEp {
+    resource function get greeting() returns string {
+        return "Hello";
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/18_graphql_wrapping_inline_new_listener/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/18_graphql_wrapping_inline_new_listener/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "graphql_test"
+name = "graphql_wrapping_inline_new_listener"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/18_graphql_wrapping_inline_new_listener/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/18_graphql_wrapping_inline_new_listener/service.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/graphql;
+import ballerina/http;
+
+service /graphql on new graphql:Listener(check new http:Listener(9102)) {
+    resource function get greeting() returns string {
+        return "Hello";
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/18_graphql_wrapping_inline_new_listener/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/18_graphql_wrapping_inline_new_listener/service.bal
@@ -1,6 +1,6 @@
-// Copyright (c) 2026 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2026 WSO2 LLC. (http://www.wso2.org).
 //
-// WSO2 Inc. licenses this file to you under the Apache License,
+// WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.
 // You may obtain a copy of the License at

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/19_graphql_wrapping_implicit_new_listener/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/19_graphql_wrapping_implicit_new_listener/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "graphql_test"
+name = "graphql_wrapping_implicit_new_listener"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/19_graphql_wrapping_implicit_new_listener/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/endpoint_details_extraction_tests/19_graphql_wrapping_implicit_new_listener/service.bal
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 WSO2 LLC. (http://www.wso2.org).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/graphql;
+import ballerina/http;
+
+listener http:Listener unrelatedEp = new (9104);
+
+service /graphql on new graphql:Listener(check new (9103)) {
+    resource function get greeting() returns string {
+        return "Hello";
+    }
+}
+
+service /rest on unrelatedEp {
+    resource function get greeting() returns string {
+        return "Hello";
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/endpointyaml/generator/EndpointYamlGenerator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/endpointyaml/generator/EndpointYamlGenerator.java
@@ -200,7 +200,7 @@ public class EndpointYamlGenerator {
      */
     private ParenthesizedArgList resolveEffectiveArgList(ParenthesizedArgList argList, String moduleName) {
         SeparatedNodeList<FunctionArgumentNode> arguments = argList.arguments();
-        if (arguments.isEmpty() || !(arguments.get(0) instanceof PositionalArgumentNode positionalArg)) {
+        if (!(arguments.get(0) instanceof PositionalArgumentNode positionalArg)) {
             return argList;
         }
         ExpressionNode expr = unwrapCheckExpression(positionalArg.expression());

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/endpointyaml/generator/EndpointYamlGenerator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/endpointyaml/generator/EndpointYamlGenerator.java
@@ -88,7 +88,8 @@ public class EndpointYamlGenerator {
             return Optional.empty();
         }
         ListenerInfo listenerInfo = listenerInfoOpt.get();
-        port = resolvePort(listenerInfo.argList());
+        ParenthesizedArgList effectiveArgList = resolveEffectiveArgList(listenerInfo.argList(), moduleName);
+        port = resolvePort(effectiveArgList);
         String basePath = buildBasePath();
 
         return Optional.of(new Endpoint(basePath, port, basePath, GRAPHQL, this.schemaFileName));
@@ -188,6 +189,44 @@ public class EndpointYamlGenerator {
             case IMPLICIT_NEW_EXPRESSION -> ((ImplicitNewExpressionNode) initializer).parenthesizedArgList();
             default -> Optional.empty();
         };
+    }
+
+    /**
+     * A listener passed as the first argument to a {@code new} expression (e.g.
+     * {@code new graphql:Listener(httpListener)}) is not itself the port value; it is a reference to another
+     * listener whose own arguments (or nested wrapped listener) carry the port. This walks through any number of
+     * such wrapping layers, e.g. a module-level listener declaration or a nested {@code new} expression, until it
+     * finds the argument list that actually carries the port.
+     */
+    private ParenthesizedArgList resolveEffectiveArgList(ParenthesizedArgList argList, String moduleName) {
+        SeparatedNodeList<FunctionArgumentNode> arguments = argList.arguments();
+        if (arguments.isEmpty() || !(arguments.get(0) instanceof PositionalArgumentNode positionalArg)) {
+            return argList;
+        }
+        ExpressionNode expr = unwrapCheckExpression(positionalArg.expression());
+
+        Optional<ParenthesizedArgList> wrappedArgList;
+        if (expr instanceof ExplicitNewExpressionNode explicit) {
+            wrappedArgList = Optional.ofNullable(explicit.parenthesizedArgList());
+        } else if (expr instanceof ImplicitNewExpressionNode implicit) {
+            wrappedArgList = implicit.parenthesizedArgList();
+        } else if (isNameReference(expr)) {
+            wrappedArgList = resolveWrappedListenerArgList(expr, moduleName);
+        } else {
+            wrappedArgList = Optional.empty();
+        }
+
+        return wrappedArgList.map(inner -> resolveEffectiveArgList(inner, moduleName)).orElse(argList);
+    }
+
+    private Optional<ParenthesizedArgList> resolveWrappedListenerArgList(ExpressionNode expr, String moduleName) {
+        String listenerModuleName = getModuleName(context.semanticModel(), expr);
+        if (listenerModuleName.isEmpty()) {
+            listenerModuleName = moduleName;
+        }
+        String listenerName = extractVariableName(expr);
+        return packageMemberVisitor.getListenerDeclaration(listenerModuleName, listenerName)
+                .flatMap(this::extractArgListFromListenerDecl);
     }
 
     private int resolvePort(ParenthesizedArgList argListOpt) {


### PR DESCRIPTION
## Summary
- `EndpointYamlGenerator` assumed the first constructor argument of a service's listener was always the port. That breaks when the GraphQL listener wraps another listener, e.g. `new graphql:Listener(sharedListener)` or `listener graphql:Listener gl = new (sharedListener)` — the argument is a listener reference, not a port, so it silently fell back to port `0`. This is the pattern used to run GraphQL and HTTP/REST services on a shared listener (wso2/product-integrator#2185).
- Added `resolveEffectiveArgList`, which recursively unwraps listener-constructor arguments (nested `new` expressions and named listener declarations) until it finds the argument list that actually carries the port.

## Test plan
- [x] Added `EndpointDetailsExtractorTest` cases: GraphQL listener wrapping a shared `http:Listener` (matches the reported issue), a module-level `listener graphql:Listener` wrapping a shared listener, and an inline nested `new graphql:Listener(check new http:Listener(...))`.
- [x] Ran `EndpointDetailsExtractorTest` (15 tests) — all pass.
- [x] Manually reproduced the reported issue with a local Ballerina distribution and confirmed the exported `endpoints.yaml` now reports the correct port instead of `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fix GraphQL endpoint export when a listener wraps another listener. The endpoint generator now recursively resolves nested listener constructors and named listener declarations to identify the configured port.

Add test coverage for shared listeners, module-level listener declarations, inline nested listener constructors, and implicit `new` listeners. Verify that generated `endpoints.yaml` files contain the expected ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->