### PR TITLE
report warning for unsupported endpoint export

### DIFF
--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/CompilationDiagnostic.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/CompilationDiagnostic.java
@@ -113,7 +113,9 @@ public enum CompilationDiagnostic {
                                                                      DiagnosticSeverity.WARNING),
     UNABLE_TO_VALIDATE_DEFAULT_VALUES_OF_INPUT_OBJECT_AT_COMPILE_TIME(DiagnosticMessage.WARNING_210,
                                                                       DiagnosticCode.WARNING_210,
-                                                                      DiagnosticSeverity.WARNING);
+                                                                      DiagnosticSeverity.WARNING),
+    UNSUPPORTED_ENDPOINT_METADATA(DiagnosticMessage.WARNING_211, DiagnosticCode.WARNING_211,
+                                   DiagnosticSeverity.WARNING);
 
     private final String diagnostic;
     private final String diagnosticCode;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/DiagnosticCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/DiagnosticCode.java
@@ -79,5 +79,6 @@ public enum DiagnosticCode {
     GRAPHQL_207,
     GRAPHQL_208,
     WARNING_209,
-    WARNING_210
+    WARNING_210,
+    WARNING_211
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/DiagnosticMessage.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/diagnostics/DiagnosticMessage.java
@@ -119,7 +119,8 @@ public enum DiagnosticMessage {
                         + "resolve this warning"),
     WARNING_210("unable to validate the default values of input type ''{0}''. This could potentially lead to the "
                         + "generation of an incorrect GraphQL schema. Try defining this type in the same module where"
-                        + " the graphql:Service is defined to resolve this warning");
+                        + " the graphql:Service is defined to resolve this warning"),
+    WARNING_211("the Ballerina version is not supported for endpoints.yaml. Try using Ballerina 2201.13.6 or above");
 
     private final String message;
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/endpointyaml/generator/EndpointMetadataTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/graphql/compiler/endpointyaml/generator/EndpointMetadataTask.java
@@ -19,6 +19,13 @@ package io.ballerina.stdlib.graphql.compiler.endpointyaml.generator;
 
 import io.ballerina.projects.plugins.CompilerLifecycleEventContext;
 import io.ballerina.projects.plugins.CompilerLifecycleTask;
+import io.ballerina.stdlib.graphql.compiler.diagnostics.CompilationDiagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticFactory;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
+import io.ballerina.tools.diagnostics.Location;
+import io.ballerina.tools.text.LinePosition;
+import io.ballerina.tools.text.LineRange;
+import io.ballerina.tools.text.TextRange;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -48,23 +55,41 @@ public class EndpointMetadataTask implements CompilerLifecycleTask<CompilerLifec
         if (endpoints == null || endpoints.isEmpty()) {
             return;
         }
-        for (Endpoint endpoint : endpoints) {
-            addEndpointMetadata(context, endpoint);
+        try {
+            for (Endpoint endpoint : endpoints) {
+                addEndpointMetadata(context, endpoint);
+            }
+        } catch (ReflectiveOperationException | SecurityException e) {
+            DiagnosticInfo diagnosticInfo = new DiagnosticInfo(
+                    CompilationDiagnostic.UNSUPPORTED_ENDPOINT_METADATA.getDiagnosticCode(),
+                    CompilationDiagnostic.UNSUPPORTED_ENDPOINT_METADATA.getDiagnostic(),
+                    CompilationDiagnostic.UNSUPPORTED_ENDPOINT_METADATA.getDiagnosticSeverity());
+            context.reportDiagnostic(DiagnosticFactory.createDiagnostic(diagnosticInfo, new NullLocation()));
         }
     }
 
-    private void addEndpointMetadata(CompilerLifecycleEventContext context, Endpoint endpoint) {
-        try {
-            Class<?> endpointMetaInfoClass = Class.forName(ENDPOINT_META_INFO_CLASS);
-            Constructor<?> constructor = endpointMetaInfoClass.getConstructor(String.class, int.class, String.class,
-                    String.class, String.class);
-            Object endpointMetaInfo = constructor.newInstance(endpoint.getName(), endpoint.getPort(),
-                    endpoint.getBasePath(), endpoint.getType(), endpoint.getSchemaPath());
-            Method method = context.getClass().getMethod(ADD_ENDPOINT_METADATA_METHOD, endpointMetaInfoClass);
-            method.setAccessible(true);
-            method.invoke(context, endpointMetaInfo);
-        } catch (ReflectiveOperationException | SecurityException e) {
-            // Endpoint metadata export is supported only with newer Ballerina lang versions.
+    private void addEndpointMetadata(CompilerLifecycleEventContext context, Endpoint endpoint)
+            throws ReflectiveOperationException {
+        Class<?> endpointMetaInfoClass = Class.forName(ENDPOINT_META_INFO_CLASS);
+        Constructor<?> constructor = endpointMetaInfoClass.getConstructor(String.class, int.class, String.class,
+                String.class, String.class);
+        Object endpointMetaInfo = constructor.newInstance(endpoint.getName(), endpoint.getPort(),
+                endpoint.getBasePath(), endpoint.getType(), endpoint.getSchemaPath());
+        Method method = context.getClass().getMethod(ADD_ENDPOINT_METADATA_METHOD, endpointMetaInfoClass);
+        method.setAccessible(true);
+        method.invoke(context, endpointMetaInfo);
+    }
+
+    private static class NullLocation implements Location {
+        @Override
+        public LineRange lineRange() {
+            LinePosition position = LinePosition.from(0, 0);
+            return LineRange.from("", position, position);
+        }
+
+        @Override
+        public TextRange textRange() {
+            return TextRange.from(0, 0);
         }
     }
 }


### PR DESCRIPTION
## Purpose

Fixes:

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
- [ ] No `commons` package changes (if there are any, please update the GraphQL version in [GraphQL tools](https://github.com/ballerina-platform/graphql-tools) and [Ballerina dev tools](https://github.com/ballerina-platform/ballerina-dev-tools))
- [ ] No `compiler` package changes (if there are any, please update the GraphQL version in [Ballerina dev tools](https://github.com/ballerina-platform/ballerina-dev-tools))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added a compilation warning for unsupported endpoint metadata exports.
- Updated endpoint metadata generation to report reflection or security failures instead of ignoring them.
- Added diagnostic code and message `WARNING_211` for unsupported `endpoints.yaml` versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->