### PR TITLE
DO NOT MERGE: diagnostic - re-enable subscription tests on Linux CI

### DIFF
--- a/ballerina-tests/build.gradle
+++ b/ballerina-tests/build.gradle
@@ -165,18 +165,6 @@ task ballerinaTest {
 
     doLast {
         testSuites.each { testPackage ->
-            // TODO: Disable the graphql-subscription-test-suite on Linux
-            // Check issue: https://github.com/ballerina-platform/ballerina-library/issues/7529
-            if (Os.isFamily(Os.FAMILY_UNIX) && testPackage == "graphql-subscription-test-suite") {
-                return
-            }
-            // TODO: Disable the client_subscriptions group on Linux; these tests hang
-            // intermittently under CI's Ubuntu runner.
-            def effectiveDisableGroups = disableGroups
-            if (Os.isFamily(Os.FAMILY_UNIX) && testPackage == "graphql-client-test-suite") {
-                effectiveDisableGroups = disableGroups ?
-                        "${disableGroups},client_subscriptions" : "--disable-groups client_subscriptions"
-            }
             if (!skipTests) {
                 exec {
                     workingDir "${project.projectDir}/${testPackage}"
@@ -184,7 +172,7 @@ task ballerinaTest {
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                         commandLine 'cmd', '/c', "${balJavaDebugParam} ${distributionBinPath}/bal.bat test ${graalvmFlag} ${testParams} --offline ${groupParams} ${disableGroups} ${debugParams} && exit %%ERRORLEVEL%%"
                     } else {
-                        commandLine 'sh', '-c', "BALLERINA_MAX_POOL_SIZE=500 ${balJavaDebugParam} ${distributionBinPath}/bal test ${graalvmFlag} ${testParams} --offline ${groupParams} ${effectiveDisableGroups} ${debugParams}"
+                        commandLine 'sh', '-c', "BALLERINA_MAX_POOL_SIZE=500 ${balJavaDebugParam} ${distributionBinPath}/bal test ${graalvmFlag} ${testParams} --offline ${groupParams} ${disableGroups} ${debugParams}"
                     }
                 }
             }


### PR DESCRIPTION
**Diagnostic PR. Do not merge.** Opened to get a real GitHub-runner data point; will be closed once the investigation concludes.

## What this does

Removes both Linux test skips in `ballerina-tests/build.gradle`:

1. The whole `graphql-subscription-test-suite` (server-side subscription tests), skipped on Unix since [ballerina-library#7529](https://github.com/ballerina-platform/ballerina-library/issues/7529).
2. The `client_subscriptions` group in `graphql-client-test-suite`, disabled on Unix by 243f3412 in #2534.

## Why now

Neither skip has been exercised on Ubuntu CI since the fixes that should address them landed:

- **Server side:** the RFC 6455 simultaneous-close race was fixed in `module-ballerina-http` ([#2665](https://github.com/ballerina-platform/module-ballerina-http/pull/2665) + 2.15.x/2.16.x backports) and released in `http` v2.15.8, which `master` now pins.
- **Client side:** the `pongTimeout` widening (543bddb9) and the mock abnormal-close fix (a3e45f95) landed in the *same push* that disabled the group, so they were never actually run against Ubuntu with the group enabled.

## What we are looking for

The dominant Ubuntu failure signature across #2534's runs was:

```
CompleteEarlyError("The GraphQL subscription server stopped responding to the keep-alive ping messages")
```

hit by `testSubscriptionWithRecordBinding`, `testSubscriptionWithJsonBinding`, `testSubscriptionWithGenericResponseBinding`, `testMultipleConcurrentSubscriptions`, `testPingPongKeepAlive` and `testPingMessageHandlerErrorResilience`, plus reconnect-resume assertion failures in `testReconnectResumesSubscriptions` and `testClosedStreamNotResubscribed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8625FcUxKSGaXdNj4PAeh