### PR TITLE
chore: sync test module versions to 1.18.1 and fix toml-sync build bug

### DIFF
--- a/ballerina-tests/build.gradle
+++ b/ballerina-tests/build.gradle
@@ -67,12 +67,13 @@ task updateTomlFiles {
             newBallerinaToml = newBallerinaToml.replace("@package.name@", testPackage.replaceAll("-", "_"))
             ballerinaTomlFile.text = newBallerinaToml
         }
+
+        def ballerinaTomlFile =  new File("${project.projectDir}/${testCommonPackage}/Ballerina.toml")
+        def newBallerinaToml = testCommonTomlFilePlaceHolder.text.replace("@project.version@", project.version)
+        newBallerinaToml = newBallerinaToml.replace("@toml.version@", tomlVersion)
+        newBallerinaToml = newBallerinaToml.replace("@package.name@", testCommonPackage.replaceAll("-", "_"))
+        ballerinaTomlFile.text = newBallerinaToml
     }
-    def ballerinaTomlFile =  new File("${project.projectDir}/${testCommonPackage}/Ballerina.toml")
-    def newBallerinaToml = testCommonTomlFilePlaceHolder.text.replace("@project.version@", project.version)
-    newBallerinaToml = newBallerinaToml.replace("@toml.version@", tomlVersion)
-    newBallerinaToml = newBallerinaToml.replace("@package.name@", testCommonPackage.replaceAll("-", "_"))
-    ballerinaTomlFile.text = newBallerinaToml
 }
 
 task commitTomlFiles {

--- a/ballerina-tests/graphql-advanced-test-suite/Ballerina.toml
+++ b/ballerina-tests/graphql-advanced-test-suite/Ballerina.toml
@@ -1,10 +1,10 @@
 [package]
 org = "ballerina"
 name = "graphql_advanced_test_suite"
-version = "1.18.0"
+version = "1.18.1"
 
 [[dependency]]
 org = "ballerina"
 name = "graphql_test_common"
 repository = "local"
-version = "1.18.0"
+version = "1.18.1"

--- a/ballerina-tests/graphql-advanced-test-suite/Dependencies.toml
+++ b/ballerina-tests/graphql-advanced-test-suite/Dependencies.toml
@@ -62,7 +62,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -73,7 +73,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "graphql"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -105,7 +105,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql_advanced_test_suite"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "graphql"},
@@ -123,7 +123,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql_test_common"
-version = "1.18.0"
+version = "1.18.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "file"},
@@ -397,7 +397,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "websocket"
-version = "2.15.6"
+version = "2.15.7"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina-tests/graphql-client-test-suite/Ballerina.toml
+++ b/ballerina-tests/graphql-client-test-suite/Ballerina.toml
@@ -1,10 +1,10 @@
 [package]
 org = "ballerina"
 name = "graphql_client_test_suite"
-version = "1.18.0"
+version = "1.18.1"
 
 [[dependency]]
 org = "ballerina"
 name = "graphql_test_common"
 repository = "local"
-version = "1.18.0"
+version = "1.18.1"

--- a/ballerina-tests/graphql-client-test-suite/Dependencies.toml
+++ b/ballerina-tests/graphql-client-test-suite/Dependencies.toml
@@ -64,7 +64,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.13.0"
+version = "1.13.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -76,7 +76,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "graphql"
-version = "1.18.0"
+version = "1.18.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -109,7 +109,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql_client_test_suite"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
 	{org = "ballerina", name = "graphql"},
 	{org = "ballerina", name = "graphql_test_common"},
@@ -126,7 +126,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql_test_common"
-version = "1.18.0"
+version = "1.18.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "file"},
@@ -419,7 +419,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "websocket"
-version = "2.15.6"
+version = "2.15.7"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},

--- a/ballerina-tests/graphql-dataloader-test-suite/Ballerina.toml
+++ b/ballerina-tests/graphql-dataloader-test-suite/Ballerina.toml
@@ -1,10 +1,10 @@
 [package]
 org = "ballerina"
 name = "graphql_dataloader_test_suite"
-version = "1.18.0"
+version = "1.18.1"
 
 [[dependency]]
 org = "ballerina"
 name = "graphql_test_common"
 repository = "local"
-version = "1.18.0"
+version = "1.18.1"

--- a/ballerina-tests/graphql-dataloader-test-suite/Dependencies.toml
+++ b/ballerina-tests/graphql-dataloader-test-suite/Dependencies.toml
@@ -64,7 +64,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.13.0"
+version = "1.13.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -76,7 +76,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "graphql"
-version = "1.18.0"
+version = "1.18.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -109,7 +109,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql_dataloader_test_suite"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
 	{org = "ballerina", name = "graphql"},
 	{org = "ballerina", name = "graphql_test_common"},
@@ -124,7 +124,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql_test_common"
-version = "1.18.0"
+version = "1.18.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "file"},
@@ -411,7 +411,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "websocket"
-version = "2.15.6"
+version = "2.15.7"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},

--- a/ballerina-tests/graphql-interceptor-test-suite/Ballerina.toml
+++ b/ballerina-tests/graphql-interceptor-test-suite/Ballerina.toml
@@ -1,10 +1,10 @@
 [package]
 org = "ballerina"
 name = "graphql_interceptor_test_suite"
-version = "1.18.0"
+version = "1.18.1"
 
 [[dependency]]
 org = "ballerina"
 name = "graphql_test_common"
 repository = "local"
-version = "1.18.0"
+version = "1.18.1"

--- a/ballerina-tests/graphql-interceptor-test-suite/Dependencies.toml
+++ b/ballerina-tests/graphql-interceptor-test-suite/Dependencies.toml
@@ -64,7 +64,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.13.0"
+version = "1.13.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -76,7 +76,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "graphql"
-version = "1.18.0"
+version = "1.18.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -109,7 +109,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql_interceptor_test_suite"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
 	{org = "ballerina", name = "graphql"},
 	{org = "ballerina", name = "graphql_test_common"},
@@ -124,7 +124,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql_test_common"
-version = "1.18.0"
+version = "1.18.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "file"},
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "websocket"
-version = "2.15.6"
+version = "2.15.7"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},

--- a/ballerina-tests/graphql-security-test-suite/Ballerina.toml
+++ b/ballerina-tests/graphql-security-test-suite/Ballerina.toml
@@ -1,10 +1,10 @@
 [package]
 org = "ballerina"
 name = "graphql_security_test_suite"
-version = "1.18.0"
+version = "1.18.1"
 
 [[dependency]]
 org = "ballerina"
 name = "graphql_test_common"
 repository = "local"
-version = "1.18.0"
+version = "1.18.1"

--- a/ballerina-tests/graphql-service-test-suite/Ballerina.toml
+++ b/ballerina-tests/graphql-service-test-suite/Ballerina.toml
@@ -1,10 +1,10 @@
 [package]
 org = "ballerina"
 name = "graphql_service_test_suite"
-version = "1.18.0"
+version = "1.18.1"
 
 [[dependency]]
 org = "ballerina"
 name = "graphql_test_common"
 repository = "local"
-version = "1.18.0"
+version = "1.18.1"

--- a/ballerina-tests/graphql-subgraph-test-suite/Ballerina.toml
+++ b/ballerina-tests/graphql-subgraph-test-suite/Ballerina.toml
@@ -1,10 +1,10 @@
 [package]
 org = "ballerina"
 name = "graphql_subgraph_test_suite"
-version = "1.18.0"
+version = "1.18.1"
 
 [[dependency]]
 org = "ballerina"
 name = "graphql_test_common"
 repository = "local"
-version = "1.18.0"
+version = "1.18.1"

--- a/ballerina-tests/graphql-subscription-test-suite/Ballerina.toml
+++ b/ballerina-tests/graphql-subscription-test-suite/Ballerina.toml
@@ -1,10 +1,10 @@
 [package]
 org = "ballerina"
 name = "graphql_subscription_test_suite"
-version = "1.18.0"
+version = "1.18.1"
 
 [[dependency]]
 org = "ballerina"
 name = "graphql_test_common"
 repository = "local"
-version = "1.18.0"
+version = "1.18.1"

--- a/ballerina-tests/graphql-test-common/Ballerina.toml
+++ b/ballerina-tests/graphql-test-common/Ballerina.toml
@@ -1,4 +1,4 @@
 [package]
 org = "ballerina"
 name = "graphql_test_common"
-version = "1.18.0"
+version = "1.18.1"

--- a/ballerina-tests/graphql-test-common/Dependencies.toml
+++ b/ballerina-tests/graphql-test-common/Dependencies.toml
@@ -59,7 +59,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -73,7 +73,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -105,7 +105,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql_test_common"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "graphql"},
@@ -370,7 +370,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "websocket"
-version = "2.15.6"
+version = "2.15.7"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "graphql"
-version = "1.18.0"
+version = "1.18.1"
 authors = ["Ballerina"]
 keywords = ["gql", "network", "query", "service", "Type/Connector", "Type/Trigger", "Area/Built-in", "Area/Communication", "Name/GraphQL"]
 repository = "https://github.com/ballerina-platform/module-ballerina-graphql"
@@ -31,11 +31,11 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "graphql-native"
-version = "1.18.0"
-path = "../native/build/libs/graphql-native-1.18.0.jar"
+version = "1.18.1"
+path = "../native/build/libs/graphql-native-1.18.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "graphql-commons"
-version = "1.18.0"
-path = "../commons/build/libs/graphql-commons-1.18.0.jar"
+version = "1.18.1"
+path = "../commons/build/libs/graphql-commons-1.18.1-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "graphql-compiler-plugin"
 class = "io.ballerina.stdlib.graphql.compiler.GraphqlCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/graphql-compiler-plugin-1.18.0.jar"
+path = "../compiler-plugin/build/libs/graphql-compiler-plugin-1.18.1-SNAPSHOT.jar"
 
 [[dependency]]
-path = "../commons/build/libs/graphql-commons-1.18.0.jar"
+path = "../commons/build/libs/graphql-commons-1.18.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -82,7 +82,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "graphql"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},


### PR DESCRIPTION
## Summary
- Regenerates and commits the `ballerina-tests/*` and `ballerina/` package toml/dependency files to match the current `1.18.1-SNAPSHOT` project version (via the standard `updateTomlFiles`/`commitTomlFiles` gradle tasks, i.e. the same automated commits a normal full build/test run produces).
- Fixes a bug in `ballerina-tests/build.gradle`'s `updateTomlFiles` task: the `graphql-test-common/Ballerina.toml` regeneration lived outside the task's `doLast` block, so it ran unconditionally on every Gradle invocation (configuration phase) instead of only when the task executes. This left that file modified-but-uncommitted whenever a build skipped tests, which is exactly what happens in the release workflow's "Build without Tests" step.

## Why
The [Publish Release run for v1.18.1](https://github.com/ballerina-platform/module-ballerina-graphql/actions/runs/34249639379/job/102140475015) failed at `:module-ballerina-graphql:checkCommitNeeded` with:
```
> You have uncommitted files:
   M ballerina-tests/graphql-test-common/Ballerina.toml
```
because `graphql-test-common/Ballerina.toml` was still at version `1.18.0` (last synced by a normal PR before the v1.18.0 release) while `gradle.properties` had already moved to `1.18.1-SNAPSHOT` after that release, and no PR had run a full test build in between to resync it. Yesterday's v1.18.0 release happened to succeed only because the two versions coincidentally matched at that time.

No tags/releases/packages were published for 1.18.1 — the failure occurred before any publish step ran, so this PR plus a re-run of the Publish Release workflow should be sufficient.

## Test plan
- [x] Ran `./gradlew clean build` locally; `updateTomlFiles`/`commitTomlFiles` correctly synced all Ballerina.toml/Dependencies.toml files to `1.18.1`.
- [ ] Note: the local run also hit `graphql-interceptor-test-suite`'s pre-existing, already-tracked intermittent `java.util.ConcurrentModificationException` (ballerina-platform/ballerina-library#8893), unrelated to this change. CI should confirm whether it reproduces there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated Ballerina package, test suite, dependency, and native JAR versions to `1.18.1-SNAPSHOT`.
- Moved `graphql-test-common/Ballerina.toml` generation into the `updateTomlFiles` task.
- Prevented release builds that skip tests from leaving modified, uncommitted files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->