### PR TITLE
Upgrade Gradle to 9.5.1 and Ballerina Gradle plugin to 4.0.0

### DIFF
--- a/ballerina-tests/build.gradle
+++ b/ballerina-tests/build.gradle
@@ -16,6 +16,13 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 plugins {
     id 'groovy'
@@ -77,13 +84,14 @@ task updateTomlFiles {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
         def files = "${project.projectDir}/${testCommonPackage}/Ballerina.toml ${project.projectDir}/${testCommonPackage}/Dependencies.toml "
         testSuites.each{ testPackage ->
             files += "${project.projectDir}/${testPackage}/Ballerina.toml ${project.projectDir}/${testPackage}/Dependencies.toml "
         }
 
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" ${files}"
@@ -132,11 +140,12 @@ task initializeVariables {
 }
 
 task publishTestCommonPackageToLocal {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     dependsOn(":${packageName}-${packageOrg}:build")
     dependsOn(updateTomlFiles)
     doLast {
         if (!skipTests) {
-            exec {
+            execHelper.execOperations.exec {
                 workingDir "${project.projectDir}/${testCommonPackage}"
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                     commandLine 'cmd', '/c', "${distributionBinPath}/bal.bat pack && exit  %%ERRORLEVEL%%"
@@ -144,7 +153,7 @@ task publishTestCommonPackageToLocal {
                     commandLine 'sh', '-c', "${distributionBinPath}/bal pack"
                 }
             }
-            exec {
+            execHelper.execOperations.exec {
                 workingDir "${project.projectDir}/${testCommonPackage}"
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                     commandLine 'cmd', '/c', "${distributionBinPath}/bal.bat push --repository=local" +
@@ -158,6 +167,7 @@ task publishTestCommonPackageToLocal {
 }
 
 task ballerinaTest {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     dependsOn(publishTestCommonPackageToLocal)
     dependsOn(":${packageName}-${packageOrg}:build")
     dependsOn(updateTomlFiles)
@@ -179,7 +189,7 @@ task ballerinaTest {
                         "${disableGroups},client_subscriptions" : "--disable-groups client_subscriptions"
             }
             if (!skipTests) {
-                exec {
+                execHelper.execOperations.exec {
                     workingDir "${project.projectDir}/${testPackage}"
                     environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -16,6 +16,13 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 plugins {
     id 'io.ballerina.plugin'
@@ -64,8 +71,9 @@ task updateTomlFiles {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml CompilerPlugin.toml"

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -28,7 +28,7 @@ task downloadCheckstyleRuleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -39,10 +39,10 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -46,3 +46,5 @@ artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
 artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
+
+test.mustRunAfter(downloadCheckstyleRuleFiles)

--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ subprojects {
     }
 }
 
-task build {
+tasks.named('build') {
     dependsOn(':graphql-commons:build')
     dependsOn(':graphql-compiler-plugin:build')
     dependsOn(':graphql-native:build')

--- a/build.gradle
+++ b/build.gradle
@@ -102,14 +102,28 @@ subprojects {
     }
 }
 
-tasks.named('build') {
-    dependsOn(':graphql-commons:build')
-    dependsOn(':graphql-compiler-plugin:build')
-    dependsOn(':graphql-native:build')
-    dependsOn(':graphql-ballerina:build')
-    dependsOn(':graphql-compiler-plugin-tests:test')
-    dependsOn(':graphql-ballerina-tests:test')
-    dependsOn(':graphql-examples:build')
+if (tasks.names.contains('build')) {
+    tasks.named('build') {
+        dependsOn(':graphql-commons:build')
+        dependsOn(':graphql-compiler-plugin:build')
+        dependsOn(':graphql-native:build')
+        dependsOn(':graphql-ballerina:build')
+        dependsOn(':graphql-compiler-plugin-tests:test')
+        dependsOn(':graphql-ballerina-tests:test')
+        dependsOn(':graphql-examples:build')
+
+    }
+} else {
+    tasks.register('build') {
+        dependsOn(':graphql-commons:build')
+        dependsOn(':graphql-compiler-plugin:build')
+        dependsOn(':graphql-native:build')
+        dependsOn(':graphql-ballerina:build')
+        dependsOn(':graphql-compiler-plugin-tests:test')
+        dependsOn(':graphql-ballerina-tests:test')
+        dependsOn(':graphql-examples:build')
+
+    }
 }
 
 release {

--- a/commons/build.gradle
+++ b/commons/build.gradle
@@ -52,7 +52,7 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     reports {
         html.enabled true
         text.enabled = true

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -65,7 +65,7 @@ spotbugsTest {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     reports {
         html.enabled true
         text.enabled = true
@@ -95,7 +95,7 @@ compileJava {
 
 jacoco {
     toolVersion = "${jacocoVersion}"
-    reportsDirectory = file("$buildDir/reports/jacoco")
+    reportsDirectory = layout.buildDirectory.dir("reports/jacoco")
 }
 
 jacocoTestReport {

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceArtifactsExtractionTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceArtifactsExtractionTest.java
@@ -79,7 +79,7 @@ public class ServiceArtifactsExtractionTest {
     private static final String GQL_SUFFIX = ".graphql";
 
     @Test
-    public void testServiceArtifactsGenerationForSingleService() throws Exception {
+    public void testServiceArtifactsGenerationForSingleService() throws IOException {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve(SCHEMA_VALIDATOR_DIR)
                 .resolve("01_graphql_service");
         try {
@@ -102,7 +102,7 @@ public class ServiceArtifactsExtractionTest {
 
 
     @Test
-    public void testServiceArtifactsGenerationForMultipleServices() throws Exception {
+    public void testServiceArtifactsGenerationForMultipleServices() throws IOException {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve(GENERATOR_TESTS_DIR)
                 .resolve("22_graphql_service_with_http_service");
         try {
@@ -144,7 +144,7 @@ public class ServiceArtifactsExtractionTest {
     }
 
     @Test
-    public void testServiceArtifactsGenerationForGqlWithHttp() throws Exception {
+    public void testServiceArtifactsGenerationForGqlWithHttp() throws IOException {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve(GENERATOR_TESTS_DIR)
                 .resolve("22_graphql_service_with_http_service");
         try {
@@ -163,7 +163,7 @@ public class ServiceArtifactsExtractionTest {
     }
 
     @Test
-    public void testServiceArtifactsGenerationWithInvalidSchema() throws Exception {
+    public void testServiceArtifactsGenerationWithInvalidSchema() throws IOException {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve(VALIDATOR_TESTS_DIR)
                 .resolve("60_invalid_use_of_reserved_federation_type_names");
         try {
@@ -179,7 +179,7 @@ public class ServiceArtifactsExtractionTest {
     }
 
     @Test
-    public void testServiceArtifactsGenerationWithDynamicallyAttachedListeners() throws Exception {
+    public void testServiceArtifactsGenerationWithDynamicallyAttachedListeners() throws IOException {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve(VALIDATOR_TESTS_DIR)
                 .resolve("23_dynamically_attaching_service");
         try {
@@ -194,7 +194,7 @@ public class ServiceArtifactsExtractionTest {
     }
 
     @Test
-    public void testServiceArtifactsWithDuplicateServicePaths() throws Exception {
+    public void testServiceArtifactsWithDuplicateServicePaths() throws IOException {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve(ENDPOINT_DETAILS_TESTS_DIR)
                 .resolve("04_service_with_duplicate_paths");
         try {

--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -57,7 +57,7 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     reports {
         html.enabled true
         text.enabled = true

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -17,6 +17,13 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 apply plugin: 'java'
 
@@ -42,13 +49,14 @@ clean {
 }
 
 task testExamples {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     if (project.hasProperty("balGraalVMTest")) {
         graalvmFlag = "--graalvm"
     }
     doLast {
         examples.each { example ->
             try {
-                exec {
+                execHelper.execOperations.exec {
                     workingDir project.projectDir
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                         commandLine 'cmd', '/c', "${ballerinaDist}/bin/bal.bat test ${graalvmFlag} ${example} && exit %%ERRORLEVEL%%"
@@ -65,6 +73,7 @@ task testExamples {
 }
 
 task buildExamples {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     gradle.taskGraph.whenReady { graph ->
         if (graph.hasTask(":graphql-examples:test")) {
             buildExamples.enabled = false
@@ -75,7 +84,7 @@ task buildExamples {
     doLast {
         examples.each { example ->
             try {
-                exec {
+                execHelper.execOperations.exec {
                     workingDir project.projectDir
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                         commandLine 'cmd', '/c', "${ballerinaDist}/bin/bal.bat build ${example} && exit %%ERRORLEVEL%%"

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,14 @@ version=1.18.1-SNAPSHOT
 ballerinaLangVersion=2201.13.6
 
 checkstylePluginVersion=10.12.0
-spotbugsPluginVersion=6.0.18
+spotbugsPluginVersion=6.5.1
 shadowJarPluginVersion=8.1.1
 downloadPluginVersion=5.4.0
-releasePluginVersion=2.8.0
+releasePluginVersion=3.1.0
 testngVersion=7.6.1
 eclipseLsp4jVersion=0.12.0
-ballerinaGradlePluginVersion=2.3.1
-jacocoVersion=0.8.10
+ballerinaGradlePluginVersion=4.0.0
+jacocoVersion=0.8.14
 
 jacksonVersion=2.17.2
 swaggerVersion=2.2.22

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -52,7 +52,7 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     reports {
         html.enabled true
         text.enabled = true

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,7 +29,7 @@ pluginManagement {
 }
 
 plugins {
-   id "com.gradle.enterprise" version "3.2"
+   id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'graphql'
@@ -52,9 +52,9 @@ project(':graphql-ballerina-tests').projectDir = file("ballerina-tests")
 project(':graphql-examples').projectDir = file("examples")
 project(':graphql-commons').projectDir = file("commons")
 
-gradleEnterprise {
+develocity {
    buildScan {
-       termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-       termsOfServiceAgree = 'yes'
+       termsOfUseUrl = 'https://gradle.com/help/legal-terms-of-use'
+       termsOfUseAgree = 'yes'
    }
 }

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -53,4 +53,9 @@
         <Method name = "getServiceResolver" />
         <Bug pattern="DCN_NULLPOINTER_EXCEPTION" />
     </Match>
+    <!-- gradle9-rollout: temporary suppression pending review: surfaced by the SpotBugs plugin version bump needed for Gradle 9 / Java 25 support (see PR body) — pre-existing code, not introduced by this PR -->
+    <Match>
+        <Class name="io.ballerina.stdlib.graphql.compiler.ServiceArtifactsExtractionTest"/>
+        <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
+    </Match>
 </FindBugsFilter>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -53,9 +53,4 @@
         <Method name = "getServiceResolver" />
         <Bug pattern="DCN_NULLPOINTER_EXCEPTION" />
     </Match>
-    <!-- gradle9-rollout: temporary suppression pending review: surfaced by the SpotBugs plugin version bump needed for Gradle 9 / Java 25 support (see PR body) — pre-existing code, not introduced by this PR -->
-    <Match>
-        <Class name="io.ballerina.stdlib.graphql.compiler.ServiceArtifactsExtractionTest"/>
-        <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
-    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
## Summary
- Upgrade the Gradle wrapper to 9.5.1 (with distribution checksum) and the Ballerina Gradle plugin to 4.0.0, needed for Java 21/25 compatibility.
- Fix Gradle 9 breakage: `project.exec` calls now use an injected `ExecOperations`, `com.gradle.enterprise` is migrated to `com.gradle.develocity`, any `task build {}` redefinition is replaced with `tasks.named('build')`, and checkstyle's `build.gradle` drops the deprecated `buildDir` property.
- Fix the SpotBugs findings the SpotBugs version bump surfaced: six `ServiceArtifactsExtractionTest` test methods declared `throws Exception`; narrowed to `IOException`, matching the file-based helper methods (`getDiagnosticResults`, `deleteDirectories`, etc.) they call, which already declared `IOException`.

## Test plan
- [x] `./gradlew clean build` passes locally on Gradle 9.5.1 with plugin 4.0.0
- [x] `./gradlew :graphql-compiler-plugin-tests:spotbugsTest` passes with no suppressions needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Upgrade Gradle to 9.5.1 with checksum verification and update the Ballerina Gradle plugin for Java 21 and Java 25 compatibility.
- Replace Gradle 9-incompatible APIs with supported alternatives, including `ExecOperations`, `layout.buildDirectory`, compatible build-task configuration, and the Develocity plugin.
- Update SpotBugs configuration and narrow test exception declarations to address findings from the tool upgrade.
- Derive compiler test JVM targets from the active Java runtime.
- Verify the build with `./gradlew clean build` and `./gradlew :graphql-compiler-plugin-tests:spotbugsTest`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->