### PR TITLE
Drop timestamped websocket dependency version for release

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -47,7 +47,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.2"
+version = "2.9.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -59,7 +59,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -115,7 +115,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.15.0"
+version = "2.15.8"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -148,7 +148,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -295,7 +295,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.0"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -346,7 +346,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.0"
+version = "2.11.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"},
@@ -370,7 +370,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -381,7 +381,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -403,7 +403,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "websocket"
-version = "2.15.5"
+version = "2.15.6"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "constraint"},

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ stdlibOAuth2Version=2.15.0
 stdlibHttpVersion=2.15.8
 
 # Level 06
-stdlibWebsocketVersion=2.15.6-20260904-111900-8bf225d
+stdlibWebsocketVersion=2.15.6
 
 # Ballerinax Observer
 observeVersion=1.7.1


### PR DESCRIPTION
## Summary
- `stdlibWebsocketVersion` in `gradle.properties` was pinned to a timestamped nightly build (`2.15.6-20260904-111900-8bf225d`), used to pick up an unreleased fix during development.
- module-ballerina-websocket [v2.15.6](https://github.com/ballerina-platform/module-ballerina-websocket/releases/tag/v2.15.6) has since been released, so this switches to the clean release version ahead of this repo's own release.
- Ran a full `./gradlew build` to regenerate `ballerina/Dependencies.toml`, which also picked up several other stdlib versions (crypto, data.jsondata, http, io, mime, task, time, url) that had drifted out of sync with `gradle.properties`.

## Test plan
- [x] `./gradlew clean build -x test` passes locally with no further Dependencies.toml drift
- [x] CI build passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates `stdlibWebsocketVersion` from the nightly snapshot to released version `2.15.6`.

Regenerates `ballerina/Dependencies.toml` with aligned versions for related standard library dependencies. The clean build passes with tests skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->